### PR TITLE
Fix ‘UCHAR_MAX’ undeclared

### DIFF
--- a/lua/luaconf.h
+++ b/lua/luaconf.h
@@ -870,14 +870,12 @@ static inline int time(void *p)
 /* signal.h */
 #define l_signalT	lu_byte
 
-#ifdef __mips__
 /* limits.h */
 #define UCHAR_MAX	(255)
 #define CHAR_BIT	(8)
 
 #undef LUAL_BUFFERSIZE /* stack shouldn't be greater than 2048 */
 #define LUAL_BUFFERSIZE		(1024)
-#endif /* __mips__ */
 
 #endif /* __linux__ */
 


### PR DESCRIPTION
Fix compile error

> In file included from drivers/lunatik/lua/lctype.c:13:0:
> drivers/lunatik/lua/lctype.h:73:37: error: ‘UCHAR_MAX’ undeclared here (not in a function)
> LUAI_DDEC const lu_byte luai_ctype_[UCHAR_MAX + 2];
>                                     ^~~~~~~~~
> scripts/Makefile.build:298: recipe for target 'drivers/lunatik/lua/lctype.o' failed
> make[2]: *** [drivers/lunatik/lua/lctype.o] Error 1
> scripts/Makefile.build:549: recipe for target 'drivers/lunatik' failed