### PR TITLE
Luasocket (05/14/2018 - 05/24/2018)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+.cache.mk

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "poc-driver"]
+	path = poc-driver
+	url = git@github.com:luainkernel/poc-driver.git

--- a/Kconfig
+++ b/Kconfig
@@ -1,2 +1,7 @@
 config LUNATIK
     tristate "Lunatik"
+
+config LUNATIK_POC
+    bool "Use poc driver"
+    depends on LUNATIK
+    default y

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ lunatik-objs += arch/$(ARCH)/setjmp.o
 
 lunatik-objs += socket/socket.o socket/enums.o
 
-lunatik-${CONFIG_LUNATIK_POC} += poc-driver/luadev.o
+lunatik-${CONFIG_LUNATIK_POC} += poc-driver/luadrv.o

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 EXTRA_CFLAGS += -D_KERNEL
+EXTRA_CFLAGS += -I$(src)
 
 obj-$(CONFIG_LUNATIK) +=lunatik.o
 
@@ -11,3 +12,5 @@ lunatik-objs := lua/lapi.o lua/lcode.o lua/lctype.o lua/ldebug.o lua/ldo.o \
 	 lua/ltablib.o lua/lutf8lib.o lua/loslib.o lua/lmathlib.o lua/linit.o
 
 lunatik-objs += arch/$(ARCH)/setjmp.o
+
+lunatik-${CONFIG_LUNATIK_POC} += poc-driver/luadev.o

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,6 @@ lunatik-objs := lua/lapi.o lua/lcode.o lua/lctype.o lua/ldebug.o lua/ldo.o \
 
 lunatik-objs += arch/$(ARCH)/setjmp.o
 
+lunatik-objs += socket/socket.o socket/enums.o
+
 lunatik-${CONFIG_LUNATIK_POC} += poc-driver/luadev.o

--- a/lua/luaconf.h
+++ b/lua/luaconf.h
@@ -870,14 +870,12 @@ static inline int time(void *p)
 /* signal.h */
 #define l_signalT	lu_byte
 
-#ifdef __mips__
 /* limits.h */
 #define UCHAR_MAX	(255)
 #define CHAR_BIT	(8)
 
 #undef LUAL_BUFFERSIZE /* stack shouldn't be greater than 2048 */
 #define LUAL_BUFFERSIZE		(1024)
-#endif /* __mips__ */
 
 #endif /* __linux__ */
 

--- a/socket/enums.c
+++ b/socket/enums.c
@@ -1,0 +1,32 @@
+#include "../lua/lua.h"
+#include "../lua/lualib.h"
+#include "../lua/lauxlib.h"
+#include <linux/socket.h>
+#include <net/sock.h>
+
+int socket_tofamily(lua_State *L, int n)
+{
+    const char *str = luaL_checkstring(L, n);
+    switch (*str)
+    {
+    case 'i':
+        return AF_INET;
+    default:
+        luaL_argerror(L, n, "invalid family name");
+    }
+    return -EINVAL;
+}
+int socket_totype(lua_State *L, int n)
+{
+    const char *str = luaL_checkstring(L, n);
+    switch (*str)
+    {
+    case 't':
+        return SOCK_STREAM;
+    case 'u':
+        return SOCK_DGRAM;
+    default:
+        luaL_argerror(L, n, "invalid family name");
+    }
+    return -EINVAL;
+}

--- a/socket/enums.h
+++ b/socket/enums.h
@@ -1,0 +1,10 @@
+#ifndef _SOCKET_ENUMS_H_
+#define _SOCKET_ENUMS_H_
+#include "../lua/lua.h"
+#include "../lua/lualib.h"
+#include "../lua/lauxlib.h"
+
+
+int socket_tofamily(lua_State *L, int n);
+int socket_totype(lua_State *L, int n);
+#endif

--- a/socket/socket.c
+++ b/socket/socket.c
@@ -255,5 +255,5 @@ int luaopen_libsocket(lua_State *L)
     /* Register the object.func functions into the table that is at the top of the
      * stack. */
     luaL_newlib(L, libluasocket_funtions);
-    return 0;
+    return 1;
 }

--- a/socket/socket.c
+++ b/socket/socket.c
@@ -1,14 +1,14 @@
+#include "../lua/lauxlib.h"
 #include "../lua/lua.h"
 #include "../lua/lualib.h"
-#include "../lua/lauxlib.h"
 
-#include <linux/string.h>
+#include <linux/errno.h>
 #include <linux/in.h>
 #include <linux/inet.h>
 #include <linux/socket.h>
-#include <net/sock.h>
+#include <linux/string.h>
 #include <linux/unistd.h>
-#include <linux/errno.h>
+#include <net/sock.h>
 
 #include "enums.h"
 
@@ -18,205 +18,179 @@ typedef struct socket *sock_t;
 
 lua_Integer luaL_optfieldinteger(lua_State *L, int idx, const char *k, int def)
 {
-    int isnum;
-    lua_Integer d;
-    lua_getfield(L, idx, k);
-    d = lua_tointegerx(L, -1, &isnum);
-    lua_pop(L, 1);
-    if (!isnum)
-    {
-        return def;
-    }
-    return d;
+	int isnum;
+	lua_Integer d;
+	lua_getfield(L, idx, k);
+	d = lua_tointegerx(L, -1, &isnum);
+	lua_pop(L, 1);
+	if (!isnum)
+		return def;
+
+	return d;
 }
 
 static const char *inet_ntoa(struct in_addr ina)
 {
-    static char buf[4 * sizeof "123"];
-    unsigned char *ucp = (unsigned char *)&ina;
+	static char buf[4 * sizeof "123"];
+	unsigned char *ucp = (unsigned char *) &ina;
 
-    sprintf(buf, "%d.%d.%d.%d",
-            ucp[0] & 0xff,
-            ucp[1] & 0xff,
-            ucp[2] & 0xff,
-            ucp[3] & 0xff);
-    return buf;
+	sprintf(buf, "%d.%d.%d.%d", ucp[0] & 0xff, ucp[1] & 0xff, ucp[2] & 0xff,
+		ucp[3] & 0xff);
+	return buf;
 }
 static unsigned int inet_addr(const char *str)
 {
-    int a, b, c, d;
-    char arr[4];
-    sscanf(str, "%d.%d.%d.%d", &a, &b, &c, &d);
-    arr[0] = a;
-    arr[1] = b;
-    arr[2] = c;
-    arr[3] = d;
-    return *(unsigned int *)arr;
+	int a, b, c, d;
+	char arr[4];
+	sscanf(str, "%d.%d.%d.%d", &a, &b, &c, &d);
+	arr[0] = a;
+	arr[1] = b;
+	arr[2] = c;
+	arr[3] = d;
+	return *(unsigned int *) arr;
 }
 
 int luasocket(lua_State *L)
 {
-    int err;
-    sock_t sock = (sock_t)kmalloc(sizeof(struct socket), GFP_KERNEL);
-    if (sock == NULL)
-    {
-        luaL_error(L, "kmalloc fail");
-    }
+	int err;
+	sock_t sock;
 
-    memset(sock, 0, sizeof(struct socket));
-    err = sock_create(
-        socket_tofamily(L, 1),
-        socket_totype(L, 2),
-        0, &sock);
+	err = sock_create(socket_tofamily(L, 1), socket_totype(L, 2), 0, &sock);
 
-    if (err < 0)
-    {
-        luaL_error(L, "Socket creation error %d", err);
-    }
+	if (err < 0)
+		luaL_error(L, "Socket creation error %d", err);
 
-    *((sock_t *)lua_newuserdata(L, sizeof(sock_t))) = sock;
-    luaL_getmetatable(L, LUA_SOCKET);
-    lua_setmetatable(L, -2);
-    return 1;
+	*((sock_t *) lua_newuserdata(L, sizeof(sock_t))) = sock;
+	luaL_getmetatable(L, LUA_SOCKET);
+	lua_setmetatable(L, -2);
+	return 1;
 }
 
 int luasocket_bind(lua_State *L)
 {
-    int err;
-    struct sockaddr_in addr;
-    sock_t s = *(sock_t *)luaL_checkudata(L, 1, LUA_SOCKET);
-    const char *ip = luaL_checkstring(L, 2);
-    const int port = luaL_checkinteger(L, 3);
+	int err;
+	struct sockaddr_in addr;
+	sock_t s = *(sock_t *) luaL_checkudata(L, 1, LUA_SOCKET);
+	const char *ip = luaL_checkstring(L, 2);
+	const int port = luaL_checkinteger(L, 3);
 
-    if (port <= 0 || port > 65535)
-    {
-        luaL_argerror(L, 2, "Port number out of range");
-    }
+	if (port <= 0 || port > 65535)
+		luaL_argerror(L, 2, "Port number out of range");
 
-    addr.sin_family = s->sk->sk_family;
-    addr.sin_port = htons((u_short)port);
-    addr.sin_addr.s_addr = inet_addr(ip);
+	addr.sin_family = s->sk->sk_family;
+	addr.sin_port = htons((u_short) port);
+	addr.sin_addr.s_addr = inet_addr(ip);
 
-    if ((err = kernel_bind(s, (struct sockaddr *)&addr, sizeof(addr))) < 0)
-    {
-        luaL_error(L, "Socket bind error: %d", err);
-    }
+	if ((err = kernel_bind(s, (struct sockaddr *) &addr, sizeof(addr))) < 0)
+		luaL_error(L, "Socket bind error: %d", err);
 
-    return 0;
+	return 0;
 }
 int luasocket_listen(lua_State *L)
 {
-    int err;
-    sock_t s = *(sock_t *)luaL_checkudata(L, 1, LUA_SOCKET);
-    const int backlog = luaL_checkinteger(L, 2);
+	int err;
+	sock_t s = *(sock_t *) luaL_checkudata(L, 1, LUA_SOCKET);
+	const int backlog = luaL_checkinteger(L, 2);
 
-    if (backlog <= 0)
-    {
-        luaL_argerror(L, 2, "Backlog number out of range");
-    }
+	if (backlog <= 0)
+		luaL_argerror(L, 2, "Backlog number out of range");
 
-    if ((err = kernel_listen(s, backlog)) < 0)
-    {
-        luaL_error(L, "Socket listen error: %d", err);
-    }
+	if ((err = kernel_listen(s, backlog)) < 0)
+		luaL_error(L, "Socket listen error: %d", err);
 
-    return 0;
+	return 0;
 }
 int luasocket_accept(lua_State *L)
 {
-    int err;
-    sock_t s = *(sock_t *)luaL_checkudata(L, 1, LUA_SOCKET);
-    const int flags = luaL_optnumber(L, 2, 0);
-    sock_t newsock;
+	int err;
+	sock_t s = *(sock_t *) luaL_checkudata(L, 1, LUA_SOCKET);
+	const int flags = luaL_optnumber(L, 2, 0);
+	sock_t newsock;
 
-    if ((err = kernel_accept(s, &newsock, flags)) < 0)
-    {
-        luaL_error(L, "Socket accept error: %d", err);
-    }
+	if ((err = kernel_accept(s, &newsock, flags)) < 0)
+		luaL_error(L, "Socket accept error: %d", err);
 
-    *((sock_t *)lua_newuserdata(L, sizeof(sock_t))) = newsock;
-    luaL_getmetatable(L, LUA_SOCKET);
-    lua_setmetatable(L, -2);
+	*((sock_t *) lua_newuserdata(L, sizeof(sock_t))) = newsock;
+	luaL_getmetatable(L, LUA_SOCKET);
+	lua_setmetatable(L, -2);
 
-    return 1;
+	return 1;
 }
 int luasocket_connect(lua_State *L)
 {
-    int err;
-    struct sockaddr_in addr;
-    sock_t s = *(sock_t *)luaL_checkudata(L, 1, LUA_SOCKET);
-    const char *ip = luaL_checkstring(L, 2);
-    const int port = luaL_checkinteger(L, 3);
-    const int flags = luaL_optinteger(L, 4, 0);
+	int err;
+	struct sockaddr_in addr;
+	sock_t s = *(sock_t *) luaL_checkudata(L, 1, LUA_SOCKET);
+	const char *ip = luaL_checkstring(L, 2);
+	const int port = luaL_checkinteger(L, 3);
+	const int flags = luaL_optinteger(L, 4, 0);
 
-    if (port <= 0 || port > 65535)
-    {
-        luaL_argerror(L, 2, "Port number out of range");
-    }
+	if (port <= 0 || port > 65535)
+		luaL_argerror(L, 2, "Port number out of range");
 
-    addr.sin_family = s->sk->sk_family;
-    addr.sin_port = htons((u_short)port);
-    addr.sin_addr.s_addr = inet_addr(ip);
+	addr.sin_family = s->sk->sk_family;
+	addr.sin_port = htons((u_short) port);
+	addr.sin_addr.s_addr = inet_addr(ip);
 
-    if ((err = kernel_connect(s, (struct sockaddr *)&addr, sizeof(addr), flags)) < 0)
-    {
-        luaL_error(L, "Socket connect error: %d", err);
-    }
+	if ((err = kernel_connect(s, (struct sockaddr *) &addr, sizeof(addr),
+				  flags)) < 0)
+		luaL_error(L, "Socket connect error: %d", err);
 
-    return 0;
+	return 0;
 }
 int luasocket_sendmsg(lua_State *L)
 {
-    int i;
-    int err;
-    int size;
-    struct msghdr msg;
-    struct kvec vec;
-    struct sockaddr_in addr;
-    sock_t s = *(sock_t *)luaL_checkudata(L, 1, LUA_SOCKET);
-    char *buffer;
+	int i;
+	int err;
+	int size;
+	struct msghdr msg;
+	struct kvec vec;
+	struct sockaddr_in addr;
+	sock_t s = *(sock_t *) luaL_checkudata(L, 1, LUA_SOCKET);
+	char *buffer;
 
-    luaL_checktype(L, 2, LUA_TTABLE);
-    luaL_checktype(L, 3, LUA_TTABLE);
+	luaL_checktype(L, 2, LUA_TTABLE);
+	luaL_checktype(L, 3, LUA_TTABLE);
 
-    size = luaL_len(L, 3);
-    luaL_argcheck(L, size > 0, 3, "data can not be empty");
+	size = luaL_len(L, 3);
+	luaL_argcheck(L, size > 0, 3, "data can not be empty");
 
-    memset(&msg, 0, sizeof(msg));
-    msg.msg_flags = luaL_optfieldinteger(L, 2, "flags", 0);
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_flags = luaL_optfieldinteger(L, 2, "flags", 0);
 
-    if (lua_getfield(L, 2, "name") == LUA_TTABLE)
-    {
-        addr.sin_family = s->sk->sk_family;
-        addr.sin_port = htons((u_short)luaL_optfieldinteger(L, -1, "port", 0));
-        if (lua_getfield(L, -1, "addr") == LUA_TSTRING)
-        {
-            addr.sin_addr.s_addr = inet_addr(lua_tostring(L, -1));
-        }
-        lua_pop(L, 1);
+	if (lua_getfield(L, 2, "name") == LUA_TTABLE) {
+		addr.sin_family = s->sk->sk_family;
+		addr.sin_port =
+		    htons((u_short) luaL_optfieldinteger(L, -1, "port", 0));
 
-        msg.msg_name = &addr;
-        msg.msg_namelen = sizeof(addr);
-    }
-    lua_pop(L, 1);
+		if (lua_getfield(L, -1, "addr") == LUA_TSTRING)
+			addr.sin_addr.s_addr = inet_addr(lua_tostring(L, -1));
 
-    buffer = kmalloc(size, GFP_KERNEL);
-    if (buffer == NULL)
-        luaL_error(L, "Buffer alloc fail.");
-    for (i = 0; i < size; i++)
-    {
-        lua_rawgeti(L, 2, i + 1);
-        buffer[i] = lua_tointeger(L, -1);
-    }
+		lua_pop(L, 1);
 
-    vec.iov_base = buffer;
-    vec.iov_len = size;
+		msg.msg_name = &addr;
+		msg.msg_namelen = sizeof(addr);
+	}
+	lua_pop(L, 1);
 
-    if ((err = kernel_sendmsg(s, &msg,&vec, 1, size)) < 0)
-    {
-        luaL_error(L, "Socket sendmsg error: %d", err);
-    }
-    return 0;
+	buffer = kmalloc(size, GFP_KERNEL);
+	if (buffer == NULL)
+		luaL_error(L, "Buffer alloc fail.");
+	for (i = 0; i < size; i++) {
+		lua_rawgeti(L, 2, i + 1);
+		buffer[i] = lua_tointeger(L, -1);
+	}
+
+	vec.iov_base = buffer;
+	vec.iov_len = size;
+
+	if ((err = kernel_sendmsg(s, &msg, &vec, 1, size)) < 0) {
+		kfree(buffer);
+		luaL_error(L, "Socket sendmsg error: %d", err);
+	}
+	kfree(buffer);
+
+	return 0;
 }
 
 static const struct luaL_Reg libluasocket_methods[] = {
@@ -232,28 +206,29 @@ static const struct luaL_Reg libluasocket_methods[] = {
 };
 
 static const struct luaL_Reg libluasocket_funtions[] = {
-    {"new", luasocket},
-    {NULL, NULL} /* sentinel */
+    {"new", luasocket}, {NULL, NULL} /* sentinel */
 };
 
 int luaopen_libsocket(lua_State *L)
 {
-    luaL_newmetatable(L, LUA_SOCKET);
-    /* Duplicate the metatable on the stack (We know have 2). */
-    lua_pushvalue(L, -1);
-    /* Pop the first metatable off the stack and assign it to __index
-     * of the second one. We set the metatable for the table to itself.
-     * This is equivalent to the following in lua:
-     * metatable = {}
-     * metatable.__index = metatable
-     */
-    lua_setfield(L, -2, "__index");
+	luaL_newmetatable(L, LUA_SOCKET);
+	/* Duplicate the metatable on the stack (We know have 2). */
+	lua_pushvalue(L, -1);
+	/* Pop the first metatable off the stack and assign it to __index
+	 * of the second one. We set the metatable for the table to itself.
+	 * This is equivalent to the following in lua:
+	 * metatable = {}
+	 * metatable.__index = metatable
+	 */
+	lua_setfield(L, -2, "__index");
 
-    /* Set the methods to the metatable that should be accessed via object:func */
-    luaL_setfuncs(L, libluasocket_methods, 0);
+	/* Set the methods to the metatable that should be accessed via
+	 * object:func
+	 */
+	luaL_setfuncs(L, libluasocket_methods, 0);
 
-    /* Register the object.func functions into the table that is at the top of the
-     * stack. */
-    luaL_newlib(L, libluasocket_funtions);
-    return 1;
+	/* Register the object.func functions into the table that is at the top
+	 * of the stack. */
+	luaL_newlib(L, libluasocket_funtions);
+	return 1;
 }

--- a/socket/socket.c
+++ b/socket/socket.c
@@ -1,0 +1,227 @@
+#include "../lua/lua.h"
+#include "../lua/lualib.h"
+#include "../lua/lauxlib.h"
+
+#include <linux/string.h>
+#include <linux/in.h>
+#include <linux/inet.h>
+#include <linux/socket.h>
+#include <net/sock.h>
+#include <linux/unistd.h>
+#include <linux/errno.h>
+
+#include "enums.h"
+
+#define LUA_SOCKET "luasocket"
+
+typedef struct socket *sock_t;
+
+lua_Integer luaL_optfieldinteger(lua_State *L, int idx, const char *k, int def)
+{
+    int isnum;
+    lua_Integer d;
+    lua_getfield(L, idx, k);
+    d = lua_tointegerx(L, -1, &isnum);
+    if (!isnum)
+    {
+        return def;
+    }
+    return d;
+}
+
+static const char *inet_ntoa(struct in_addr ina)
+{
+    static char buf[4 * sizeof "123"];
+    unsigned char *ucp = (unsigned char *)&ina;
+
+    sprintf(buf, "%d.%d.%d.%d",
+            ucp[0] & 0xff,
+            ucp[1] & 0xff,
+            ucp[2] & 0xff,
+            ucp[3] & 0xff);
+    return buf;
+}
+static unsigned int inet_addr(const char *str)
+{
+    int a, b, c, d;
+    char arr[4];
+    sscanf(str, "%d.%d.%d.%d", &a, &b, &c, &d);
+    arr[0] = a;
+    arr[1] = b;
+    arr[2] = c;
+    arr[3] = d;
+    return *(unsigned int *)arr;
+}
+
+int luasocket(lua_State *L)
+{
+    int err;
+    sock_t sock = (sock_t)kmalloc(sizeof(struct socket), GFP_KERNEL);
+    if (sock == NULL)
+    {
+        luaL_error(L, "kmalloc fail");
+    }
+
+    memset(sock, 0, sizeof(struct socket));
+    err = sock_create(
+        socket_tofamily(L, 1),
+        socket_totype(L, 2),
+        0, &sock);
+
+    if (err < 0)
+    {
+        luaL_error(L, "Socket creation error %d", err);
+    }
+
+    *((sock_t *)lua_newuserdata(L, sizeof(sock_t))) = sock;
+    luaL_getmetatable(L, LUA_SOCKET);
+    lua_setmetatable(L, -2);
+    return 1;
+}
+
+int luasocket_bind(lua_State *L)
+{
+    int err;
+    struct sockaddr_in addr;
+    sock_t s = *(sock_t *)luaL_checkudata(L, 1, LUA_SOCKET);
+    const char *ip = luaL_checkstring(L, 2);
+    const int port = luaL_checkinteger(L, 3);
+
+    if (port <= 0 || port > 65535)
+    {
+        luaL_argerror(L, 2, "Port number out of range");
+    }
+
+    addr.sin_family = s->sk->sk_family;
+    addr.sin_port = htons((u_short)port);
+    addr.sin_addr.s_addr = inet_addr(ip);
+
+    if ((err = kernel_bind(s, (struct sockaddr *)&addr, sizeof(addr))) < 0)
+    {
+        luaL_error(L, "Socket bind error: %d", err);
+    }
+
+    return 0;
+}
+int luasocket_listen(lua_State *L)
+{
+    int err;
+    sock_t s = *(sock_t *)luaL_checkudata(L, 1, LUA_SOCKET);
+    const int backlog = luaL_checkinteger(L, 2);
+
+    if (backlog <= 0)
+    {
+        luaL_argerror(L, 2, "Backlog number out of range");
+    }
+
+    if ((err = kernel_listen(s, backlog)) < 0)
+    {
+        luaL_error(L, "Socket listen error: %d", err);
+    }
+
+    return 0;
+}
+int luasocket_accept(lua_State *L)
+{
+    int err;
+    sock_t s = *(sock_t *)luaL_checkudata(L, 1, LUA_SOCKET);
+    const int flags = luaL_optnumber(L, 2, 0);
+    sock_t newsock;
+
+    if ((err = kernel_accept(s, &newsock, flags)) < 0)
+    {
+        luaL_error(L, "Socket accept error: %d", err);
+    }
+
+    *((sock_t *)lua_newuserdata(L, sizeof(sock_t))) = newsock;
+    luaL_getmetatable(L, LUA_SOCKET);
+    lua_setmetatable(L, -2);
+
+    return 1;
+}
+int luasocket_connect(lua_State *L)
+{
+    int err;
+    struct sockaddr_in addr;
+    sock_t s = *(sock_t *)luaL_checkudata(L, 1, LUA_SOCKET);
+    const char *ip = luaL_checkstring(L, 2);
+    const int port = luaL_checkinteger(L, 3);
+    const int flags = luaL_optinteger(L, 4, 0);
+
+    if (port <= 0 || port > 65535)
+    {
+        luaL_argerror(L, 2, "Port number out of range");
+    }
+
+    addr.sin_family = s->sk->sk_family;
+    addr.sin_port = htons((u_short)port);
+    addr.sin_addr.s_addr = inet_addr(ip);
+
+    if ((err = kernel_connect(s, (struct sockaddr *)&addr, sizeof(addr), flags)) < 0)
+    {
+        luaL_error(L, "Socket connect error: %d", err);
+    }
+
+    return 0;
+}
+int luasocket_sendmsg(lua_State *L)
+{
+    int err;
+    struct msghdr msg;
+    struct sockaddr_in addr;
+    sock_t s = *(sock_t *)luaL_checkudata(L, 1, LUA_SOCKET);
+
+    luaL_checktype(L, 2, LUA_TTABLE);
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_flags = luaL_optfieldinteger(L, 2, "flags", 0);
+
+    // if (lua_getfield(L, 2, "name") == LUA_TTABLE)
+    // {
+    //     addr.sin_family = s->sk->sk_family;
+    //     addr.sin_port = htons((u_short)port);
+    //     addr.sin_addr.s_addr = inet_addr(ip);
+
+    //     msg.msg_name = &addr;
+    //     msg.msg_namelen = sizeof(addr);
+    // }
+
+    if ((err = sock_sendmsg(s, &msg)) < 0)
+    {
+        luaL_error(L, "Socket connect error: %d", err);
+    }
+
+    return 0;
+}
+
+static const struct luaL_Reg libluasocket_methods[] = {
+    {"bind", luasocket_bind},
+    {"listen", luasocket_listen},
+    {"accept", luasocket_accept},
+    {"connect", luasocket_connect},
+    {"sendmsg", luasocket_sendmsg},
+    // {"write", luaudp_write},
+    // {"close", luaudp_close},
+    // {"__gc", luaudp_close},
+    {NULL, NULL} /* sentinel */
+};
+
+int luaopen_libluaudp(lua_State *L)
+{
+    luaL_newmetatable(L, LUA_SOCKET);
+    /* Duplicate the metatable on the stack (We know have 2). */
+    lua_pushvalue(L, -1);
+    /* Pop the first metatable off the stack and assign it to __index
+     * of the second one. We set the metatable for the table to itself.
+     * This is equivalent to the following in lua:
+     * metatable = {}
+     * metatable.__index = metatable
+     */
+    lua_setfield(L, -2, "__index");
+
+    /* Set the methods to the metatable that should be accessed via object:func */
+    luaL_setfuncs(L, libluasocket_methods, 0);
+
+    lua_pushcfunction(L, luasocket);
+    lua_setglobal(L, "socket");
+    return 0;
+}


### PR DESCRIPTION
- Add luasocket funtions: `socket.new()`, `socket.bind()`, `socket.listen()`, `socket.connect()`, `socket.accept()` and `socket.sendmsg()`
- The adaption of `luadata` will be applied later
- `socket.sendmsg()` and `socket.recvmsg()` give users ability to modify or get `struct msghdr` to control advanced network function
- A quick install script:
  ```shell
  insmod lunatik.ko
  
  if [ ! -f /dev/luadrv ]  
  then  
      major=$(awk '$2=="luadrv" {print $1}' /proc/devices)  
      mknod /dev/luadrv c ${major} 1  
  fi  
  ```
- clang formating config:
  ```
  BasedOnStyle: LLVM
  IndentWidth: 8
  SpaceAfterCStyleCast: true
  BreakBeforeBraces: Linux
  UseTab: Always
  AllowShortIfStatementsOnASingleLine: false
  ```
- `luasocket` test script
```lua
assert(socket)
sock1 = socket.new("i", "t")
assert(sock1)

sock1:bind("127.0.0.1", 80)
sock1:listen(5)

sock2 = socket.new("i", "t")
assert(sock2)

sock2:connect("127.0.0.1", 80)
sock3 = sock1:accept()
assert(sock3)

sock3:sendmsg({}, {1, 2, 3})

sock4 = socket.new("i", "u")
assert(sock4)
sock4:sendmsg(
    {
        name = {
            addr = "127.0.0.1",
            port = 1234
        }
    },
    {1, 2, 3}
)

-- msg_control example
-- sock4:sendmsg(
--     {
--         name = {
--             addr = "127.0.0.1",
--             port = 1234
--         },
--         control = {
--             {level = "ip", type = "if"} -- IPPROTO_IP and IP_RECVIF
--         },
--         flags = "r" -- MSG_DONTROUTE
--     },
--     {1, 2, 3}
-- )
```