### PR TITLE
Stop using the deprecated 32-bit time interfaces when using kernel versions >= 5.6.0

### DIFF
--- a/lua/loslib.c
+++ b/lua/loslib.c
@@ -328,8 +328,8 @@ static int os_date (lua_State *L) {
 
 
 static int os_time (lua_State *L) {
-#ifndef _KERNEL
   time_t t;
+#ifndef _KERNEL
   if (lua_isnoneornil(L, 1))  /* called without args? */
     t = time(NULL);  /* get current time */
   else {
@@ -351,12 +351,11 @@ static int os_time (lua_State *L) {
   l_pushtime(L, t);
   return 1;
 #else
-  struct timespec ts;
   lua_Integer res;
 
-  getnstimeofday(&ts);
-  lua_pushinteger(L, (lua_Integer)ts.tv_sec);
-  res = ts.tv_sec * NSEC_PER_SEC + ts.tv_nsec;
+  luai_time(t);
+  lua_pushinteger(L, (lua_Integer)t.tv_sec);
+  res = t.tv_sec * NSEC_PER_SEC + t.tv_nsec;
   lua_pushinteger(L, res);
 
   return 2;

--- a/lua/luaconf.h
+++ b/lua/luaconf.h
@@ -839,13 +839,23 @@ extern void longjmp(luai_jmpbuf);
 #define LUAI_TRY(L,c,a)		if (setjmp(((c)->b)) == 0) { a }
 
 /* time.h */
-#include <linux/time.h>
 #include <linux/ktime.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0)
+#include <linux/time.h>
+typedef struct timespec time_t;
+#define luai_time(t)		getnstimeofday(&t)
+#elif defined(LUA_32BITS)
+#error "kernel versions >= 5.6.0 do not support 32-bit time values"
+#else
+typedef struct timespec64 time_t;
+#define luai_time(t)		ktime_get_real_ts64(&t)
+#endif
+
 static inline int time(void *p)
 {
-  struct timespec t;
+  time_t t;
   ((void) p);
-  getnstimeofday(&t);
+  luai_time(t);
   return t.tv_sec;
 }
 #define luai_makeseed()	        cast(unsigned int, time(NULL))


### PR DESCRIPTION
Since Linux version 5.6.0, 32-bit time interfaces have been deprecated due to y2k38
https://www.kernel.org/doc/html/latest/core-api/timekeeping.html#deprecated-time-interfaces