### PR TITLE
add rm, install and mkdir variables to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ SCRIPTS_INSTALL_PATH = /lib/modules/lua
 LUNATIK_INSTALL_PATH = /usr/local/sbin
 LUA_API = lua/lua.h lua/lauxlib.h lua/lualib.h
 KDIR ?= ${MODULES_INSTALL_PATH}/build
+RM = rm -f
+MKDIR = mkdir -p -m 0755
+INSTALL = install -o root -g root
 
 all: lunatik_sym.h
 	make -C ${KDIR} M=${PWD} CONFIG_LUNATIK=m	\
@@ -14,40 +17,40 @@ all: lunatik_sym.h
 
 clean:
 	make -C ${KDIR} M=${PWD} clean
-	rm lunatik_sym.h
+	${RM} lunatik_sym.h
 
 scripts_install:
-	mkdir -p -m 0755 ${SCRIPTS_INSTALL_PATH} ${SCRIPTS_INSTALL_PATH}/socket
-	mkdir -p -m 0755 ${SCRIPTS_INSTALL_PATH} ${SCRIPTS_INSTALL_PATH}/syscall
-	install -m 0644 -o root -g root lunatik.lua ${SCRIPTS_INSTALL_PATH}
-	install -m 0644 -o root -g root lib/socket/*.lua ${SCRIPTS_INSTALL_PATH}/socket
-	install -m 0644 -o root -g root lib/syscall/*.lua ${SCRIPTS_INSTALL_PATH}/syscall
-	install -m 0755 -o root -g root lunatik ${LUNATIK_INSTALL_PATH}
+	${MKDIR} ${SCRIPTS_INSTALL_PATH} ${SCRIPTS_INSTALL_PATH}/socket
+	${MKDIR} ${SCRIPTS_INSTALL_PATH} ${SCRIPTS_INSTALL_PATH}/syscall
+	${INSTALL} -m 0644 lunatik.lua ${SCRIPTS_INSTALL_PATH}
+	${INSTALL} -m 0644 lib/socket/*.lua ${SCRIPTS_INSTALL_PATH}/socket
+	${INSTALL} -m 0644 lib/syscall/*.lua ${SCRIPTS_INSTALL_PATH}/syscall
+	${INSTALL} -m 0755 lunatik ${LUNATIK_INSTALL_PATH}
 
 scripts_uninstall:
-	rm ${SCRIPTS_INSTALL_PATH}/lunatik.lua
-	rm -r ${SCRIPTS_INSTALL_PATH}/socket
-	rm -r ${SCRIPTS_INSTALL_PATH}/syscall
-	rm ${LUNATIK_INSTALL_PATH}/lunatik
+	${RM} ${SCRIPTS_INSTALL_PATH}/lunatik.lua
+	${RM} -r ${SCRIPTS_INSTALL_PATH}/socket
+	${RM} -r ${SCRIPTS_INSTALL_PATH}/syscall
+	${RM} ${LUNATIK_INSTALL_PATH}/lunatik
 
 examples_install:
-	mkdir -p -m 0755 ${SCRIPTS_INSTALL_PATH}/examples
-	install -m 0644 -o root -g root examples/*.lua ${SCRIPTS_INSTALL_PATH}/examples
-	mkdir -p -m 0755 ${SCRIPTS_INSTALL_PATH}/examples/echod
-	install -m 0644 -o root -g root examples/echod/*.lua ${SCRIPTS_INSTALL_PATH}/examples/echod
+	${MKDIR} ${SCRIPTS_INSTALL_PATH}/examples
+	${INSTALL} -m 0644 examples/*.lua ${SCRIPTS_INSTALL_PATH}/examples
+	${MKDIR} ${SCRIPTS_INSTALL_PATH}/examples/echod
+	${INSTALL} -m 0644 examples/echod/*.lua ${SCRIPTS_INSTALL_PATH}/examples/echod
 
 examples_uninstall:
-	rm -r ${SCRIPTS_INSTALL_PATH}/examples
+	${RM} -r ${SCRIPTS_INSTALL_PATH}/examples
 
 modules_install:
-	mkdir -p -m 0755 ${MODULES_INSTALL_PATH}/lunatik
-	install -m 0644 -o root -g root *.ko lib/*.ko ${MODULES_INSTALL_PATH}/lunatik
+	${MKDIR} ${MODULES_INSTALL_PATH}/lunatik
+	${INSTALL} -m 0644 *.ko lib/*.ko ${MODULES_INSTALL_PATH}/lunatik
 
 btf_install:
 	cp /sys/kernel/btf/vmlinux ${KDIR}
 
 modules_uninstall:
-	rm -r ${MODULES_INSTALL_PATH}/lunatik
+	${RM} -r ${MODULES_INSTALL_PATH}/lunatik
 
 install: scripts_install modules_install
 	depmod -a


### PR DESCRIPTION
When running `make clean` and other rules that use `rm` to remove fils/folder, these give out errors if the reffered file/folder does not exist. Hence this PR adds `-f` to ignore nonexistent files and arguments.