### PR TITLE
require lib automatically when clonning objects

### DIFF
--- a/lib/luanetfilter.h
+++ b/lib/luanetfilter.h
@@ -16,7 +16,6 @@
 
 #define luanetfilter_newbuffer(L, idx, obj, field)	\
 do {							\
-	lunatik_requiref(L, data);			\
 	obj->field = lunatik_checknull(L, luadata_new(NULL, 0, false, LUADATA_OPT_NONE));	\
 	lunatik_cloneobject(L, obj->field);		\
 	lunatik_setregistry(L, -1, obj->field);	\

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -156,7 +156,6 @@ static int luaxdp_attach(lua_State *L)
 	lunatik_checkruntime(L, false);
 	luaL_checktype(L, 1, LUA_TFUNCTION); /* callback */
 
-	lunatik_requiref(L, data);
 	luaxdp_newdata(L); /* buffer */
 	luaxdp_newdata(L); /* argument */
 

--- a/lunatik.h
+++ b/lunatik.h
@@ -189,7 +189,6 @@ static inline void lunatik_require(lua_State *L, const char *libname)
 
 static inline void lunatik_pushobject(lua_State *L, lunatik_object_t *object)
 {
-	lunatik_require(L, object->class->name);
 	lunatik_cloneobject(L, object);
 	lunatik_getobject(object);
 }
@@ -263,12 +262,6 @@ EXPORT_SYMBOL_GPL(luaopen_##libname)
 
 #define LUNATIK_LIB(libname)		\
 int luaopen_##libname(lua_State *L);	\
-
-#define lunatik_requiref(L, libname)				\
-do {								\
-	luaL_requiref((L), #libname, luaopen_##libname, 0);	\
-	lua_pop(L, 1); /* pop lib */				\
-} while(0)
 
 #define LUNATIK_OBJECTCHECKER(checker, T)			\
 static inline T checker(lua_State *L, int ix)			\

--- a/lunatik_obj.c
+++ b/lunatik_obj.c
@@ -58,6 +58,7 @@ EXPORT_SYMBOL(lunatik_checkpobject);
 
 void lunatik_cloneobject(lua_State *L, lunatik_object_t *object)
 {
+	lunatik_require(L, object->class->name);
 	lunatik_object_t **pobject = lunatik_newpobject(L, 1);
 	const lunatik_class_t *class = object->class;
 


### PR DESCRIPTION
* remove lunatik_requiref() API
* now it's not needed to require the obj lib before indexing an RCU table