### PR TITLE
fix struct sockaddr version check

### DIFF
--- a/lib/luasocket.c
+++ b/lib/luasocket.c
@@ -41,7 +41,7 @@ do {						\
 
 #define LUASOCKET_SOCKADDR(addr)	(struct sockaddr *)&addr, sizeof(addr)
 #define LUASOCKET_ADDRMAX		(sizeof(struct sockaddr_ll)) /* AF_PACKET */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 80)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 150)
 #define LUASOCKET_ADDRMIN(addr)	(sizeof((addr)->sa_data_min))
 #else
 #define LUASOCKET_ADDRMIN(addr)	(sizeof((addr)->sa_data))


### PR DESCRIPTION
* sa_data_min field was actual introduced on v5.15.150