### PR TITLE
separate kernel build directory and module build path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,11 @@ MODULES_PATH := /lib/modules
 MODULES_RELEASE_PATH := ${MODULES_PATH}/${KERNEL_RELEASE}
 MODULES_ORDER_LIST := lunatik/lunatik.ko kernel/zfs/zfs.ko # needed for Ubuntu
 MODULES_ORDER_FILE := ${MODULES_RELEASE_PATH}/modules.order
-MODULES_BUILD_PATH ?= ${MODULES_RELEASE_PATH}/build
+BTF_INSTALL_PATH = ${MODULES_RELEASE_PATH}/build
+MODULES_BUILD_PATH ?= ${BTF_INSTALL_PATH}
 MODULES_INSTALL_PATH := ${MODULES_RELEASE_PATH}/kernel
 SCRIPTS_INSTALL_PATH := ${MODULES_PATH}/lua
+
 
 LUNATIK_INSTALL_PATH = /usr/local/sbin
 LUNATIK_EBPF_INSTALL_PATH = /usr/local/lib/bpf/lunatik
@@ -85,7 +87,7 @@ modules_install:
 	${INSTALL} -m 0644 *.ko lib/*.ko ${MODULES_INSTALL_PATH}/lunatik
 
 btf_install:
-	cp /sys/kernel/btf/vmlinux ${MODULES_BUILD_PATH}
+	cp /sys/kernel/btf/vmlinux ${BTF_INSTALL_PATH}
 
 modules_uninstall:
 	${RM} -r ${MODULES_INSTALL_PATH}/lunatik


### PR DESCRIPTION
The MODULES_BUILD_PATH variable was used to designate both the location of kernel headers and where to copy `/sys/kernel/btf/vmlinux` when
`btf_install` target. when building and installing a module for the same machine, they are indeed the same; however they differ if we pass
a MODULES_BUILD_PATH externally, for example the kernel source, with a config for a different target platform.
 
The default values remain the same as they were.
