### PR TITLE
added vt support to luanotifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,30 @@ _notifier.netdev_ is a table that exports
 [NETDEV](https://elixir.bootlin.com/linux/v6.3/source/include/linux/netdevice.h#L2812)
 flags to Lua.
 
+### `notifier.vterm(callback)`
+
+_notifier.vterm()_ returns a new virtual terminal `notifier` object and installs it in the system. The `callback` function is called whenever a virtual terminal event happens (e.g. new character written to the terminal, new terminal allocated, etc).
+The callback function receives the following arguments:
+* `event`: the available _events_ are defined by the
+[notifier.vt](https://github.com/luainkernel/lunatik#notifiervt) table.
+* `c`: character related to the event.
+* `vc_num`: virtual console number associated with the event.
+
+The `callback` function might return the values defined by the
+[notifier.notify](https://github.com/luainkernel/lunatik#notifiernotify) table.
+
+#### `notifier.vt`
+
+_notifier.vt_ is a table that exports
+[VT](https://elixir.bootlin.com/linux/latest/source/include/linux/vt.h)
+flags to Lua.
+
+* `"VT_ALLOCATE"`: virtual terminal is being allocated.
+* `"VT_DEALLOCATE"`: virtual terminal is being deallocated.
+* `"VT_WRITE"`: character is written to virtual terminal.
+* `"VT_UPDATE"`: virtual terminal update event.
+* `"VT_PREWRITE"`: before writing character to virtual terminal.
+
 #### `notifier.notify`
 
 _notifier.notify_ is a table that exports

--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -8,6 +8,8 @@
 #include <linux/version.h>
 #include <linux/keyboard.h>
 #include <linux/netdevice.h>
+#include <linux/vt_kern.h>
+#include <linux/vt.h>
 
 #include <lua.h>
 #include <lualib.h>
@@ -42,6 +44,15 @@ static int luanotifier_netdevice_handler(lua_State *L, void *data)
 
 	lua_pushstring(L, dev->name);
 	return 1;
+}
+
+static int luanotifier_vt_handler (lua_State* L, void* data)
+{
+	struct vt_notifier_param* param = data;
+
+	lua_pushinteger(L, param->c);
+	lua_pushinteger(L, param->vc->vc_num);
+	return 2;
 }
 
 static int luanotifier_handler(lua_State *L, luanotifier_t *notifier, unsigned long event, void *data)
@@ -93,6 +104,7 @@ static int luanotifier_##name(lua_State *L)					\
 
 LUANOTIFIER_NEWCHAIN(keyboard);
 LUANOTIFIER_NEWCHAIN(netdevice);
+LUANOTIFIER_NEWCHAIN(vt);
 
 static void luanotifier_release(void *private)
 {
@@ -147,6 +159,7 @@ static int luanotifier_delete(lua_State *L)
 static const luaL_Reg luanotifier_lib[] = {
 	{"keyboard", luanotifier_keyboard},
 	{"netdevice", luanotifier_netdevice},
+	{"vterm", luanotifier_vt},
 	{NULL, NULL}
 };
 
@@ -223,10 +236,19 @@ static const lunatik_reg_t luanotifier_netdev[] = {
 	{NULL, 0}
 };
 
+static const lunatik_reg_t luanotifier_vt_evs[] = {
+	{"VT_ALLOCATE", VT_ALLOCATE},
+	{"VT_DEALLOCATE", VT_DEALLOCATE},
+	{"VT_WRITE", VT_WRITE},
+	{"VT_UPDATE", VT_UPDATE},
+	{"VT_PREWRITE", VT_PREWRITE},
+	{NULL, 0}
+};
 static const lunatik_namespace_t luanotifier_flags[] = {
 	{"notify", luanotifier_notify},
 	{"kbd", luanotifier_kbd},
 	{"netdev", luanotifier_netdev},
+	{"vt", luanotifier_vt_evs},
 	{NULL, NULL}
 };
 


### PR DESCRIPTION
This enables registration of notifier blocks for virtual terminal events. Here's an example of use:

```lua
local notifier = require 'notifier'
local notify = notifier.notify
local vt_ev = notifier.vt

function vt_monitor (event, c, vc_num)
    print (string.format("event=%d, c=%d, vc_num=%d", event, c, vc_num))
return notify.OK end

notifier.vterm (vt_monitor)
```