### PR TITLE
Adjust build for mips(el) + 1-cpu targets

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -11,9 +11,9 @@ endif
 
 KLIBC_USR := /klibc/usr
 ccflags-y += -D_LUNATIK -D_KERNEL -DLUNATIK_RUNTIME=$(CONFIG_LUNATIK_RUNTIME) \
-	-Wimplicit-fallthrough=0 -I$(src) -I${PWD} -I${PWD}/include -I${PWD}/lua \
+	-Wimplicit-fallthrough=0 -I$(src) -I${PWD} -I${PWD}/include -I${PWD}/lua
+asflags-y += -D_LUNATIK -D_KERNEL \
 	-I${PWD}$(KLIBC_USR)/include/arch/$(KLIBC_ARCH)
-asflags-y += -D_LUNATIK -D_KERNEL
 
 obj-$(CONFIG_LUNATIK) += lunatik.o
 

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -100,8 +100,10 @@ static int luathread_task(lua_State *L)
 	lua_createtable(L, 0, nrec);
 	table = lua_gettop(L);
 
+#ifdef CONFIG_SMP
 	lua_pushinteger(L, task->on_cpu);
 	lua_setfield(L, table, "cpu");
+#endif
 
 	lua_pushstring(L, task->comm);
 	lua_setfield(L, table, "command");


### PR DESCRIPTION
- amend asm compilation for mips/mipsel
- condition multi-cpu task management to allow builds for 1-cpu target machines

Relates to [luainkernel/openwrt_feed/pull/5](https://github.com/luainkernel/openwrt_feed/pull/5)