### PR TITLE
make MAX_SCHEDULE_TIMEOUT definition available

### DIFF
--- a/lib/luacompletion.c
+++ b/lib/luacompletion.c
@@ -7,6 +7,7 @@
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/completion.h>
+#include <linux/sched.h>
 
 #include <lua.h>
 #include <lualib.h>


### PR DESCRIPTION
`MAX_SCHEDULE_TIMEOUT` is defined at [`linux/sched.h`](https://elixir.bootlin.com/linux/v6.15-rc3/source/include/linux/sched.h#L324) since [v.2.1](https://elixir.bootlin.com/linux/2.1.133pre5/source/include/linux/sched.h#L120).