### PR TITLE
Fix :  add kernel version guard to luaxdp_exit() for compatibility with < 6.4

### DIFF
--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -205,8 +205,10 @@ static int __init luaxdp_init(void)
 
 static void __exit luaxdp_exit(void)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0))
 	if (luaxdp_runtimes != NULL)
 		lunatik_putobject(luaxdp_runtimes);
+#endif
 }
 
 module_init(luaxdp_init);


### PR DESCRIPTION
fixes : #262 

### Summary

This pull request fixes a build failure when compiling Lunatik on Linux kernels older than 6.4.0 (e.g., Debian 12 with 6.1.x).

### Problem

The `luaxdp_exit()` function references `luaxdp_runtimes`  which is only available in Linux >= 6.4. This causes compilation error.

### Solution 

Added an version guard in before using the `luaxdp_runtimes` variable.


