### PR TITLE
move lunatik_setstring into lunatik.h

### DIFF
--- a/lib/luanetfilter.h
+++ b/lib/luanetfilter.h
@@ -40,17 +40,6 @@ do {							\
 		nf->field = opt;			\
 } while (0)
 
-#define luanetfilter_setstring(L, idx, hook, field, maxlen)        \
-do {								\
-	size_t len;						\
-	lunatik_checkfield(L, idx, #field, LUA_TSTRING);	\
-	const char *str = lua_tolstring(L, -1, &len);			\
-	if (len > maxlen)					\
-		luaL_error(L, "'%s' is too long", #field);	\
-	strncpy((char *)hook->field, str, maxlen);		\
-	lua_pop(L, 1);						\
-} while (0)
-
 const lunatik_reg_t luanetfilter_family[] = {
 	{"UNSPEC", NFPROTO_UNSPEC},
 	{"INET", NFPROTO_INET},

--- a/lunatik.h
+++ b/lunatik.h
@@ -283,6 +283,18 @@ static inline T checker(lua_State *L, int ix)			\
 
 #define lunatik_getregistry(L, key)	lua_rawgetp((L), LUA_REGISTRYINDEX, (key))
 
+#define lunatik_setstring(L, idx, hook, field, maxlen)        \
+do {								\
+	size_t len;						\
+	lunatik_checkfield(L, idx, #field, LUA_TSTRING);	\
+	const char *str = lua_tolstring(L, -1, &len);			\
+	if (len > maxlen)					\
+		luaL_error(L, "'%s' is too long", #field);	\
+	strncpy((char *)hook->field, str, maxlen);		\
+	lua_pop(L, 1);						\
+} while (0)
+
+
 static inline void lunatik_setregistry(lua_State *L, int ix, void *key)
 {
 	lua_pushvalue(L, ix);


### PR DESCRIPTION
moving the marco `lunatik_setstring` to the header `lunatik.h`, which giving access privileges to all c codes.