### PR TITLE
hotfix: correct function name to fix build failure

### DIFF
--- a/lib/luaxtable.c
+++ b/lib/luaxtable.c
@@ -215,7 +215,7 @@ static int luaxtable_new##hook(lua_State *L) 				\
 	struct xt_##hook *hook = &xtable->hook;				\
 	hook->me = THIS_MODULE;						\
 									\
-	luanetfilter_setstring(L, 1, hook, name, XT_EXTENSION_MAXNAMELEN - 1);	\
+	lunatik_setstring(L, 1, hook, name, XT_EXTENSION_MAXNAMELEN - 1);	\
 	luanetfilter_setinteger(L, 1, hook, revision);			\
 	luanetfilter_setinteger(L, 1, hook, family);			\
 	luanetfilter_setinteger(L, 1, hook, proto);			\


### PR DESCRIPTION
re-added the netfilter's marco and kept the `lunatik.h`'s marco as well.
consider that can be saved and changed in the `lunatik.h`.
the one in the `luanetfilter.h` can be specialized for netfilter