### PR TITLE
move luanetfilter_setinteger/optinteger into lunatik.h

### DIFF
--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -173,10 +173,10 @@ static int luanetfilter_register(lua_State *L)
 	nfops->hook = luanetfilter_hook;
 	nfops->dev = NULL;
 	nfops->priv = nf;
-	luanetfilter_setinteger(L, 1, nfops, pf);
-	luanetfilter_setinteger(L, 1, nfops, hooknum);
-	luanetfilter_setinteger(L, 1, nfops, priority);
-	luanetfilter_optinteger(L, 1, nf, mark, 0);
+	lunatik_setinteger(L, 1, nfops, pf);
+	lunatik_setinteger(L, 1, nfops, hooknum);
+	lunatik_setinteger(L, 1, nfops, priority);
+	lunatik_optinteger(L, 1, nf, mark, 0);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0))
 	if (nf_register_net_hook(&init_net, nfops) != 0)

--- a/lib/luanetfilter.h
+++ b/lib/luanetfilter.h
@@ -30,23 +30,6 @@ do {							\
 	lua_pop(L, 1); /* skb */			\
 } while (0)
 
-#define luanetfilter_setinteger(L, idx, hook, field) 		\
-do {								\
-	lunatik_checkfield(L, idx, #field, LUA_TNUMBER);	\
-	hook->field = lua_tointeger(L, -1);			\
-	lua_pop(L, 1);						\
-} while (0)
-
-#define luanetfilter_optinteger(L, idx, nf, field, opt)	\
-do {							\
-	lua_getfield(L, idx, #field);			\
-	if (!lua_isnil(L, -1)) {			\
-		nf->field = lua_tointeger(L, -1);	\
-		lua_pop(L, 1);				\
-	}						\
-	else						\
-		nf->field = opt;			\
-} while (0)
 
 /***
 * Table of Netfilter protocol families.

--- a/lib/luaxtable.c
+++ b/lib/luaxtable.c
@@ -347,10 +347,10 @@ static int luaxtable_new##hook(lua_State *L) 				\
 	hook->me = THIS_MODULE;						\
 									\
 	lunatik_setstring(L, 1, hook, name, XT_EXTENSION_MAXNAMELEN - 1);	\
-	luanetfilter_setinteger(L, 1, hook, revision);			\
-	luanetfilter_setinteger(L, 1, hook, family);			\
-	luanetfilter_setinteger(L, 1, hook, proto);			\
-	luanetfilter_setinteger(L, 1, hook, hooks);			\
+	lunatik_setinteger(L, 1, hook, revision);			\
+	lunatik_setinteger(L, 1, hook, family);			\
+	lunatik_setinteger(L, 1, hook, proto);			\
+	lunatik_setinteger(L, 1, hook, hooks);			\
 	lunatik_checkfield(L, 1, "checkentry", LUA_TFUNCTION);		\
 	lunatik_checkfield(L, 1, "destroy", LUA_TFUNCTION);		\
 	lunatik_checkfield(L, 1, #hook, LUA_TFUNCTION);			\

--- a/lunatik.h
+++ b/lunatik.h
@@ -294,6 +294,24 @@ do {								\
 	lua_pop(L, 1);						\
 } while (0)
 
+#define lunatik_setinteger(L, idx, hook, field) 		\
+do {								\
+	lunatik_checkfield(L, idx, #field, LUA_TNUMBER);	\
+	hook->field = lua_tointeger(L, -1);			\
+	lua_pop(L, 1);						\
+} while (0)
+
+#define lunatik_optinteger(L, idx, nf, field, opt)	\
+do {							\
+	lua_getfield(L, idx, #field);			\
+	if (!lua_isnil(L, -1)) {			\
+		nf->field = lua_tointeger(L, -1);	\
+		lua_pop(L, 1);				\
+	}						\
+	else						\
+		nf->field = opt;			\
+} while (0)
+
 
 static inline void lunatik_setregistry(lua_State *L, int ix, void *key)
 {


### PR DESCRIPTION
This pull request refactors the Lua-Netfilter integration by replacing `luanetfilter_*` macros with equivalent `lunatik_*` macros across the codebase. This change consolidates functionality into the `lunatik.h` file, simplifying maintenance and improving consistency.

### Refactoring Lua-Netfilter macros:

* **Macro replacement in `lib/luanetfilter.c`:** Updated calls to `luanetfilter_setinteger` and `luanetfilter_optinteger` with `lunatik_setinteger` and `lunatik_optinteger` respectively, ensuring consistent macro usage.

* **Macro removal in `lib/luanetfilter.h`:** Removed definitions of `luanetfilter_setinteger` and `luanetfilter_optinteger`, as their functionality is now handled by `lunatik.h`.

* **Macro replacement in `lib/luaxtable.c`:** Replaced `luanetfilter_setinteger` calls with `lunatik_setinteger` for setting integer fields in Netfilter hooks.

* **Macro addition in `lunatik.h`:** Added definitions for `lunatik_setinteger` and `lunatik_optinteger` macros, centralizing the logic for setting and optionally setting integer fields.