### PR TITLE
update the optinteger with removed nil version

### DIFF
--- a/lunatik.h
+++ b/lunatik.h
@@ -301,15 +301,11 @@ do {								\
 	lua_pop(L, 1);						\
 } while (0)
 
-#define lunatik_optinteger(L, idx, nf, field, opt)	\
-do {							\
-	lua_getfield(L, idx, #field);			\
-	if (!lua_isnil(L, -1)) {			\
-		nf->field = lua_tointeger(L, -1);	\
-		lua_pop(L, 1);				\
-	}						\
-	else						\
-		nf->field = opt;			\
+#define lunatik_optinteger(L, idx, priv, field, opt)			\
+do {									\
+	lua_getfield(L, idx, #field);					\
+	priv->field = lua_isnil(L, -1) ? opt : lua_tointeger(L, -1);	\
+	lua_pop(L, 1);							\
 } while (0)
 
 


### PR DESCRIPTION
This pull request makes a single change to the macro definition in `lunatik.h`, renaming it and simplifying its logic.

* Renamed the macro `lunatik_optinteger` to `luahid_optinteger` and simplified its logic by removing conditional checks for `lua_isnil`. The new implementation directly assigns `opt` if the field is `nil`, reducing redundancy.