### PR TITLE
Fix compilation warning

### DIFF
--- a/lunatik.h
+++ b/lunatik.h
@@ -246,7 +246,7 @@ static inline lunatik_object_t *lunatik_testobject(lua_State *L, int ix)
 	return class != NULL && (pobject = luaL_testudata(L, ix, class->name)) != NULL ? *pobject : NULL;
 }
 
-static void inline lunatik_newnamespaces(lua_State *L, const lunatik_namespace_t *namespaces)
+static inline void lunatik_newnamespaces(lua_State *L, const lunatik_namespace_t *namespaces)
 {
 	for (; namespaces->name; namespaces++) {
 		const lunatik_reg_t *reg;


### PR DESCRIPTION
Fixes the warning that gets triggered for each module compilation:

```
In file included from lib/luaMODULE.c:29:
././lunatik.h:249:1: warning: ‘inline’ is not at beginning of declaration [-Wold-style-declaration]
  249 | static void inline lunatik_newnamespaces(lua_State *L, const lunatik_namespace_t *namespaces)
      | ^~~~~~
```