### PR TITLE
add handler for probe

### DIFF
--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -49,12 +49,12 @@ static int luahid_register(lua_State *L);
 
 static const luaL_Reg luahid_lib[] = {
 	{"register", luahid_register},
-	{NULL, NULL}
+	{NULL, NULL},
 };
 
 static const luaL_Reg luahid_mt[] = {
 	{"__gc", lunatik_deleteobject},
-	{NULL, NULL}
+	{NULL, NULL},
 };
 
 static const lunatik_class_t luahid_class = {
@@ -136,7 +136,7 @@ static int luahid_register(lua_State *L)
 
 	lunatik_checkfield(L, 1, "id_table", LUA_TTABLE);
 	luaL_argcheck(L, (user_driver->id_table = luahid_setidtable(L, -1)) != NULL,
-			   2, "invaild id_table");
+		      2, "invaild id_table");
 
 	lunatik_setruntime(L, hid, hid);
 	lunatik_getobject(hid->runtime);


### PR DESCRIPTION
This pull request introduces significant enhancements to the `lib/luahid.c` file to improve HID (Human Interface Device) driver functionality. The changes include adding new dependencies, extending the `luahid_t` structure, implementing a `probe` mechanism for device initialization, and modifying the HID driver registration process to support Lua-based device handling.

### Enhancements to HID driver functionality:

* **Added new dependencies for Lua and kernel utilities**:
  Included `linux/printk.h` and `lua.h` headers to enable logging and Lua integration in the HID driver. 

* **Extended `luahid_t` structure**:
  Added a `devtable` member to store device-specific private data, improving the driver's ability to manage multiple devices. 

### Implementation of device initialization (`probe` mechanism):

* **Introduced `luahid_probe` and `luahid_probe_handler`**:
  Implemented a `probe` function and its Lua-based handler to initialize devices using Lua scripts. The handler retrieves device information, calls an `init` function defined in Lua, and sets device-specific data (`drvdata`).

* **Lua example for device initialization**:
  Added a sample Lua function (`hid_driver:init`) to demonstrate how device-specific features can be set based on `devinfo`.

### Modifications to HID driver registration:

* **Updated `luahid_register` function**:
  Integrated the `probe` mechanism into the HID driver registration process. This includes setting up the Lua registry for device handling and ensuring proper cleanup in case of registration failure.