### PR TITLE
add callback for report_descriptor

### DIFF
--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -103,7 +103,6 @@ do { 						\
 	lua_setfield(L, idx - 1, #field);	\
 } while (0)
 
-static inline void luahid_pushdevid(lua_State *L, int idx, const struct hid_device_id *device_id)
 #define luahid_pcall(L, func, arg) 					\
 do { 									\
 	int n = lua_gettop(L); 						\
@@ -125,13 +124,11 @@ do { 							\
 	luahid_setfield(L, -1, dev, extra); 		\
 } while (0)
 
+static inline int luahid_pushdevid(lua_State *L)
 {
-	lua_newtable(L);
-	luahid_setfield(L, -1, device_id, bus);
-	luahid_setfield(L, -1, device_id, group);
-	luahid_setfield(L, -1, device_id, vendor);
-	luahid_setfield(L, -1, device_id, product);
-	luahid_setfield(L, -1, device_id, driver_data);
+	struct hid_device_id *device_id = (struct hid_device_id *)lua_touserdata(L, 1);
+	luahid_newtable(L, device_id, driver_data);
+	return 1; /* devid table */
 }
 
 static inline int luahid_pushhdev(lua_State *L)
@@ -163,7 +160,7 @@ static int luahid_doprobe(lua_State *L, luahid_t *hid, struct hid_device *hdev, 
 		return 0;
 
 	lua_pushvalue(L, -3); /* hid.ops */
-	luahid_pushdevid(L, -4, id);
+	luahid_pcall(L, luahid_pushdevid, id);
 
 	if (lua_pcall(L, 2, 1, 0) != LUA_OK) {
 		pr_err("probe: %s\n", lua_tostring(L, -1));

--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -155,7 +155,7 @@ static inline void luahid_pushinfo(lua_State *L, int idx, struct hid_device *hde
 static int luahid_doprobe(lua_State *L, luahid_t *hid, struct hid_device *hdev, const struct hid_device_id *id)
 {
 	if (luahid_checkdriver(L, hid, -1, "_info")) {
-		pr_err("probe: couldn't find driver");
+		pr_err("probe: couldn't find driver\n");
 		return -ENXIO;
 	}
 


### PR DESCRIPTION
This pull request introduces enhancements to the HID driver integration in the `lib/luahid.c` file, including the addition of support for report fixups, a new `luadata_t` structure, and improved Lua integration for HID device information. These changes aim to extend the functionality of the driver and improve its interaction with Lua scripts.

### New functionality for report fixups:
* Added the `luahid_report_fixup` function to handle report fixups for HID devices, with support for kernel versions 6.12.0 and above. This function integrates Lua-based processing of HID reports, allowing modifications to the report data.
* Introduced the `luahid_doreport_fixup` helper function to manage the Lua interaction for report fixups, including creating and handling `luadata_t` objects for report data.

### New data structure and Lua integration:
* Defined a new `luadata_t` structure to encapsulate report data, including a pointer to the data, its size, and additional options.
* Added the `luahid_push_device_info` function to populate a Lua table with detailed HID device information, such as vendor, product, and version.

### Registration enhancements:
* Updated the `luahid_register` function to initialize a `_report_des` table for storing report descriptors and to assign the new `report_fixup` callback to the HID driver.

These changes improve the modularity and extensibility of the HID driver, enabling advanced use cases through Lua scripting.