### PR TITLE
moving the newbuffer marco from netfilter to the core

### DIFF
--- a/lib/luadata.c
+++ b/lib/luadata.c
@@ -368,7 +368,7 @@ static int luadata_lnew(lua_State *L)
 
 LUNATIK_NEWLIB(data, luadata_lib, &luadata_class, NULL);
 
-lunatik_object_t *luadata_new(void *ptr, size_t size, bool sleep, uint8_t opt)
+static inline lunatik_object_t *luadata_create(void *ptr, size_t size, bool sleep, uint8_t opt)
 {
 	lunatik_object_t *object = lunatik_createobject(&luadata_class, sizeof(luadata_t), sleep);
 
@@ -379,6 +379,13 @@ lunatik_object_t *luadata_new(void *ptr, size_t size, bool sleep, uint8_t opt)
 		data->opt = opt;
 	}
 	return object;
+}
+
+lunatik_object_t *luadata_new(lua_State *L)
+{
+	lunatik_object_t *data = lunatik_checknull(L, luadata_create(NULL, 0, false, LUADATA_OPT_NONE));
+	lunatik_cloneobject(L, data);
+	return data;
 }
 EXPORT_SYMBOL(luadata_new);
 

--- a/lib/luadata.h
+++ b/lib/luadata.h
@@ -17,7 +17,7 @@ LUNATIK_LIB(data);
 
 #define luadata_clear(o)	(luadata_reset((o), NULL, 0, LUADATA_OPT_KEEP))
 
-lunatik_object_t *luadata_new(void *ptr, size_t size, bool sleep, uint8_t opt);
+lunatik_object_t *luadata_new(lua_State *L);
 int luadata_reset(lunatik_object_t *object, void *ptr, size_t size, uint8_t opt);
 
 static inline void luadata_close(lunatik_object_t *object)
@@ -25,6 +25,13 @@ static inline void luadata_close(lunatik_object_t *object)
 	luadata_clear(object);
 	lunatik_putobject(object);
 }
+
+#define luadata_attach(L, obj, field)			\
+do {							\
+	obj->field = luadata_new(L); 			\
+	lunatik_setregistry(L, -1, obj->field);		\
+	lua_pop(L, 1);					\
+} while (0)
 
 #endif
 

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -163,7 +163,7 @@ static int luanetfilter_register(lua_State *L)
 	luaL_checktype(L, 1, LUA_TTABLE);
 	lunatik_object_t *object = lunatik_newobject(L, &luanetfilter_class , sizeof(luanetfilter_t));
 	luanetfilter_t *nf = (luanetfilter_t *)object->private;
-	luanetfilter_newbuffer(L, nf, skb);
+	luadata_attach(L, nf, skb);
 	nf->runtime = NULL;
 
 	struct nf_hook_ops *nfops = &nf->nfops;

--- a/lib/luanetfilter.h
+++ b/lib/luanetfilter.h
@@ -22,14 +22,6 @@
 
 #include <lunatik.h>
 
-#define luanetfilter_newbuffer(L, obj, field)		\
-do {							\
-	obj->field = lunatik_checknull(L, luadata_new(NULL, 0, false, LUADATA_OPT_NONE));	\
-	lunatik_cloneobject(L, obj->field);		\
-	lunatik_setregistry(L, -1, obj->field);	\
-	lua_pop(L, 1); /* skb */			\
-} while (0)
-
 
 /***
 * Table of Netfilter protocol families.

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -170,12 +170,6 @@ static const struct btf_kfunc_id_set bpf_luaxdp_kfunc_set = {
 */
 #define luaxdp_setcallback(L, i)	(lunatik_setregistry((L), (i), luaxdp_callback))
 
-static inline void luaxdp_newdata(lua_State *L)
-{
-	lunatik_object_t *data = lunatik_checknull(L, luadata_new(NULL, 0, false, LUADATA_OPT_NONE));
-	lunatik_cloneobject(L, data);
-}
-
 /***
 * Unregisters the Lua callback function associated with the current Lunatik runtime.
 * After calling this, `bpf_luaxdp_run` calls targeting this runtime will no longer
@@ -243,8 +237,8 @@ static int luaxdp_attach(lua_State *L)
 	lunatik_checkruntime(L, false);
 	luaL_checktype(L, 1, LUA_TFUNCTION); /* callback */
 
-	luaxdp_newdata(L); /* buffer */
-	luaxdp_newdata(L); /* argument */
+	luadata_new(L); /* buffer */
+	luadata_new(L); /* argument */
 
 	lua_pushcclosure(L, luaxdp_callback, 3);
 	luaxdp_setcallback(L, -1);

--- a/lib/luaxtable.c
+++ b/lib/luaxtable.c
@@ -326,7 +326,7 @@ static inline lunatik_object_t *luaxtable_new(lua_State *L, int idx, int hook)
 
 	xtable->type = hook;
 	xtable->runtime = NULL;
-	luanetfilter_newbuffer(L, xtable, skb);
+	luadata_attach(L, xtable, skb);
 	return object;
 }
 


### PR DESCRIPTION
This pull request refactors the `lunatik_newbuffer` macro to improve reusability and consistency across the codebase. The macro is moved from `lib/luanetfilter.h` to `lunatik.h`, and references to the old `luanetfilter_newbuffer` macro are replaced with the new `lunatik_newbuffer`.

### Refactoring and Code Reorganization:

* Removed the `luanetfilter_newbuffer` macro from `lib/luanetfilter.h` and replaced its usage with the `lunatik_newbuffer` macro for consistency. 
### Cleanup:

* Removed an unused `#include <lunatik.h>` directive from `lib/luadata.h` to streamline the header file.