### PR TITLE
Ifdef comp kernelverion

### DIFF
--- a/lib/luacrypto_comp.c
+++ b/lib/luacrypto_comp.c
@@ -21,6 +21,7 @@
 #include <linux/err.h>
 #include <linux/slab.h>
 #include <linux/limits.h>
+#include <linux/version.h>
 
 #include <lua.h>
 #include <lualib.h>
@@ -29,6 +30,9 @@
 
 #include "luacrypto.h"
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
+#warning "crypto_comp API was removed in Linux 6.15, skip COMP module"
+#else
 LUNATIK_PRIVATECHECKER(luacrypto_comp_check, struct crypto_comp *);
 
 LUACRYPTO_RELEASER(comp, struct crypto_comp, crypto_free_comp, NULL);
@@ -119,6 +123,7 @@ static const luaL_Reg luacrypto_comp_lib[] = {
 };
 
 LUNATIK_NEWLIB(crypto_comp, luacrypto_comp_lib, &luacrypto_comp_class, NULL);
+#endif
 
 static int __init luacrypto_comp_init(void)
 {


### PR DESCRIPTION
This pull request updates the `luacrypto_comp.c` file to ensure compatibility with different Linux kernel versions. The changes introduce conditional compilation to handle the deprecation of the `crypto_comp` API in Linux kernel version 6.15 and later.

### Compatibility updates for Linux kernel versions:

* Added a version check using `LINUX_VERSION_CODE` to conditionally include the `crypto_comp` module only for kernels below version 6.15. 
* Introduced a preprocessor warning to notify developers that the `crypto_comp` API is removed in Linux kernel versions 6.15 and above.

### Code maintenance:

* Included `<linux/version.h>` to access the `LINUX_VERSION_CODE` macro for kernel version checks. 