### PR TITLE
add luadata_clear for netfilter & xtable

### DIFF
--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -83,6 +83,7 @@ static int luanetfilter_hook_cb(lua_State *L, luanetfilter_t *luanf, struct sk_b
 
 	if (lua_pcall(L, 1, 2, 0) != LUA_OK) {
 		pr_err("%s\n", lua_tostring(L, -1));
+		luadata_clear(data);
 		return -1;
 	}
 

--- a/lib/luaxtable.c
+++ b/lib/luaxtable.c
@@ -124,8 +124,13 @@ static int luaxtable_pushparams(lua_State *L, const struct xt_action_param *par,
 	return 0;
 }
 
+static inline int luaxtable_cleanup(luaxtable_t *xtable)
+{
+	return luadata_clear(xtable->skb);
+}
+
 #define luaxtable_call(L, op, xtable, skb, par, info, opt)	\
-	((luaxtable_pushparams(L, par, xtable, skb, opt) == -1) || (luaxtable_docall(L, xtable, info, op, 2, 1) == -1))
+	((luaxtable_pushparams(L, par, xtable, skb, opt) == -1) || (luaxtable_docall(L, xtable, info, op, 2, 1) == -1) || luaxtable_cleanup(xtable))
 
 static int luaxtable_domatch(lua_State *L, luaxtable_t *xtable, const struct sk_buff *skb, struct xt_action_param *par, int fallback)
 {
@@ -135,7 +140,6 @@ static int luaxtable_domatch(lua_State *L, luaxtable_t *xtable, const struct sk_
 	int ret = lua_toboolean(L, -1);
 	lua_getfield(L, -2, "hotdrop");
 	par->hotdrop = lua_toboolean(L, -1);
-	luadata_clear(xtable->skb);
 	return ret;
 }
 
@@ -145,7 +149,6 @@ static int luaxtable_dotarget(lua_State *L, luaxtable_t *xtable, struct sk_buff 
 		return fallback;
 
 	int ret = lua_tointeger(L, -1);
-	luadata_clear(xtable->skb);
 	return ret >= 0 && ret <= NF_MAX_VERDICT ? ret : fallback;
 }
 


### PR DESCRIPTION
This pull request introduces a small but important change to the `luanetfilter_hook_cb` function in `lib/luanetfilter.c`. The update ensures that the `data` structure is cleared before further processing, which can help prevent issues caused by stale or leftover data.

* Added a call to `luadata_clear(data);` at the beginning of the function to ensure the `data` structure is reset before use.