### PR TITLE
fix struct sockaddr version check

### DIFF
--- a/lib/luasocket.c
+++ b/lib/luasocket.c
@@ -46,7 +46,8 @@ do {						\
 
 #define LUASOCKET_SOCKADDR(addr)	(struct sockaddr *)&addr, sizeof(addr)
 #define LUASOCKET_ADDRMAX		(sizeof(struct sockaddr_ll)) /* AF_PACKET */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 150)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 150) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)) \
+	|| LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 80)
 #define LUASOCKET_ADDRMIN(addr)	(sizeof((addr)->sa_data_min))
 #else
 #define LUASOCKET_ADDRMIN(addr)	(sizeof((addr)->sa_data))


### PR DESCRIPTION
* sa_data_min field was introduced on v5.15.150, removed on v5.16 and reintroduced on v6.1.80