### PR TITLE
implement generic resize method with SKB support

### DIFF
--- a/lib/luadata.h
+++ b/lib/luadata.h
@@ -13,6 +13,7 @@ LUNATIK_LIB(data);
 #define	LUADATA_OPT_NONE	0x00
 #define	LUADATA_OPT_READONLY	0x01
 #define	LUADATA_OPT_FREE	0x02
+#define LUADATA_OPT_SKB  	0x04
 #define	LUADATA_OPT_KEEP  	0x80
 
 #define luadata_clear(o)	(luadata_reset((o), NULL, 0, LUADATA_OPT_KEEP))

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -77,9 +77,9 @@ static int luanetfilter_hook_cb(lua_State *L, luanetfilter_t *luanf, struct sk_b
 		return -1;
 
 	if (skb_mac_header_was_set(skb))
-		luadata_reset(data, skb_mac_header(skb), skb_headlen(skb) + skb_mac_header_len(skb), LUADATA_OPT_NONE);
+		luadata_reset(data, skb, skb_headlen(skb) + skb_mac_header_len(skb), LUADATA_OPT_SKB);
 	else
-		luadata_reset(data, skb->data, skb_headlen(skb), LUADATA_OPT_NONE);
+		luadata_reset(data, skb, skb_headlen(skb), LUADATA_OPT_SKB);
 
 	if (lua_pcall(L, 1, 2, 0) != LUA_OK) {
 		pr_err("%s\n", lua_tostring(L, -1));

--- a/lib/luaxtable.c
+++ b/lib/luaxtable.c
@@ -129,7 +129,7 @@ static int luaxtable_pushparams(lua_State *L, const struct xt_action_param *par,
 
 static int luaxtable_domatch(lua_State *L, luaxtable_t *xtable, const struct sk_buff *skb, struct xt_action_param *par, int fallback)
 {
-	if (luaxtable_call(L, "match", xtable, (struct sk_buff *)skb, par, (luaxtable_info_t *)par->matchinfo, LUADATA_OPT_READONLY) != 0)
+	if (luaxtable_call(L, "match", xtable, (struct sk_buff *)skb, par, (luaxtable_info_t *)par->matchinfo, LUADATA_OPT_READONLY | LUADATA_OPT_SKB) != 0)
 		return fallback;
 
 	int ret = lua_toboolean(L, -1);
@@ -140,7 +140,7 @@ static int luaxtable_domatch(lua_State *L, luaxtable_t *xtable, const struct sk_
 
 static int luaxtable_dotarget(lua_State *L, luaxtable_t *xtable, struct sk_buff *skb, const struct xt_action_param *par, int fallback)
 {
-	if (luaxtable_call(L, "target", xtable,  skb, par, (luaxtable_info_t *)par->targinfo, LUADATA_OPT_NONE) != 0)
+	if (luaxtable_call(L, "target", xtable, skb, par, (luaxtable_info_t *)par->targinfo, LUADATA_OPT_SKB) != 0)
 		return fallback;
 
 	int ret = lua_tointeger(L, -1);


### PR DESCRIPTION
This PR implements a generic resize() method for luadata objects, specifically enabling dynamic packet expansion and shrinking for network buffers.

Key Changes
- Architectural Refactor: Replaced the previous union with a generic void *ptr in luadata_t to simplify the data model and streamline pointer assignments.
- Abstraction Macros: Introduced LUADATA_TOPTR and LUADATA_TOSKB to cleanly handle memory access and type casting for both raw buffers and sk_buff objects.
- Resize Method: Implemented data:resize(new_size) in luadata.c.
       - For SKB-tagged data, it manages the buffer using skb_put() and skb_trim() after verifying skb_tailroom for expansion.
       - For allocated data, it utilizes lunatik_realloc() with standard OOM error handling via lunatik_checknull().
- Netfilter Integration: Updated luanetfilter.c to properly tag intercepted packets

Testing
Verified the logic using the Lunatik REPL by expanding and shrinking buffers. Confirmed via dmesg that the kernel reflects the correct size updates and that memory remains stable under both raw buffer and SKB contexts.