### PR TITLE
provide automatic nop fallback for missing callbacks

### DIFF
--- a/examples/spyglass.lua
+++ b/examples/spyglass.lua
@@ -24,9 +24,7 @@ local function printable(keysym)
 	return keysym >= 32 and keysym <= 126
 end
 
-local function nop() end
-
-local spyglass = {name = "spyglass", open = nop, release = nop, log = ""}
+local spyglass = {name = "spyglass", log = ""}
 
 function spyglass:read()
 	local log = self.log

--- a/examples/systrack.lua
+++ b/examples/systrack.lua
@@ -10,10 +10,8 @@ local systab = require("syscall.table")
 
 local syscalls = {"openat", "read", "write", "readv", "writev", "close"}
 
-local function nop() end -- do nothing
-
 local s = linux.stat
-local driver = {name = "systrack", open = nop, release = nop, mode = s.IRUGO}
+local driver = {name = "systrack", mode = s.IRUGO}
 
 local track = {}
 local toggle = true
@@ -36,7 +34,7 @@ for _, symbol in ipairs(syscalls) do
 		track[symbol] = track[symbol] + 1
 	end
 
-	probe.new(address, {pre = handler, post = nop})
+	probe.new(address, {pre = handler})
 end
 
 device.new(driver)

--- a/examples/tap.lua
+++ b/examples/tap.lua
@@ -12,10 +12,8 @@ local RAW       = socket.sock.RAW
 local ETH_P_ALL = 0x0003
 local MTU       = 1500
 
-local function nop() end
-
 local s = linux.stat
-local tap = {name = "tap", open = nop, release = nop, mode = s.IRUGO}
+local tap = {name = "tap", mode = s.IRUGO}
 
 local socket = socket.new(PACKET, RAW, ETH_P_ALL)
 socket:bind(string.pack(">I2", ETH_P_ALL))

--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -96,11 +96,7 @@ static int luadevice_fop(lua_State *L, luadevice_t *luadev, const char *fop, int
 		goto err;
 	}
 
-	if (lua_getfield(L, -1, fop) != LUA_TFUNCTION) {
-		lua_getfield(L, -2, "name");
-		pr_err("%s: operation isn't defined for /dev/%s\n", fop, lua_tostring(L, -1));
-		goto err;
-	}
+	lunatik_optcfunction(L, -1, fop, lunatik_nop);
 
 	lua_insert(L, base + 1); /* fop */
 	lua_insert(L, base + 2); /* driver */

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -58,10 +58,7 @@ static int luaprobe_handler(lua_State *L, luaprobe_t *probe, const char *handler
 		goto out;
 	}
 
-	if (lua_getfield(L, -1, handler) != LUA_TFUNCTION) {
-		pr_err("%s handler isn't defined\n", handler);
-		goto out;
-	}
+	lunatik_optcfunction(L, -1, handler, lunatik_nop);
 
 	if (symbol != NULL)
 		lua_pushstring(L, symbol);

--- a/lunatik.h
+++ b/lunatik.h
@@ -102,6 +102,11 @@ static inline int lunatik_trylock(lunatik_object_t *object)
 int lunatik_runtime(lunatik_object_t **pruntime, const char *script, bool sleep);
 int lunatik_stop(lunatik_object_t *runtime);
 
+static inline int lunatik_nop(lua_State *L)
+{
+	return 0;
+}
+
 static inline void *lunatik_realloc(lua_State *L, void *ptr, size_t size)
 {
 	void *ud = NULL;
@@ -326,6 +331,14 @@ do {									\
 	priv->field = lua_isnil(L, -1) ? opt : lua_tointeger(L, -1);	\
 	lua_pop(L, 1);							\
 } while (0)
+
+static inline void lunatik_optcfunction(lua_State *L, int idx, const char *field, lua_CFunction default_func)
+{
+	if (lua_getfield(L, idx, field) != LUA_TFUNCTION) {
+		lua_pop(L, 1);
+		lua_pushcfunction(L, default_func);
+	}
+}
 
 #define lunatik_checkbounds(L, idx, val, min, max)	luaL_argcheck(L, val >= min && val <= max, idx, "out of bounds")
 


### PR DESCRIPTION
### Changes:
Added:  
- `lunatik_nop1 : A generic no-op lua_CFunction in `lunatik.h`
- `lunatik_defaultfield` : reusable helper to default table fields to a function 
- Modified device.new to automatically apply `lunatik_nop` when callbacks are missing

### Testing : 

- Verified with devices using default callbacks
- Verified custom callbacks are preserved
- Verified mixed scenarios (custom + default)
`All tests pass with kernel module loaded successfully`

### Screenshots : 

<img width="575" height="62" alt="image" src="https://github.com/user-attachments/assets/8871ddc1-37a4-4143-ab52-82c3171dd73f" />

