### PR TITLE
Fix skb luadata leak on netfilter hook registration failure

### DIFF
--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -198,10 +198,18 @@ static const luaL_Reg luanetfilter_lib[] = {
 static void luanetfilter_release(void *private)
 {
 	luanetfilter_t *nf = (luanetfilter_t *)private;
+	if (nf->skb) {
+		luadata_close(nf->skb);
+		nf->skb = NULL;
+	}
 	if (!nf->runtime)
 		return;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0))
 	nf_unregister_net_hook(&init_net, &nf->nfops);
+#else
+	nf_unregister_hook(&nf->nfops);
+#endif
 	lunatik_putobject(nf->runtime);
 	nf->runtime = NULL;
 }


### PR DESCRIPTION
***Description**
Fixes a memory leak that occurred when netfilter hook registration failed
after creating the skb luadata object. In this case, the object was left
registered in Lua and never released.

The cleanup path now reliably releases the skb object, ensuring correct
resource management in all failure scenarios.
