### PR TITLE
Fix problems of `lneto_hid` and project follow-up

### DIFF
--- a/config.ld
+++ b/config.ld
@@ -77,3 +77,4 @@ sort = true
 -- all = false -- This is the default
 
 -- For more LDoc options, see: https://github.com/lunarmodules/LDoc
+

--- a/examples/gesture.lua
+++ b/examples/gesture.lua
@@ -65,3 +65,4 @@ function driver:raw_event(hdev, state, report, raw_data)
 end
 
 hid.register(driver)
+

--- a/examples/xiaomi.lua
+++ b/examples/xiaomi.lua
@@ -1,5 +1,5 @@
 --
--- SPDX-FileCopyrightText: (c) 2024 Mohammad Shehar Yaar Tausif <sheharyaar48@gmail.com>
+-- SPDX-FileCopyrightText: (c) 2025 Jieming Zhou <qrsikno@gmail.com>
 -- SPDX-License-Identifier: MIT OR GPL-2.0-only
 --
 
@@ -73,3 +73,4 @@ function driver:report_fixup(hdev, priv_data, original_report)
 end
 
 hid.register(driver)
+

--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -15,8 +15,8 @@
 #include <linux/version.h>
 #include <linux/string.h>
 #include <linux/hid.h>
+
 #include <lunatik.h>
-#include <lauxlib.h>
 
 #include "luadata.h"
 
@@ -34,7 +34,6 @@ typedef struct luahid_s {
 	struct hid_driver driver;
 	bool registered;
 } luahid_t;
-
 
 static void luahid_release(void *private)
 {


### PR DESCRIPTION
This is a fixup of comments in [this](https://github.com/luainkernel/lunatik/pull/337)PR 337.

Update Notes：
1. Removed trailing blank lines in `lib/luahid.c`, `config.ld`, and `examples/gesture.lua`
2. Added copyright header to `examples/xiaomi.lua`
3. Removed redundant headers in `lib/luahid.c`

Follow-up Items (Per @lneto 's Request):
| Priority | Area | Description |
|----------|------|-------------|
| **High** | `raw_event` completion  | Complete partial implementation for real hardware events |
| **Medium** | Linux input subsystem integration  | Implement standard event flags/callbacks mapping (e.g., `EV_KEY`, `EV_ABS`) |
| **Low** | Power management & report sending  | Add suspend/resume handlers and async report API |

 