### PR TITLE
Fix lunatik starter unexpected behaviour

### DIFF
--- a/bin/lunatik
+++ b/bin/lunatik
@@ -98,13 +98,6 @@ if command then
 	os.exit()
 end
 
-if not lunatik.probe() then
-	lunatik.commands.load()
-end
-
-local version = lunatik.dostring("return _LUNATIK_VERSION")
-lunatik.copyright = version .. "  " .. lunatik.copyright
-
 local function set(t)
 	local s = {}
 	for _, key in ipairs(t) do s[key] = true end
@@ -127,6 +120,13 @@ if #arg >= 1 then
 	end
 	os.exit()
 end
+
+if not lunatik.probe() then
+	lunatik.commands.load()
+end
+
+local version = lunatik.dostring("return _LUNATIK_VERSION")
+lunatik.copyright = version .. "  " .. lunatik.copyright
 
 print(lunatik.copyright)
 lunatik.prompt()


### PR DESCRIPTION
Fix #350

Bahaviour with this patch:

$ sudo lunatik foobar
usage: lunatik [load|unload|reload|status|list] [run|spawn|stop <script>] $ lsmod |grep lua
$ sudo lunatik load
$ lsmod |grep lunatik
lunatik_run            12288  0
luarcu                 12288  4 luaxtable,luaxdp,lunatik_run
lunatik               344064  22 luaprobe,luacrypto_rng,luacrypto_skcipher,...
$ sudo lunatik unload
$ lsmod |grep lunatik
$