### PR TITLE
Fix bind signature in raw.lua pattern

### DIFF
--- a/config.ld
+++ b/config.ld
@@ -37,6 +37,7 @@ file = {
 	'./lib/luarcu.c',
 	'./lib/luasocket.c',
 	'./lib/socket/inet.lua',
+	'./lib/socket/raw.lua',
 	'./lib/socket/unix.lua',
 	'./lib/luasyscall.c',
 	'./lib/syscall/table.lua',

--- a/examples/lldpd.lua
+++ b/examples/lldpd.lua
@@ -1,5 +1,5 @@
 --
--- SPDX-FileCopyrightText: (c) 2025 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
+-- SPDX-FileCopyrightText: (c) 2025-2026 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
 -- SPDX-License-Identifier: MIT OR GPL-2.0-only
 --
 
@@ -33,10 +33,10 @@ local config = {
 	},
 }
 
-local ethertype = string.pack(">H", ETH_P_LLDP)
+local ethertype = string.pack(">I2", ETH_P_LLDP)
 
-local function get_src_mac(ifindex)
-	local rx <close> = raw.bind(ETH_P_ALL, ifindex)
+local function get_src_mac()
+	local rx <close> = raw.bind(ETH_P_ALL)
 	local frame = rx:receive(2048)
 	return frame:sub(7, 12)
 end
@@ -45,13 +45,13 @@ local function tlv(t, payload, subtype)
 	if subtype then
 		payload = string.char(subtype) .. payload
 	end
-	return string.pack(">H", (t << 9) | #payload) .. payload
+	return string.pack(">I2", (t << 9) | #payload) .. payload
 end
 
 local function build_lldp_frame(chassis_id)
 	local port_id = config.interface
-	local ttl = string.pack(">H", config.system.ttl)
-	local capabilities = string.pack(">HH", config.system.capabilities, config.system.capabilities_enabled)
+	local ttl = string.pack(">I2", config.system.ttl)
+	local capabilities = string.pack(">I2I2", config.system.capabilities, config.system.capabilities_enabled)
 
 	local pdu = {
 		-- Ethernet header
@@ -75,7 +75,7 @@ end
 
 local ifindex = linux.ifindex(config.interface)
 
-local src_mac = get_src_mac(ifindex)
+local src_mac = get_src_mac()
 local lldp_frame = build_lldp_frame(src_mac)
 
 local function worker()

--- a/lib/luasocket.c
+++ b/lib/luasocket.c
@@ -232,7 +232,7 @@ static int luasocket_receive(lua_State *L)
 *       if not binding to a specific protocol via other means (e.g. `socket.new`'s protocol argument for `AF_PACKET` might set this).
 *     - If `addr` is a string: It's a packed string directly representing parts of the `sockaddr_ll` structure
 *       (specifically, the fields after `sll_family`, like `sll_protocol`).
-*       Example from `tap.lua` for binding to `ETH_P_ALL` (0x0003): `sock:bind(string.pack(">H", 0x0003))`.
+*       Example from `tap.lua` for binding to `ETH_P_ALL` (0x0003): `sock:bind(string.pack(">I2", 0x0003))`.
 *   - Other families: A packed string representing the family-specific address structure.
 * @tparam[opt] integer port The local port number (required and used only if the family is `AF_INET`).
 * @treturn nil

--- a/lib/socket/raw.lua
+++ b/lib/socket/raw.lua
@@ -1,5 +1,5 @@
 --
--- SPDX-FileCopyrightText: (c) 2025 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
+-- SPDX-FileCopyrightText: (c) 2026 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
 -- SPDX-License-Identifier: MIT OR GPL-2.0-only
 --
 
@@ -20,18 +20,21 @@ local ETH_P_ALL  = 0x0003
 local raw = {}
 
 ---
--- Creates and binds a raw packet socket for receiving and sending frames.
+-- Creates and binds a raw packet socket for receiving frames.
 -- @param proto (number) EtherType (defaults to ETH_P_ALL).
--- @param ifindex (number) Interface index.
--- @return A new raw packet socket bound for RX.
+-- @param ifindex (number) [optional] Interface index (defaults to listen all interfaces).
+-- @return A new raw packet socket bound for proto and ifindex.
 -- @raise Error if socket.new() or socket.bind() fail.
+-- @usage
+--   local rx <close> = raw.bind(0x0003)
+--   local tx <close> = raw.bind(0x88cc, ifindex)
 -- @see socket.new
 -- @see socket.bind
-function raw.new(proto, ifindex)
+function raw.bind(proto, ifindex)
 	local proto = proto or ETH_P_ALL
-	local ifindex = ifindex or 0
 	local s = socket.new(af.PACKET, sock.RAW, proto)
-	s:bind(string.pack(">H", proto), ifindex)
+	local param = ifindex and ifindex or string.pack(">I2", proto)
+	s:bind(param)
 	return s
 end
 


### PR DESCRIPTION
We need separate call signatures for 
- receiving socket (protocol is required, passed in the form of packed string)
- transmitting socket (only numeric interface index is passed to bind)

Related PR
#360 