### PR TITLE
Use ${CC} instead of cpp in gensymbols.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ uninstall: scripts_uninstall modules_uninstall
 	depmod -a
 
 lunatik_sym.h: $(LUA_API) gensymbols.sh
-	${shell ./gensymbols.sh $(LUA_API) > lunatik_sym.h}
+	${shell CC='$(CC)' ./gensymbols.sh $(LUA_API) > lunatik_sym.h}
 
 moontastik_install_%:
 	[ $* ] || (echo "usage: make moontastik_install_TARGET" ; exit 1)

--- a/gensymbols.sh
+++ b/gensymbols.sh
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: (c) 2023-2026 Ring Zero Desenvolvimento de Software LTDA
 # SPDX-License-Identifier: MIT OR GPL-2.0-only
 
-cat "$@" | sed "s/.*luaconf.h.*//g" | cpp -Ilua/ -D_KERNEL -DLUNATIK_GENSYMBOLS -E -pipe | \
+sed "s/.*luaconf.h.*//g" "$@" | \
+        ${CC} -Ilua/ -D_KERNEL -DLUNATIK_GENSYMBOLS -E - | \
 	grep API | sed "s/.*(\(\w*\))\s*(.*/EXPORT_SYMBOL(\1);/g"
 


### PR DESCRIPTION
This fixes a build problem on NixOS.
cpp is not predefined in the kernel build environment on NixOS.

