### PR TITLE
introduce lunatik_pusherrname helper for error handling

### DIFF
--- a/lib/lualinux.c
+++ b/lib/lualinux.c
@@ -25,9 +25,6 @@
 #include <linux/pid.h> 
 #include <linux/signal.h>
 #include <linux/errno.h>
-#include <linux/errname.h>
-#include <linux/version.h>
-#include <linux/err.h>
 
 #include <lua.h>
 #include <lauxlib.h>
@@ -524,17 +521,8 @@ static const lunatik_reg_t lualinux_signal[] = {
 */
 static int lualinux_errname(lua_State *L)
 {
-    int e = abs((int)luaL_checkinteger(L, 1));
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
-    const char *n = errname(e);
-    lua_pushstring(L, n ? n : "unknown");
-#else
-    char buf[LUAL_BUFFERSIZE];
-    snprintf(buf, sizeof(buf), "%pE", ERR_PTR(-e));
-    lua_pushstring(L, buf);
-#endif
-
+    int e = (int)luaL_checkinteger(L, 1);
+    lunatik_pusherrname(L, e);
     return 1;
 }
 

--- a/lunatik.h
+++ b/lunatik.h
@@ -10,7 +10,6 @@
 #include <linux/spinlock.h>
 #include <linux/slab.h>
 #include <linux/kref.h>
-#include <linux/errname.h>
 
 #include <lua.h>
 #include <lauxlib.h>
@@ -147,14 +146,12 @@ static inline void *lunatik_checknull(lua_State *L, void *ptr)
 
 #define lunatik_checkalloc(L, s)	(lunatik_checknull((L), lunatik_malloc((L), (s))))
 
+void lunatik_pusherrname(lua_State *L, int err);
+
 #define lunatik_tryret(L, ret, op, ...)				\
 do {								\
 	if ((ret = op(__VA_ARGS__)) < 0) {			\
-		const char *err = errname(-ret);		\
-		if (likely(err != NULL))			\
-			lua_pushstring(L, err);			\
-		else						\
-			lua_pushinteger(L, -ret);		\
+		lunatik_pusherrname(L, ret);		\
 		lua_error(L);					\
 	}							\
 } while (0)

--- a/lunatik_aux.c
+++ b/lunatik_aux.c
@@ -5,6 +5,8 @@
 
 #include <linux/slab.h>
 #include <linux/fs.h>
+#include <linux/version.h>
+#include <linux/errname.h>
 
 #include <lua.h>
 #include <lauxlib.h>
@@ -62,6 +64,21 @@ error:
 	return status;
 }
 EXPORT_SYMBOL(lunatik_loadfile);
+
+void lunatik_pusherrname(lua_State *L, int err)
+{
+    err = abs(err);
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
+    const char *name = errname(err);
+    lua_pushstring(L, name ? name : "unknown");
+#else
+    char buf[LUAL_BUFFERSIZE];
+    snprintf(buf, sizeof(buf), "%pE", ERR_PTR(-err));
+    lua_pushstring(L, buf);
+#endif
+}
+EXPORT_SYMBOL(lunatik_pusherrname);
 
 #ifdef MODULE /* see https://lwn.net/Articles/813350/ */
 #include <linux/kprobes.h>


### PR DESCRIPTION
This PR implements a central error handling helper to fix build failures on Linux kernels older than 6.7 (where `errname()` is not yet available).

It introduces a fallback mechanism that ensures `lunatik` compiles and runs correctly across different kernel versions, consolidating the error reporting logic into a single API.

## Changes

* **Introduced `lunatik_pusherrname(L, err)` in `lunatik_aux.c`:**
    * Implements a version check using `LINUX_VERSION_CODE`.
    * Uses the native `errname(err)` on Linux 6.7+.
    * Provides a fallback using `snprintf(..., "%pE", ...)` for older kernels.
* **Updated `lunatik_tryret` macro in `lunatik.h`:**
    * Replaced the direct `errname()` call with the new `lunatik_pusherrname()` helper.
    * This fixes compilation errors for all modules (Socket, Crypto, etc.) that use `lunatik_tryret`.
* **Refactored `lib/lualinux.c`:**
    * Updated `lualinux_errname` to use the new shared helper.
    * Removed unused headers (`<linux/errname.h>`, `<linux/version.h>`) and redundant logic.

## Related Issue
Fixes [#369](https://github.com/luainkernel/lunatik/issues/369)