### PR TITLE
Require explicit (protocol, ifindex) pair in raw sockets bind()

### DIFF
--- a/examples/lldpd.lua
+++ b/examples/lldpd.lua
@@ -35,8 +35,8 @@ local config = {
 
 local ethertype = string.pack(">I2", ETH_P_LLDP)
 
-local function get_src_mac()
-	local rx <close> = raw.bind(ETH_P_ALL)
+local function get_src_mac(ifindex)
+	local rx <close> = raw.bind(ETH_P_ALL, ifindex)
 	local frame = rx:receive(2048)
 	return frame:sub(7, 12)
 end
@@ -75,7 +75,7 @@ end
 
 local ifindex = linux.ifindex(config.interface)
 
-local src_mac = get_src_mac()
+local src_mac = get_src_mac(ifindex)
 local lldp_frame = build_lldp_frame(src_mac)
 
 local function worker()

--- a/lib/socket/raw.lua
+++ b/lib/socket/raw.lua
@@ -32,9 +32,9 @@ local raw = {}
 -- @see socket.bind
 function raw.bind(proto, ifindex)
 	local proto = proto or ETH_P_ALL
+	local ifindex = ifindex or 0
 	local s = socket.new(af.PACKET, sock.RAW, proto)
-	local param = ifindex and ifindex or string.pack(">I2", proto)
-	s:bind(param)
+	s:bind(proto, ifindex)
 	return s
 end
 

--- a/lunatik.h
+++ b/lunatik.h
@@ -340,6 +340,13 @@ static inline void lunatik_optcfunction(lua_State *L, int idx, const char *field
 #define lunatik_checkbounds(L, idx, val, min, max)	\
 	luaL_argcheck(L, val >= min && val <= max, idx, "out of bounds")
 
+static inline lua_Integer lunatik_checkinteger(lua_State *L, int idx, lua_Integer min, lua_Integer max)
+{
+	lua_Integer v = luaL_checkinteger(L, idx);
+	lunatik_checkbounds(L, idx, v, min, max);
+	return v;
+}
+
 static inline unsigned int lunatik_checkuint(lua_State *L, int idx)
 {
 	lua_Integer val = luaL_checkinteger(L, idx);


### PR DESCRIPTION
AF_PACKET sockets previously allowed ambiguous bind() arguments, leaving `sockaddr_ll.sll_protocol` uninitialized in some cases.
This change enforces an explicit (protocol, ifindex) pair when binding AF_PACKET sockets, ensuring `sll_protocol` is always initialized

Fixes #367 