### PR TITLE
Add ifindex to nf hook callback

### DIFF
--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -81,8 +81,15 @@ static int luanetfilter_hook_cb(lua_State *L, luanetfilter_t *luanf, struct sk_b
 	else
 		luadata_reset(data, skb, skb_headlen(skb), LUADATA_OPT_SKB);
 
-	if (lua_pcall(L, 1, 2, 0) != LUA_OK) {
+	struct net_device *dev = skb->dev;
+	if (dev)
+		lua_pushinteger(L, dev->ifindex);
+	else
+		lua_pushnil(L); /* dev may be NULL if hook is LOCAL_OUT */
+
+	if (lua_pcall(L, 2, 2, 0) != LUA_OK) {
 		pr_err("%s\n", lua_tostring(L, -1));
+		lua_pop(L, 1);
 		return -1;
 	}
 


### PR DESCRIPTION
Also add luasocket side MAC getter

- Add `ifindex` on stack for `netfilter` hook
- `ifindex` can be used as parameter for luasocket's `getmacaddress`

There are corner cases I don't handle yet, like in netfilter's `skb->dev` can be `NULL` if , for example nf hook is `LOCAL_OUT` 

Also, is `luasocket` the best placehold for `getmacaddr` ?
I've not added any documentation yet, as we'll discuss the best approach here. 

