### PR TITLE
Simplify lua integer bounds check API

### DIFF
--- a/lib/luacrypto_aead.c
+++ b/lib/luacrypto_aead.c
@@ -64,7 +64,7 @@ static int luacrypto_aead_setkey(lua_State *L)
 static int luacrypto_aead_setauthsize(lua_State *L)
 {
 	struct crypto_aead *tfm = luacrypto_aead_check(L, 1);
-	unsigned int tagsize = lunatik_checkuint(L, 2);
+	unsigned int tagsize = (unsigned int)lunatik_checkinteger(L, 2, 1, UINT_MAX);
 	lunatik_try(L, crypto_aead_setauthsize, tfm, tagsize);
 	return 0;
 }
@@ -116,8 +116,7 @@ static inline void luacrypto_aead_newrequest(lua_State *L, luacrypto_aead_reques
 
 	request->combined = luaL_checklstring(L, 3, &request->combined_len);
 
-	request->aad_len = (size_t)luaL_checkinteger(L, 4);
-	lunatik_checkbounds(L, 4, request->aad_len, 0, request->combined_len);
+	request->aad_len = (size_t)lunatik_checkinteger(L, 4, 0, request->combined_len);
 
 	request->crypt_len = request->combined_len - request->aad_len;
 	request->authsize = (size_t)crypto_aead_authsize(tfm);

--- a/lib/luacrypto_comp.c
+++ b/lib/luacrypto_comp.c
@@ -51,7 +51,7 @@ static int luacrypto_comp_##name(lua_State *L)								\
 	size_t datalen;											\
 	const u8 *data = (const u8 *)luaL_checklstring(L, 2, &datalen);					\
 	lunatik_checkbounds(L, 2, datalen, 1, UINT_MAX);						\
-	unsigned int max_len = lunatik_checkuint(L, 3);							\
+	unsigned int max_len = (unsigned int)lunatik_checkinteger(L, 3, 1, UINT_MAX);	\
 													\
 	luaL_Buffer b;											\
 	u8 *output_buf = luaL_buffinitsize(L, &b, max_len);						\

--- a/lib/luacrypto_rng.c
+++ b/lib/luacrypto_rng.c
@@ -51,7 +51,7 @@ LUACRYPTO_RELEASER(rng, struct crypto_rng, crypto_free_rng, NULL);
 static int luacrypto_rng_generate(lua_State *L)
 {
 	struct crypto_rng *tfm = luacrypto_rng_check(L, 1);
-	unsigned int num_bytes = lunatik_checkuint(L, 2);
+	unsigned int num_bytes = (unsigned int)lunatik_checkinteger(L, 2, 1, UINT_MAX);
 
 	size_t seed_len = 0;
 	const char *seed_data = lua_tolstring(L, 3, &seed_len);
@@ -75,7 +75,7 @@ static int luacrypto_rng_generate(lua_State *L)
 static int luacrypto_rng_getbytes(lua_State *L)
 {
 	struct crypto_rng *tfm = luacrypto_rng_check(L, 1);
-	unsigned int num_bytes = lunatik_checkuint(L, 2);
+	unsigned int num_bytes = (unsigned int)lunatik_checkinteger(L, 2, 1, UINT_MAX);
 
 	luaL_Buffer b;
 	u8 *buffer = (u8 *)luaL_buffinitsize(L, &b, num_bytes);

--- a/lunatik.h
+++ b/lunatik.h
@@ -360,13 +360,6 @@ static inline lua_Integer lunatik_checkinteger(lua_State *L, int idx, lua_Intege
 	return v;
 }
 
-static inline unsigned int lunatik_checkuint(lua_State *L, int idx)
-{
-	lua_Integer val = luaL_checkinteger(L, idx);
-	lunatik_checkbounds(L, idx, val, 1, UINT_MAX);
-	return (unsigned int)val;
-}
-
 static inline void lunatik_setregistry(lua_State *L, int ix, void *key)
 {
 	lua_pushvalue(L, ix);


### PR DESCRIPTION
This replaces ad-hoc `luaL_checkinteger()` + `lunatik_checkbounds()` patterns and removes `lunatik_checkuint` in favor
of a single, range-aware helper.

Fixes #389 