### PR TITLE
wrap class methods eagerly instead of via __index

### DIFF
--- a/lib/luacrypto_aead.c
+++ b/lib/luacrypto_aead.c
@@ -224,7 +224,6 @@ static const luaL_Reg luacrypto_aead_mt[] = {
 	{"decrypt", luacrypto_aead_decrypt},
 	{"__gc", lunatik_deleteobject},
 	{"__close", lunatik_closeobject},
-	{"__index", lunatik_monitorobject},
 	{NULL, NULL}
 };
 
@@ -237,6 +236,7 @@ static const lunatik_class_t luacrypto_aead_class = {
 	.methods = luacrypto_aead_mt,
 	.release = luacrypto_aead_release,
 	.sleep = true,
+	.shared = true,
 	.pointer = true,
 };
 

--- a/lib/luacrypto_comp.c
+++ b/lib/luacrypto_comp.c
@@ -92,7 +92,6 @@ static const luaL_Reg luacrypto_comp_mt[] = {
 	{"decompress", luacrypto_comp_decompress},
 	{"__gc", lunatik_deleteobject},
 	{"__close", lunatik_closeobject},
-	{"__index", lunatik_monitorobject},
 	{NULL, NULL}
 };
 
@@ -101,6 +100,7 @@ static const lunatik_class_t luacrypto_comp_class = {
 	.methods = luacrypto_comp_mt,
 	.release = luacrypto_comp_release,
 	.sleep = true,
+	.shared = true,
 	.pointer = true,
 };
 

--- a/lib/luacrypto_rng.c
+++ b/lib/luacrypto_rng.c
@@ -134,7 +134,6 @@ static const luaL_Reg luacrypto_rng_mt[] = {
 	{"info", luacrypto_rng_info},
 	{"__gc", lunatik_deleteobject},
 	{"__close", lunatik_closeobject},
-	{"__index", lunatik_monitorobject},
 	{NULL, NULL}
 };
 
@@ -147,6 +146,7 @@ static const lunatik_class_t luacrypto_rng_class = {
 	.methods = luacrypto_rng_mt,
 	.release = luacrypto_rng_release,
 	.sleep = true,
+	.shared = true,
 	.pointer = true,
 };
 

--- a/lib/luacrypto_shash.c
+++ b/lib/luacrypto_shash.c
@@ -209,7 +209,6 @@ static const luaL_Reg luacrypto_shash_mt[] = {
 	{"import", luacrypto_shash_import},
 	{"__gc", lunatik_deleteobject},
 	{"__close", lunatik_closeobject},
-	{"__index", lunatik_monitorobject},
 	{NULL, NULL}
 };
 
@@ -223,6 +222,7 @@ static const lunatik_class_t luacrypto_shash_class = {
 	.methods = luacrypto_shash_mt,
 	.release = luacrypto_shash_release,
 	.sleep = true,
+	.shared = true,
 	.pointer = true,
 };
 

--- a/lib/luacrypto_skcipher.c
+++ b/lib/luacrypto_skcipher.c
@@ -190,7 +190,6 @@ static const luaL_Reg luacrypto_skcipher_mt[] = {
 	{"decrypt", luacrypto_skcipher_decrypt},
 	{"__gc", lunatik_deleteobject},
 	{"__close", lunatik_closeobject},
-	{"__index", lunatik_monitorobject},
 	{NULL, NULL}
 };
 
@@ -205,6 +204,7 @@ static const lunatik_class_t luacrypto_skcipher_class = {
 	.methods = luacrypto_skcipher_mt,
 	.release = luacrypto_skcipher_release,
 	.sleep = true,
+	.shared = true,
 	.pointer = true,
 };
 

--- a/lib/luadata.c
+++ b/lib/luadata.c
@@ -234,7 +234,6 @@ static const luaL_Reg luadata_lib[] = {
 };
 
 static const luaL_Reg luadata_mt[] = {
-	{"__index", lunatik_monitorobject},
 	{"__gc", lunatik_deleteobject},
 	{"__len", luadata_length},
 	{"__tostring", luadata_tostring},
@@ -409,6 +408,7 @@ static const lunatik_class_t luadata_class = {
 	.methods = luadata_mt,
 	.release = luadata_release,
 	.sleep = false,
+	.shared = true,
 };
 
 static inline void luadata_set(luadata_t *data, void *ptr, ptrdiff_t offset, size_t size, uint8_t opt)

--- a/lib/luafifo.c
+++ b/lib/luafifo.c
@@ -116,7 +116,6 @@ static const luaL_Reg luafifo_lib[] = {
 * @treturn nil
 */
 static const luaL_Reg luafifo_mt[] = {
-	{"__index", lunatik_monitorobject},
 	{"__gc", lunatik_deleteobject},
 	{"__close", lunatik_closeobject},
 	{"close", lunatik_closeobject},
@@ -130,6 +129,7 @@ static const lunatik_class_t luafifo_class = {
 	.methods = luafifo_mt,
 	.release = luafifo_release,
 	.sleep = false,
+	.shared = true,
 };
 
 static int luafifo_new(lua_State *L)

--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -71,7 +71,6 @@ static const luaL_Reg luahid_lib[] = {
 };
 
 static const luaL_Reg luahid_mt[] = {
-	{"__index", lunatik_monitorobject},
 	{"__gc", lunatik_deleteobject},
 	{NULL, NULL},
 };
@@ -81,6 +80,7 @@ static const lunatik_class_t luahid_class = {
 	.methods = luahid_mt,
 	.release = luahid_release,
 	.sleep = false,
+	.shared = true,
 };
 
 static const struct hid_device_id *luahid_setidtable(lua_State *L, int idx)

--- a/lib/luasocket.c
+++ b/lib/luasocket.c
@@ -385,7 +385,6 @@ static const luaL_Reg luasocket_lib[] = {
 };
 
 static const luaL_Reg luasocket_mt[] = {
-	{"__index", lunatik_monitorobject},
 	{"__gc", lunatik_deleteobject},
 	{"__close", lunatik_closeobject},
 	{"close", lunatik_closeobject},
@@ -697,6 +696,7 @@ static const lunatik_class_t luasocket_class = {
 	.methods = luasocket_mt,
 	.release = luasocket_release,
 	.sleep = true,
+	.shared = true,
 	.pointer = true,
 };
 

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -183,7 +183,6 @@ static const luaL_Reg luathread_lib[] = {
 };
 
 static const luaL_Reg luathread_mt[] = {
-	{"__index", lunatik_monitorobject},
 	{"__gc", lunatik_deleteobject},
 	{"stop", luathread_stop},
 	{"task", luathread_task},
@@ -194,6 +193,7 @@ static const lunatik_class_t luathread_class = {
 	.name = "thread",
 	.methods = luathread_mt,
 	.sleep = true,
+	.shared = true,
 };
 
 #define luathread_new(L)	(lunatik_newobject((L), &luathread_class, sizeof(luathread_t)))

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -205,7 +205,6 @@ static const luaL_Reg lunatik_stub_lib[] = {
 *   rt:stop()
 */
 static const luaL_Reg lunatik_mt[] = {
-	{"__index", lunatik_monitorobject},
 	{"__gc", lunatik_deleteobject},
 	{"__close", lunatik_closeobject},
 	{"stop", lunatik_closeobject},
@@ -218,6 +217,7 @@ static const lunatik_class_t lunatik_class = {
 	.methods = lunatik_mt,
 	.release = lunatik_releaseruntime,
 	.sleep = true,
+	.shared = true,
 	.pointer = true,
 };
 


### PR DESCRIPTION
This patch eliminates the need for the `__index` metamethod to handle method dispatching for shared modules. By eagerly pre-wrapping methods in the `lunatik_monitor` closure at class initialization, we avoid repeated closure allocations and metatable churn in performance-critical paths.

Tested performance with the following script
```lua
local linux = require("linux")
local data = require("data")

local d = data.new(1024)
local iterations = 1000000

local start_ns = linux.time()
for i = 1, iterations do
    d:getbyte(0)
end
local end_ns = linux.time()
local total_ns = end_ns - start_ns

local ns_per_call = total_ns / iterations

print("Total ns: " .. total_ns)
print("Ns per call: " .. ns_per_call)


local m_getbyte = d.getbyte 

start_ns = linux.time()
for i = 1, iterations do
    m_getbyte(d, 0)
end
end_ns = linux.time()
total_ns = end_ns - start_ns

ns_per_call = total_ns / iterations

print("Localized method total ns: " .. total_ns)
print("Localized method Ns per call: " .. ns_per_call)
```

master:
```shell
Total ns: 275151687
Ns per call: 275
Localized method total ns: 137531899
Localized method Ns per call: 137
```

this branch:
```shell
Total ns: 128897733
Ns per call: 128
Localized method total ns: 130847719
Localized method Ns per call: 130
```