### PR TITLE
add unregister methods to luanetfilter, luaxdp, luahid

### DIFF
--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -233,6 +233,7 @@ static const luaL_Reg luaxdp_lib[] = {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0))
 	{"attach", luaxdp_attach},
 	{"detach", luaxdp_detach},
+	{"unregister", luaxdp_detach},
 #endif
 	{NULL, NULL}
 };


### PR DESCRIPTION
Adds explicit unregister() methods following the pattern from luadevice_stop() and luanotifier_stop().

- luanetfilter: adds unregister() and refactors cleanup into helper
- luaxdp: adds unregister as alias for detach()
- luahid: adds unregister() and refactors cleanup into helper

All use lunatik_unregisterobject() for explicit cleanup.

Fixes #403