### PR TITLE
Retrieve vlan tag id from skb, if present

### DIFF
--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -90,7 +90,13 @@ static int luanetfilter_hook_cb(lua_State *L, luanetfilter_t *luanf, struct sk_b
 	else
 		lua_pushnil(L); /* dev may be NULL if hook is LOCAL_OUT */
 
-	if (lua_pcall(L, 2, 2, 0) != LUA_OK) {
+	int narg = 2;
+	if (skb_vlan_tag_present(skb)) {
+		lua_pushinteger(L, skb_vlan_tag_get_id(skb));
+		narg++;
+	}
+
+	if (lua_pcall(L, narg, 2, 0) != LUA_OK) {
 		pr_err("%s\n", lua_tostring(L, -1));
 		lua_pop(L, 1);
 		goto clear;


### PR DESCRIPTION
Added a way of retrieving the vlan ID from `skb` 
Tried to make it support non-linear skb and it is idiomatic for kernel 6.x ATM

However I wasn't able to fully test in a vlan network (working on that) but I think it is safe to PR this and get some reviews in the meantime.