### PR TITLE
fix LUA_PATH detection during install in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SCRIPTS_INSTALL_PATH := ${MODULES_PATH}/lua
 INCLUDE_PATH := ${MODULES_BUILD_PATH}/include
 
 LUA ?= lua5.4
-LUA_PATH ?= $(shell $(LUA_BIN) -e 'print(package.path:match("([^;]*)/%?%.lua;"))')
+LUA_PATH ?= $(shell $(LUA) -e 'print(package.path:match("([^;]*)/%?%.lua;"))')
 
 LUNATIK_INSTALL_PATH = /usr/local/sbin
 LUNATIK_EBPF_INSTALL_PATH = /usr/local/lib/bpf/lunatik


### PR DESCRIPTION
The Makefile derives LUA_PATH using $(LUA_BIN), which is not defined, causing LUA_PATH to be empty in some environments. This can result in the lunatik/config.lua symlink being created in an incorrect location.

Use $(LUA) instead to correctly derive LUA_PATH from the configured Lua binary.