### PR TITLE
fix lldpd code block section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,12 +469,12 @@ sudo make examples_install                  # installs examples
 ip link add veth0 type veth peer name veth1
 ip link set veth0 up
 ip link set veth1 up
-```
 
 sudo lunatik spawn examples/lldpd           # runs lldpd
 
 # verify LLDP frames are being transmitted
 sudo tcpdump -i veth0 -e ether proto 0x88cc -vv
+```
 
 ### cpuexporter
 


### PR DESCRIPTION
Right now in the code block for lldpd, code is not highlighted correctly.
This patch will put the respective commands inside the code block.

<img width="725" height="430" alt="lldpd-readme" src="https://github.com/user-attachments/assets/d80917b6-676f-4ce4-908b-fb8dbff941a6" />
