### PR TITLE
add support for non-shared objects in shared class

### DIFF
--- a/doc/capi.md
+++ b/doc/capi.md
@@ -113,6 +113,32 @@ static ssize_t mydevice_read(struct file *f, char *buf, size_t len, loff_t *off)
 }
 ```
 
+## lunatik\_newobject
+```C
+lunatik_object_t *lunatik_newobject(lua_State *L, const lunatik_class_t *class, size_t size, bool shared);
+```
+_lunatik\_newobject()_ allocates a new Lunatik object and pushes a userdata
+containing a pointer to the object onto the Lua stack.
+If `shared` is _true_, the object will use the monitored metatable for safe
+access Lunatik runtimes. This requires `class->shared = true;` otherwise, it raises a
+Lua error.
+- If `class->sleep` is _true_, it uses a mutex and `GFP_KERNEL`
+- If `class->sleep` is _false_, it uses a spinlock and `GFP_ATOMIC`
+
+It allocates size bytes for the object's private data, unless `class->pointer` is true.
+
+## lunatik\_createobject
+```C
+lunatik_object_t *lunatik_createobject(const lunatik_class_t *class, size_t size, bool sleep, bool shared);
+```
+_lunatik\_createobject()_ creates a Lunatik object independently of any Lua
+state. This is intended for objects created in C context that may be shared
+with Lua runtimes later.
+
+It allocates memory with `GFP_KERNEL` if `sleep` is _true_, or `GFP_ATOMIC` otherwise.
+It returns a pointer to the `lunatik_object_t` on success, or _NULL_ if memory
+allocation fails and _ERR_PTR(-EINVAL)_ if the class is not sharable but API is called with _true_ as `shared`
+
 ## lunatik\_getobject
 ```C
 void lunatik_getobject(lunatik_object_t *object);

--- a/lib/luacompletion.c
+++ b/lib/luacompletion.c
@@ -78,7 +78,7 @@ static int luacompletion_wait(lua_State *L)
 	ret = wait_for_completion_interruptible_timeout(completion, timeout_jiffies);
 	if (ret > 0) {
 		lua_pushboolean(L, true);
-		return 1;		
+		return 1;
 	}
 
 	lua_pushnil(L);
@@ -128,7 +128,7 @@ static const lunatik_class_t luacompletion_class = {
 */
 static int luacompletion_new(lua_State *L)
 {
-	lunatik_object_t *object = lunatik_newobject(L, &luacompletion_class, sizeof(struct completion));
+	lunatik_object_t *object = lunatik_newobject(L, &luacompletion_class, sizeof(struct completion), false);
 	struct completion *completion = (struct completion *)object->private;
 
 	init_completion(completion);

--- a/lib/luacrypto.h
+++ b/lib/luacrypto.h
@@ -30,7 +30,7 @@ typedef void (*luacrypto_free_t)(void *);
 static int luacrypto_##name##_new(lua_State *L)								\
 {													\
 	const char *algname = luaL_checkstring(L, 1);							\
-	lunatik_object_t *object = lunatik_newobject(L, &class, 0);					\
+	lunatik_object_t *object = lunatik_newobject(L, &class, 0, true);					\
 													\
 	T *tfm = alloc(algname, 0, 0);									\
 	if (IS_ERR(tfm)) {										\

--- a/lib/luadata.c
+++ b/lib/luadata.c
@@ -127,7 +127,7 @@ static int luadata_setstring(lua_State *L)
 	lua_Integer offset = luaL_checkinteger(L, 2);
 	const char *str = luaL_checklstring(L, 3, &length);
 	void *ptr = luadata_checkbounds(L, 2, data, offset, length);
-	
+
 	luadata_checkwritable(L, data);
 	memcpy(ptr, str, length);
 	return 0;
@@ -176,7 +176,7 @@ static int luadata_checksum(lua_State *L)
 
 /***
 * Resizes the memory block represented by the data object.
-* If the object is a network packet (SKB), it uses skb_put() to expand 
+* If the object is a network packet (SKB), it uses skb_put() to expand
 * or skb_trim() to shrink the buffer. For raw buffers, it updates the size.
 * @function resize
 * @tparam integer new_size The desired size of the memory block in bytes.
@@ -190,7 +190,7 @@ static int luadata_resize(lua_State *L)
 	luadata_checkwritable(L, data);
 
 	if (data->opt & LUADATA_OPT_SKB)
-		luadata_skb_resize(L, data, new_size); 
+		luadata_skb_resize(L, data, new_size);
 	else if (data->opt & LUADATA_OPT_FREE)
 		data->ptr = lunatik_checknull(L, lunatik_realloc(L, data->ptr, new_size));
 	else
@@ -436,7 +436,7 @@ static inline void luadata_set(luadata_t *data, void *ptr, ptrdiff_t offset, siz
 static int luadata_lnew(lua_State *L)
 {
 	size_t size = (size_t)luaL_checkinteger(L, 1);
-	lunatik_object_t *object = lunatik_newobject(L, &luadata_class, sizeof(luadata_t));
+	lunatik_object_t *object = lunatik_newobject(L, &luadata_class, sizeof(luadata_t), true);
 	luadata_t *data = (luadata_t *)object->private;
 
 	luadata_set(data, lunatik_checkalloc(L, size), 0, size, LUADATA_OPT_FREE);
@@ -445,20 +445,22 @@ static int luadata_lnew(lua_State *L)
 
 LUNATIK_NEWLIB(data, luadata_lib, &luadata_class, NULL);
 
-static inline lunatik_object_t *luadata_create(void *ptr, size_t size, bool sleep, uint8_t opt)
+static inline lunatik_object_t *luadata_create(void *ptr, size_t size, bool sleep, uint8_t opt, bool shared)
 {
-	lunatik_object_t *object = lunatik_createobject(&luadata_class, sizeof(luadata_t), sleep);
+	lunatik_object_t *object = lunatik_createobject(&luadata_class, sizeof(luadata_t), sleep, shared);
 
-	if (object != NULL) {
+	if (!IS_ERR_OR_NULL(object)) {
 		luadata_t *data = (luadata_t *)object->private;
 		luadata_set(data, ptr, 0, size, opt);
 	}
 	return object;
 }
 
-lunatik_object_t *luadata_new(lua_State *L)
+lunatik_object_t *luadata_new(lua_State *L, bool shared)
 {
-	lunatik_object_t *data = lunatik_checknull(L, luadata_create(NULL, 0, false, LUADATA_OPT_NONE));
+	lunatik_object_t *data = lunatik_checknull(L, luadata_create(NULL, 0, false, LUADATA_OPT_NONE, shared));
+	if (IS_ERR(data))
+		luaL_error(L, LUNATIK_ERR_SHARED, luadata_class.name);
 	lunatik_cloneobject(L, data);
 	return data;
 }

--- a/lib/luadata.h
+++ b/lib/luadata.h
@@ -16,7 +16,7 @@
 
 #define luadata_clear(o)	(luadata_reset((o), NULL, 0, 0, LUADATA_OPT_KEEP))
 
-lunatik_object_t *luadata_new(lua_State *L);
+lunatik_object_t *luadata_new(lua_State *L, bool shared);
 int luadata_reset(lunatik_object_t *object, void *ptr, ptrdiff_t offset, size_t size, uint8_t opt);
 
 static inline void luadata_close(lunatik_object_t *object)
@@ -27,7 +27,7 @@ static inline void luadata_close(lunatik_object_t *object)
 
 #define luadata_attach(L, obj, field)		\
 do {						\
-	obj->field = luadata_new(L); 		\
+	obj->field = luadata_new(L, false); 		\
 	lunatik_register(L, -1, obj->field);	\
 	lua_pop(L, 1);				\
 } while (0)

--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -355,7 +355,7 @@ static int luadevice_new(lua_State *L)
 	lunatik_checkfield(L, 1, "name", LUA_TSTRING);
 	name = lua_tostring(L, -1);
 
-	object = lunatik_newobject(L, &luadevice_class, sizeof(luadevice_t));
+	object = lunatik_newobject(L, &luadevice_class, sizeof(luadevice_t), false);
 	luadev = (luadevice_t *)object->private;
 
 	memset(luadev, 0, sizeof(luadevice_t));

--- a/lib/luafifo.c
+++ b/lib/luafifo.c
@@ -129,7 +129,7 @@ static const lunatik_class_t luafifo_class = {
 static int luafifo_new(lua_State *L)
 {
 	size_t size = luaL_checkinteger(L, 1);
-	lunatik_object_t *object = lunatik_newobject(L, &luafifo_class, sizeof(struct kfifo));
+	lunatik_object_t *object = lunatik_newobject(L, &luafifo_class, sizeof(struct kfifo), true);
 	gfp_t gfp = lunatik_gfp(lunatik_toruntime(L));
 	int ret;
 

--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -305,7 +305,7 @@ static int luahid_register(lua_State *L)
 {
 	luaL_checktype(L, 1, LUA_TTABLE);
 
-	lunatik_object_t *object = lunatik_newobject(L, &luahid_class, sizeof(luahid_t));
+	lunatik_object_t *object = lunatik_newobject(L, &luahid_class, sizeof(luahid_t), true);
 	luahid_t *hid = (luahid_t *)object->private;
 	memset(hid, 0, sizeof(luahid_t));
 

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -163,7 +163,7 @@ static const lunatik_class_t luanetfilter_class = {
 static int luanetfilter_register(lua_State *L)
 {
 	luaL_checktype(L, 1, LUA_TTABLE);
-	lunatik_object_t *object = lunatik_newobject(L, &luanetfilter_class , sizeof(luanetfilter_t));
+	lunatik_object_t *object = lunatik_newobject(L, &luanetfilter_class , sizeof(luanetfilter_t), false);
 	luanetfilter_t *nf = (luanetfilter_t *)object->private;
 	nf->runtime = NULL;
 

--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -408,7 +408,7 @@ static int luanotifier_new(lua_State *L, luanotifier_register_t register_fn, lua
 
 	luaL_checktype(L, 1, LUA_TFUNCTION); /* callback */
 
-	object = lunatik_newobject(L, &luanotifier_class, sizeof(luanotifier_t));
+	object = lunatik_newobject(L, &luanotifier_class, sizeof(luanotifier_t), false);
 	notifier = (luanotifier_t *)object->private;
 
 	lunatik_setruntime(L, notifier, notifier);

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -236,7 +236,7 @@ static const lunatik_class_t luaprobe_class = {
 
 static int luaprobe_new(lua_State *L)
 {
-	lunatik_object_t *object = lunatik_newobject(L, &luaprobe_class, sizeof(luaprobe_t));
+	lunatik_object_t *object = lunatik_newobject(L, &luaprobe_class, sizeof(luaprobe_t), false);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
 	struct kprobe *kp = &probe->kp;
 	int ret;

--- a/lib/luarcu.c
+++ b/lib/luarcu.c
@@ -372,6 +372,7 @@ static const lunatik_class_t luarcu_class = {
 	.name = "rcu",
 	.methods = luarcu_mt,
 	.release = luarcu_release,
+	.shared = true,
 };
 
 lunatik_object_t *luarcu_newtable(size_t size, bool sleep)
@@ -379,7 +380,7 @@ lunatik_object_t *luarcu_newtable(size_t size, bool sleep)
 	lunatik_object_t *object;
 
 	size = roundup_pow_of_two(size);
-	if ((object = lunatik_createobject(&luarcu_class, luarcu_sizeoftable(size), sleep))!= NULL)
+	if ((object = lunatik_createobject(&luarcu_class, luarcu_sizeoftable(size), sleep, false)) != NULL)
 		luarcu_inittable((luarcu_table_t *)object->private, size);
 	return object;
 }
@@ -419,7 +420,7 @@ EXPORT_SYMBOL(luarcu_newtable);
 static int luarcu_table(lua_State *L)
 {
 	size_t size = roundup_pow_of_two(luaL_optinteger(L, 1, LUARCU_DEFAULT_SIZE));
-	lunatik_object_t *object = lunatik_newobject(L, &luarcu_class, luarcu_sizeoftable(size));
+	lunatik_object_t *object = lunatik_newobject(L, &luarcu_class, luarcu_sizeoftable(size), false);
 
 	luarcu_inittable((luarcu_table_t *)object->private, size);
 	return 1; /* object */

--- a/lib/luasocket.c
+++ b/lib/luasocket.c
@@ -695,7 +695,7 @@ static const lunatik_class_t luasocket_class = {
 	.pointer = true,
 };
 
-#define luasocket_newsocket(L)		(lunatik_newobject((L), &luasocket_class, 0))
+#define luasocket_newsocket(L)		(lunatik_newobject((L), &luasocket_class, 0, true))
 #define luasocket_psocket(object)	((struct socket **)&object->private)
 
 /***

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -190,7 +190,7 @@ static const lunatik_class_t luathread_class = {
 	.shared = true,
 };
 
-#define luathread_new(L)	(lunatik_newobject((L), &luathread_class, sizeof(luathread_t)))
+#define luathread_new(L)	(lunatik_newobject((L), &luathread_class, sizeof(luathread_t), true))
 
 /***
 * Creates and starts a new kernel thread to run a Lua task.

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -214,8 +214,8 @@ static int luaxdp_attach(lua_State *L)
 	lunatik_checkruntime(L, false);
 	luaL_checktype(L, 1, LUA_TFUNCTION); /* callback */
 
-	luadata_new(L); /* buffer */
-	luadata_new(L); /* argument */
+	luadata_new(L, false); /* buffer */
+	luadata_new(L, false); /* argument */
 
 	lua_pushcclosure(L, luaxdp_callback, 3);
 	lunatik_register(L, -1, luaxdp_callback);

--- a/lib/luaxtable.c
+++ b/lib/luaxtable.c
@@ -315,7 +315,7 @@ static const lunatik_class_t luaxtable_class = {
 static inline lunatik_object_t *luaxtable_new(lua_State *L, int idx, int hook)
 {
 	luaL_checktype(L, idx, LUA_TTABLE);
-	lunatik_object_t *object = lunatik_newobject(L, &luaxtable_class , sizeof(luaxtable_t));
+	lunatik_object_t *object = lunatik_newobject(L, &luaxtable_class , sizeof(luaxtable_t), false);
 	luaxtable_t *xtable = (luaxtable_t *)object->private;
 
 	xtable->type = hook;

--- a/lunatik.h
+++ b/lunatik.h
@@ -91,13 +91,14 @@ typedef struct lunatik_object_s {
 	};
 	bool sleep;
 	gfp_t gfp;
+	bool shared;
 } lunatik_object_t;
 
 extern lunatik_object_t *lunatik_env;
 
 static inline int lunatik_trylock(lunatik_object_t *object)
 {
-	return object->sleep ? mutex_trylock(&object->mutex) : spin_trylock(&object->spin);
+	return unlikely(object->shared) ? (object->sleep ? mutex_trylock(&object->mutex) : spin_trylock(&object->spin)) : 1;
 }
 
 int lunatik_runtime(lunatik_object_t **pruntime, const char *script, bool sleep);
@@ -181,27 +182,29 @@ static inline void lunatik_checkclass(lua_State *L, const lunatik_class_t *class
 		luaL_error(L, "cannot use '%s' class on non-sleepable runtime", class->name);
 }
 
-static inline void lunatik_setclass(lua_State *L, const lunatik_class_t *class)
+static inline void lunatik_setclass(lua_State *L, const lunatik_class_t *class, bool shared)
 {
-	if (luaL_getmetatable(L, class->name) == LUA_TNIL)
-		luaL_error(L, "metatable not found (%s)", class->name);
+	lua_pushfstring(L, shared ? "_%s" : "%s", class->name);
+	if (lua_rawget(L, LUA_REGISTRYINDEX) == LUA_TNIL)
+		luaL_error(L, "metatable not found (%s)", lua_tostring(L, -1));
 	lua_setmetatable(L, -2);
 	lua_pushlightuserdata(L, (void *)class);
 	lua_setiuservalue(L, -2, 1); /* pop class */
 }
 
-static inline void lunatik_setobject(lunatik_object_t *object, const lunatik_class_t *class, bool sleep)
+static inline void lunatik_setobject(lunatik_object_t *object, const lunatik_class_t *class, bool sleep, bool shared)
 {
 	kref_init(&object->kref);
 	object->private = NULL;
 	object->class = class;
 	object->sleep = sleep;
+	object->shared = shared;
 	object->gfp = sleep ? GFP_KERNEL : GFP_ATOMIC;
 	lunatik_newlock(object);
 }
 
-lunatik_object_t *lunatik_newobject(lua_State *L, const lunatik_class_t *class, size_t size);
-lunatik_object_t *lunatik_createobject(const lunatik_class_t *class, size_t size, bool sleep);
+lunatik_object_t *lunatik_newobject(lua_State *L, const lunatik_class_t *class, size_t size, bool shared);
+lunatik_object_t *lunatik_createobject(const lunatik_class_t *class, size_t size, bool sleep, bool shared);
 lunatik_object_t **lunatik_checkpobject(lua_State *L, int ix);
 void lunatik_cloneobject(lua_State *L, lunatik_object_t *object);
 void lunatik_releaseobject(struct kref *kref);
@@ -210,6 +213,7 @@ int lunatik_deleteobject(lua_State *L);
 void lunatik_monitorobject(lua_State *L, const lunatik_class_t *class);
 
 #define LUNATIK_ERR_NULLPTR	"null-pointer dereference"
+#define LUNATIK_ERR_SHARED 	"cannot create shared object from non-shared class '%s'"
 
 #define lunatik_newpobject(L, n)	(lunatik_object_t **)lua_newuserdatauv((L), sizeof(lunatik_object_t *), (n))
 #define lunatik_argchecknull(L, o, i)	luaL_argcheck((L), (o) != NULL, (i), LUNATIK_ERR_NULLPTR)
@@ -238,17 +242,18 @@ static inline bool lunatik_hasindex(lua_State *L, int index)
 	return hasindex;
 }
 
-static inline void lunatik_newclass(lua_State *L, const lunatik_class_t *class)
+static inline void lunatik_newclass(lua_State *L, const lunatik_class_t *class, bool monitored)
 {
-	luaL_newmetatable(L, class->name); /* mt = {} */
+	lua_pushfstring(L, monitored ? "_%s" : "%s", class->name);
+	luaL_newmetatable(L, lua_tostring(L, -1)); /* mt = {} */
 	luaL_setfuncs(L, class->methods, 0);
+	if (monitored)
+		lunatik_monitorobject(L, class);
 	if (!lunatik_hasindex(L, -1)) {
-		if (class->shared)
-			lunatik_monitorobject(L, class);
 		lua_pushvalue(L, -1);  /* push mt */
 		lua_setfield(L, -2, "__index");  /* mt.__index = mt */
 	}
-	lua_pop(L, 1);  /* pop mt */
+	lua_pop(L, 2);  /* pop mt, class name */
 }
 
 static inline lunatik_class_t *lunatik_getclass(lua_State *L, int ix)
@@ -260,8 +265,6 @@ static inline lunatik_class_t *lunatik_getclass(lua_State *L, int ix)
 	}
 	return NULL;
 }
-
-#define lunatik_isobject(L, ix)	(lunatik_getclass((L), (ix)) != NULL)
 
 static inline lunatik_object_t *lunatik_testobject(lua_State *L, int ix)
 {
@@ -292,7 +295,9 @@ int luaopen_##libname(lua_State *L)						\
 	luaL_newlib(L, funcs);							\
 	if (cls) {								\
 		lunatik_checkclass(L, cls);					\
-		lunatik_newclass(L, cls);					\
+		if (cls->shared)							\
+			lunatik_newclass(L, cls, true);			\
+		lunatik_newclass(L, cls, false);			\
 	}									\
 	if (nss)								\
 		lunatik_newnamespaces(L, nss);					\

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -275,7 +275,7 @@ static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, con
 		return -ENOMEM;
 	}
 
-	lunatik_setobject(runtime, &lunatik_class, sleep);
+	lunatik_setobject(runtime, &lunatik_class, sleep, true);
 	lunatik_toruntime(L) = runtime;
 	runtime->private = L;
 
@@ -335,7 +335,7 @@ static int lunatik_lruntime(lua_State *L)
 	lunatik_object_t **pruntime = lunatik_newpobject(L, 1);
 	if (lunatik_newruntime(pruntime, L, script, sleep) != 0)
 		lua_error(L);
-	lunatik_setclass(L, &lunatik_class);
+	lunatik_setclass(L, &lunatik_class, true);
 	return 1;
 }
 

--- a/lunatik_obj.c
+++ b/lunatik_obj.c
@@ -16,14 +16,18 @@
 	(reg)->func == lunatik_deleteobject || \
 	(reg)->func == lunatik_closeobject)
 
-lunatik_object_t *lunatik_newobject(lua_State *L, const lunatik_class_t *class, size_t size)
+#define lunatik_issharable(class, shared) 	(!(shared) || ((class)->shared))
+
+lunatik_object_t *lunatik_newobject(lua_State *L, const lunatik_class_t *class, size_t size, bool shared)
 {
 	lunatik_object_t **pobject = lunatik_newpobject(L, 1);
 	lunatik_object_t *object = lunatik_checkalloc(L, sizeof(lunatik_object_t));
 
 	lunatik_checkclass(L, class);
-	lunatik_setobject(object, class, class->sleep);
-	lunatik_setclass(L, class);
+	if (!lunatik_issharable(class, shared))
+		luaL_error(L, LUNATIK_ERR_SHARED, class->name);
+	lunatik_setobject(object, class, class->sleep, shared);
+	lunatik_setclass(L, class, shared);
 
 	object->private = class->pointer ? NULL : lunatik_checkalloc(L, size);
 
@@ -32,15 +36,19 @@ lunatik_object_t *lunatik_newobject(lua_State *L, const lunatik_class_t *class, 
 }
 EXPORT_SYMBOL(lunatik_newobject);
 
-lunatik_object_t *lunatik_createobject(const lunatik_class_t *class, size_t size, bool sleep)
+lunatik_object_t *lunatik_createobject(const lunatik_class_t *class, size_t size, bool sleep, bool shared)
 {
 	gfp_t gfp = sleep ? GFP_KERNEL : GFP_ATOMIC;
 	lunatik_object_t *object = (lunatik_object_t *)kmalloc(sizeof(lunatik_object_t), gfp);
 
+	if (!lunatik_issharable(class, shared)) {
+		pr_err(LUNATIK_ERR_SHARED, class->name);
+		return ERR_PTR(-EINVAL);
+	}
 	if (object == NULL)
 		return NULL;
 
-	lunatik_setobject(object, class, sleep);
+	lunatik_setobject(object, class, sleep, shared);
 	if ((object->private = kmalloc(size, gfp)) == NULL) {
 		lunatik_putobject(object);
 		return NULL;
@@ -49,26 +57,32 @@ lunatik_object_t *lunatik_createobject(const lunatik_class_t *class, size_t size
 }
 EXPORT_SYMBOL(lunatik_createobject);
 
+static inline bool lunatik_isobject(lua_State *L, int ix, lunatik_object_t *object)
+{
+	lunatik_class_t *class= lunatik_getclass(L, ix);
+	return object && object->class == class;
+}
+
 lunatik_object_t **lunatik_checkpobject(lua_State *L, int ix)
 {
-	lunatik_object_t **pobject;
-	lunatik_class_t *class= lunatik_getclass(L, ix);
-
-	luaL_argcheck(L, class != NULL, ix, "object expected");
-	pobject = (lunatik_object_t **)luaL_checkudata(L, ix, class->name);
-	lunatik_argchecknull(L, *pobject, ix);
+	lunatik_object_t **pobject = (lunatik_object_t **)lua_touserdata(L, ix);
+	luaL_argcheck(L, pobject && lunatik_isobject(L, ix, *pobject), ix, "invalid object");
 	return pobject;
 }
 EXPORT_SYMBOL(lunatik_checkpobject);
 
 void lunatik_cloneobject(lua_State *L, lunatik_object_t *object)
 {
-	lunatik_require(L, object->class->name);
-	lunatik_object_t **pobject = lunatik_newpobject(L, 1);
 	const lunatik_class_t *class = object->class;
 
+	if (!class->shared)
+		luaL_error(L, "cannot clone non-shared class ('%s')", class->name);
+
+	lunatik_require(L, class->name);
+	lunatik_object_t **pobject = lunatik_newpobject(L, 1);
+
 	lunatik_checkclass(L, class);
-	lunatik_setclass(L, class);
+	lunatik_setclass(L, class, object->shared);
 	*pobject = object;
 }
 EXPORT_SYMBOL(lunatik_cloneobject);


### PR DESCRIPTION
Introduces a shared flag to `lunatik_object_t` to allow creating non shared objects inside shared classes. This bypasses monitoring for objects guaranteed to be local to a single Lua state.

Results on 1M iterations of `getdata` (script used in #410)

Baseline: **master** branch

| configuration | Average time per call |
| --- | --- |
| No changes (baseline) | 125 ns |
| lunatik_monitorobject call commented out | 32 ns | 

This PR

| lunatik_newobject call mode | Average time per call |
| --- | --- |
| shared = true | 98 ns |
| shared = false | 28 ns |

Fixes #431 