### PR TITLE
Moving to task

### DIFF
--- a/configure.lua
+++ b/configure.lua
@@ -167,9 +167,14 @@ end
 local function write_constants(file, module, spec, constants, macro_names)
 	for _, macro in ipairs(macro_names) do
 		local field_name = macro:gsub("^" .. spec.prefix, "")
-		local resolved_value = resolve_value(constants[macro], constants, spec.prefix, spec.module_name)
-		if resolved_value then
-			file:write(string.format('%s["%s"]\t= %s\n', spec.module_name, field_name, resolved_value))
+		local num = resolve_numeric(constants[macro], constants)
+		if num then
+			file:write(string.format('%s["%s"]\t= 0x%08x\n', spec.module_name, field_name, num))
+		else
+			local resolved_value = resolve_value(constants[macro], constants, spec.prefix, spec.module_name)
+			if resolved_value then
+				file:write(string.format('%s["%s"]\t= %s\n', spec.module_name, field_name, resolved_value))
+			end
 		end
 	end
 end
@@ -263,3 +268,4 @@ for _, spec in ipairs(specs) do
 end
 
 write_module("lunatik", "config", write_config)
+

--- a/lib/lualinux.c
+++ b/lib/lualinux.c
@@ -88,7 +88,9 @@ static int lualinux_random(lua_State *L)
 * @see linux.task
 * @usage
 *   linux.schedule(1000) -- Sleep for 1 second (interruptible)
-*   linux.schedule(500, linux.task.UNINTERRUPTIBLE) -- Sleep for 0.5 seconds (uninterruptible)
+*
+*   local task = require("linux.task")
+*   linux.schedule(500, task.UNINTERRUPTIBLE) -- Sleep for 0.5 seconds (uninterruptible)
 */
 static int lualinux_schedule(lua_State *L)
 {


### PR DESCRIPTION
## Move `lualinux_task` and `lualinux_stat` to [configure.lua](cci:7://file:///home/suryansh/dev/GSOC/lunatik/configure.lua:0:0-0:0)

Closes #435

### Summary

Auto-generates `linux.task` and `linux.stat` constants at build time via [configure.lua](cci:7://file:///home/suryansh/dev/GSOC/lunatik/configure.lua:0:0-0:0), removing the hardcoded C arrays from [lualinux.c](cci:7://file:///home/suryansh/dev/GSOC/lunatik/lib/lualinux.c:0:0-0:0).

### Changes

#### [configure.lua](cci:7://file:///home/suryansh/dev/GSOC/lunatik/configure.lua:0:0-0:0)
- Added **grep-based extraction** for kernel-internal headers (`internal = true` flag on specs). The C preprocessor can't be used on [linux/sched.h](cci:7://file:///lib/modules/6.12.73-1-lts/build/include/linux/sched.h/lib/modules/6.12.73-1-lts/build/include/linux/sched.h:0:0-0:0) or [linux/stat.h](cci:7://file:///lib/modules/6.12.73-1-lts/build/include/linux/stat.h/lib/modules/6.12.73-1-lts/build/include/linux/stat.h:0:0-0:0) because they pull in massive kernel dependency chains that cause hangs. Instead, `#define` lines are extracted directly via file reading and parsed in Lua.
- Added `parse_c_number()` to correctly handle C octal literals (e.g. `00700` for `S_IRWXU`).
- Added `resolve_numeric()` with OR-expression support to resolve composites like `TASK_KILLABLE = (TASK_WAKEKILL | TASK_UNINTERRUPTIBLE)`.
- Added `supplement_constants()` to merge composites from [linux/stat.h](cci:7://file:///lib/modules/6.12.73-1-lts/build/include/linux/stat.h/lib/modules/6.12.73-1-lts/build/include/linux/stat.h:0:0-0:0) into the base constants already extracted from `uapi/linux/stat.h`.
- New spec: [linux/sched.h](cci:7://file:///lib/modules/6.12.73-1-lts/build/include/linux/sched.h/lib/modules/6.12.73-1-lts/build/include/linux/sched.h:0:0-0:0) → `task` module (grep mode, all `TASK_` constants)
- Updated spec: `uapi/linux/stat.h` → `stat` module + supplement from [linux/stat.h](cci:7://file:///lib/modules/6.12.73-1-lts/build/include/linux/stat.h/lib/modules/6.12.73-1-lts/build/include/linux/stat.h:0:0-0:0) for composites (`S_IRWXUGO`, `S_IALLUGO`, `S_IRUGO`, `S_IWUGO`, `S_IXUGO`)

#### [lib/lualinux.c](cci:7://file:///home/suryansh/dev/GSOC/lunatik/lib/lualinux.c:0:0-0:0)
- Removed `lualinux_task[]`, `lualinux_stat[]`, and `lualinux_flags[]`
- Changed `LUNATIK_NEWLIB(linux, lualinux_lib, NULL, lualinux_flags)` → `LUNATIK_NEWLIB(linux, lualinux_lib, NULL, NULL)`
- Removed `#include <linux/stat.h>` (no longer used); kept `#include <linux/sched.h>` (still needed by [lualinux_schedule](cci:1://file:///home/suryansh/dev/GSOC/lunatik/lib/lualinux.c:74:0-106:1))

### Generated output

**[autogen/linux/task.lua](cci:7://file:///home/suryansh/dev/GSOC/lunatik/autogen/linux/task.lua:0:0-0:0)** (kernel 6.12.73-1-lts):
```lua
task["INTERRUPTIBLE"]   = 0x00000001
task["UNINTERRUPTIBLE"] = 0x00000002
task["KILLABLE"]        = 0x00000102  -- WAKEKILL | UNINTERRUPTIBLE
task["IDLE"]            = 0x00000402  -- UNINTERRUPTIBLE | NOLOAD
task["RUNNING"]         = 0x00000000
-- + DEAD, FREEZABLE, FROZEN, NEW, NOLOAD, NORMAL, PARKED, WAKEKILL, WAKING
```


autogen/linux/stat.lua
 includes composites:
 ```lua
 stat["IRWXUGO"] = 511   -- 0777
stat["IALLUGO"] = 4095  -- 07777
stat["IRUGO"]   = 292   -- 0444
stat["IWUGO"]   = 146   -- 0222
stat["IXUGO"]   = 73    -- 0111
```
### Access pattern change
Users will now `require("linux.task")` and `require("linux.stat")`  separately instead of accessing them via the linux C module's namespace table (e.g. linux.task.INTERRUPTIBLE).