### PR TITLE
auto generating task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ MODULES_BUILD_PATH ?= ${BTF_INSTALL_PATH}
 MODULES_INSTALL_PATH := ${MODULES_RELEASE_PATH}/kernel
 SCRIPTS_INSTALL_PATH := ${MODULES_PATH}/lua
 INCLUDE_PATH := ${MODULES_BUILD_PATH}/include
+KERNEL_ARCH ?= ${shell uname -m}
+ARCH ?= $(subst x86_64,x86,$(subst aarch64,arm64,$(KERNEL_ARCH)))
 
 LUA ?= lua5.4
 LUA_PATH ?= $(shell $(LUA) -e 'print(package.path:match("([^;]*)/%?%.lua;"))')
@@ -154,7 +156,7 @@ lunatik_sym.h: $(LUA_API) gensymbols.sh
 	${shell CC='$(CC)' ./gensymbols.sh $(LUA_API) > lunatik_sym.h}
 
 configure:
-	CC='$(CC)' "$(LUA)" configure.lua "$(KERNEL_RELEASE)" "$(INCLUDE_PATH)" "$(LUNATIK_MODULES)"
+	CC='$(CC)' "$(LUA)" configure.lua "$(KERNEL_RELEASE)" "$(INCLUDE_PATH)" "$(LUNATIK_MODULES)" "$(ARCH)"
 
 moontastik_install_%:
 	[ $* ] || (echo "usage: make moontastik_install_TARGET" ; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BTF_INSTALL_PATH = ${MODULES_RELEASE_PATH}/build
 MODULES_BUILD_PATH ?= ${BTF_INSTALL_PATH}
 MODULES_INSTALL_PATH := ${MODULES_RELEASE_PATH}/kernel
 SCRIPTS_INSTALL_PATH := ${MODULES_PATH}/lua
-INCLUDE_PATH := ${MODULES_BUILD_PATH}/include
+
 KERNEL_ARCH ?= ${shell uname -m}
 ARCH ?= $(subst x86_64,x86,$(subst aarch64,arm64,$(KERNEL_ARCH)))
 
@@ -156,7 +156,7 @@ lunatik_sym.h: $(LUA_API) gensymbols.sh
 	${shell CC='$(CC)' ./gensymbols.sh $(LUA_API) > lunatik_sym.h}
 
 configure:
-	CC='$(CC)' "$(LUA)" configure.lua "$(KERNEL_RELEASE)" "$(INCLUDE_PATH)" "$(LUNATIK_MODULES)" "$(ARCH)"
+	CC='$(CC)' "$(LUA)" configure.lua "$(KERNEL_RELEASE)" "$(MODULES_BUILD_PATH)" "$(LUNATIK_MODULES)" "$(ARCH)"
 
 moontastik_install_%:
 	[ $* ] || (echo "usage: make moontastik_install_TARGET" ; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ MODULES_INSTALL_PATH := ${MODULES_RELEASE_PATH}/kernel
 SCRIPTS_INSTALL_PATH := ${MODULES_PATH}/lua
 
 KERNEL_ARCH ?= ${shell uname -m}
-ARCH ?= $(subst x86_64,x86,$(subst aarch64,arm64,$(KERNEL_ARCH)))
+export ARCH ?= $(subst x86_64,x86,$(subst aarch64,arm64,$(KERNEL_ARCH)))
 
 LUA ?= lua5.4
 LUA_PATH ?= $(shell $(LUA) -e 'print(package.path:match("([^;]*)/%?%.lua;"))')
@@ -156,7 +156,7 @@ lunatik_sym.h: $(LUA_API) gensymbols.sh
 	${shell CC='$(CC)' ./gensymbols.sh $(LUA_API) > lunatik_sym.h}
 
 configure:
-	CC='$(CC)' "$(LUA)" configure.lua "$(KERNEL_RELEASE)" "$(MODULES_BUILD_PATH)" "$(LUNATIK_MODULES)" "$(ARCH)"
+	CC='$(CC)' "$(LUA)" configure.lua "$(KERNEL_RELEASE)" "$(MODULES_BUILD_PATH)" "$(LUNATIK_MODULES)"
 
 moontastik_install_%:
 	[ $* ] || (echo "usage: make moontastik_install_TARGET" ; exit 1)

--- a/configure.lua
+++ b/configure.lua
@@ -17,7 +17,7 @@ local specs = {
 		module_name = "eth",
 	},
 	{
-		header = "uapi/linux/stat.h",
+		header = "linux/stat.h",
 		prefix = "S_",
 		module_name = "stat",
 	},

--- a/configure.lua
+++ b/configure.lua
@@ -6,7 +6,7 @@
 local OUTPUT_DIR = "autogen"
 local SCRIPT  = arg[0]
 local KERNEL  = arg[1]
-local INCLUDE = arg[2]
+local BUILD   = arg[2]
 local MODULES = arg[3]
 local ARCH    = arg[4]
 
@@ -38,12 +38,12 @@ local function exit(msg)
 	os.exit(1)
 end
 
-if not KERNEL or not INCLUDE or not MODULES or not ARCH then
-	exit("usage: lua5.4 " .. SCRIPT .. " <KERNEL> <INCLUDE> <MODULES> <ARCH>")
+if not KERNEL or not BUILD or not MODULES or not ARCH then
+	exit("usage: lua5.4 " .. SCRIPT .. " <KERNEL> <BUILD> <MODULES> <ARCH>")
 end
 
 local CC = os.getenv("CC") or "cc"
-local BUILD = INCLUDE:gsub("/include$", "")
+local INCLUDE = BUILD .. "/include"
 local CPP = string.format("%s -E -dM -I%s -I%s/include/generated -I%s/arch/%s/include -I%s/arch/%s/include/generated -include linux/kconfig.h",
 	CC, INCLUDE, BUILD, BUILD, ARCH, BUILD, ARCH)
 
@@ -77,24 +77,18 @@ local function resolve_value(value, prefix, constants, seen)
 	if seen[value] then return nil end
 
 	if tonumber(value) then return tonumber(value) end
+	local clean = value:match("^%((.+)%)$") or value
 
 	-- OR expression: (A | B | ...)
-	local inner = value:match("^%((.+)%)$")
-	if inner then
-		local is_or_expr = true
-		local result = 0
-		for token in inner:gmatch("[^%s|]+") do
-			-- only resolve if token is a number or it starts with the expected prefix
-			if not (tonumber(token) or string.sub(token, 1, #prefix) == prefix) then
-				is_or_expr = false
-				break
-			end
-			local resolved = resolve_value(token, prefix, constants, seen)
-			if not resolved then return nil end
-			result = result | resolved
-		end
-		if is_or_expr then return result end
-	end
+    if clean:find("|") then
+        local result = 0
+        for token in clean:gmatch("[^%s|]+") do
+            local resolved = resolve_value(token, prefix, constants, seen)
+            if not resolved then return nil end
+            result = result | resolved
+        end
+        return result
+    end
 
 	-- macro reference
 	if not constants[value] then return nil end

--- a/configure.lua
+++ b/configure.lua
@@ -8,6 +8,7 @@ local SCRIPT  = arg[0]
 local KERNEL  = arg[1]
 local INCLUDE = arg[2]
 local MODULES = arg[3]
+local ARCH    = arg[4]
 
 local specs = {
 	{
@@ -24,6 +25,11 @@ local specs = {
 		header = "uapi/linux/signal.h",
 		prefix = "SIG",
 		module_name = "signal",
+	},
+	{
+		header = "linux/sched.h",
+		prefix = "TASK_",
+		module_name = "task",
 	}
 }
 
@@ -32,12 +38,14 @@ local function exit(msg)
 	os.exit(1)
 end
 
-if not KERNEL or not INCLUDE or not MODULES then
-	exit("usage: lua5.4 " .. SCRIPT .. " <KERNEL> <INCLUDE> <MODULES>")
+if not KERNEL or not INCLUDE or not MODULES or not ARCH then
+	exit("usage: lua5.4 " .. SCRIPT .. " <KERNEL> <INCLUDE> <MODULES> <ARCH>")
 end
 
 local CC = os.getenv("CC") or "cc"
-local CPP = string.format("%s -E -dM -I%s", CC, INCLUDE)
+local BUILD = INCLUDE:gsub("/include$", "")
+local CPP = string.format("%s -E -dM -I%s -I%s/include/generated -I%s/arch/%s/include -I%s/arch/%s/include/generated -include linux/kconfig.h",
+	CC, INCLUDE, BUILD, BUILD, ARCH, BUILD, ARCH)
 
 local function preprocess(header_path)
 	local cmd = string.format("%s %s/%s", CPP, INCLUDE, header_path)
@@ -52,37 +60,55 @@ local function collect_constants(cpp_output, prefix)
 	local constants = {}
 	local macro_names = {}
 
-	for macro, literal in cpp_output:gmatch("#define%s+(" .. prefix .. "%w+)%s+(%S+)") do
-		constants[macro] = literal
-		table.insert(macro_names, macro)
+	for line in cpp_output:gmatch("[^\n]+") do
+		local macro, value = line:match("#define%s+(" .. prefix .. "[%u%d_]+)%s+(.+)%s*$")
+		if macro and not line:match("#define%s+" .. prefix .. "%w+%(") then
+			constants[macro] = value
+			table.insert(macro_names, macro)
+		end
 	end
 
 	table.sort(macro_names)
 	return constants, macro_names
 end
 
-local function resolve_value(value, constants, prefix, module_name, seen)
-	if tonumber(value) then return value end
-
-	if not constants[value] then return nil end
-
+local function resolve_value(value, prefix, constants, seen)
 	seen = seen or {}
-	-- recursion check: avoid cyclic defines
 	if seen[value] then return nil end
-	seen[value] = true
 
-	if value:find("^" .. prefix) then
-		local stripped = value:gsub("^" .. prefix, "")
-		return string.format('%s["%s"]', module_name, stripped)
+	if tonumber(value) then return tonumber(value) end
+
+	-- OR expression: (A | B | ...)
+	local inner = value:match("^%((.+)%)$")
+	if inner then
+		local is_or_expr = true
+		local result = 0
+		for token in inner:gmatch("[^%s|]+") do
+			-- only resolve if token is a number or it starts with the expected prefix
+			if not (tonumber(token) or string.sub(token, 1, #prefix) == prefix) then
+				is_or_expr = false
+				break
+			end
+			local resolved = resolve_value(token, prefix, constants, seen)
+			if not resolved then return nil end
+			result = result | resolved
+		end
+		if is_or_expr then return result end
 	end
 
-	return resolve_value(constants[value], constants, prefix, module_name, seen)
+	-- macro reference
+	if not constants[value] then return nil end
+
+	seen[value] = true
+	local res = resolve_value(constants[value], prefix, constants, seen)
+	seen[value] = nil
+	return res
 end
 
 local function write_constants(file, module, spec, constants, macro_names)
 	for _, macro in ipairs(macro_names) do
 		local field_name = macro:gsub("^" .. spec.prefix, "")
-		local resolved_value = resolve_value(constants[macro], constants, spec.prefix, spec.module_name)
+		local resolved_value = resolve_value(constants[macro], spec.prefix, constants)
 		if resolved_value then
 			file:write(string.format('%s["%s"]\t= %s\n', spec.module_name, field_name, resolved_value))
 		end

--- a/configure.lua
+++ b/configure.lua
@@ -8,7 +8,7 @@ local SCRIPT  = arg[0]
 local KERNEL  = arg[1]
 local BUILD   = arg[2]
 local MODULES = arg[3]
-local ARCH    = arg[4]
+local ARCH    = os.getenv("ARCH")
 
 local specs = {
 	{
@@ -39,7 +39,7 @@ local function exit(msg)
 end
 
 if not KERNEL or not BUILD or not MODULES or not ARCH then
-	exit("usage: lua5.4 " .. SCRIPT .. " <KERNEL> <BUILD> <MODULES> <ARCH>")
+	exit("usage: ARCH=<ARCH> lua5.4 " .. SCRIPT .. " <KERNEL> <BUILD> <MODULES>")
 end
 
 local CC = os.getenv("CC") or "cc"

--- a/examples/echod/daemon.lua
+++ b/examples/echod/daemon.lua
@@ -11,7 +11,6 @@ local linux   = require("linux")
 local data    = require("data")
 
 local shouldstop = thread.shouldstop
-local task = linux.task
 local sock = socket.sock
 
 local control = data.new(2)

--- a/examples/shared.lua
+++ b/examples/shared.lua
@@ -35,7 +35,6 @@ server:bind(inet.localhost, 90)
 server:listen()
 
 local shouldstop = thread.shouldstop
-local task = linux.task
 local sock = socket.sock
 
 local size = 1024

--- a/examples/systrack.lua
+++ b/examples/systrack.lua
@@ -10,7 +10,7 @@ local systab = require("syscall.table")
 
 local syscalls = {"openat", "read", "write", "readv", "writev", "close"}
 
-local s = linux.stat
+local s = require("linux.stat")
 local driver = {name = "systrack", mode = s.IRUGO}
 
 local track = {}

--- a/examples/tap.lua
+++ b/examples/tap.lua
@@ -9,7 +9,7 @@ local linux  = require("linux")
 
 local MTU       = 1500
 
-local s = linux.stat
+local s = require("linux.stat")
 local tap = {name = "tap", mode = s.IRUGO}
 
 local socket = raw.bind()

--- a/lib/lualinux.c
+++ b/lib/lualinux.c
@@ -88,7 +88,8 @@ static int lualinux_random(lua_State *L)
 * @see linux.task
 * @usage
 *   linux.schedule(1000) -- Sleep for 1 second (interruptible)
-*   linux.schedule(500, linux.task.UNINTERRUPTIBLE) -- Sleep for 0.5 seconds (uninterruptible)
+*   local task = require("linux.task")
+*   linux.schedule(500, task.UNINTERRUPTIBLE) -- Sleep for 0.5 seconds (uninterruptible)
 */
 static int lualinux_schedule(lua_State *L)
 {
@@ -231,27 +232,6 @@ static int lualinux_ifaddr(lua_State *L)
 }
 
 /***
-* Table of task state constants.
-* Exports task state flags from `<linux/sched.h>`. These are used with
-* `linux.schedule()`.
-*
-* @table task
-*   @tfield integer INTERRUPTIBLE Task is waiting for a signal or a resource (sleeping), can be interrupted.
-*   @tfield integer UNINTERRUPTIBLE Task is waiting (sleeping),
-*   cannot be interrupted by signals (except fatal ones if KILLABLE is also implied by context).
-*   @tfield integer KILLABLE Task is waiting (sleeping) like UNINTERRUPTIBLE, but can be interrupted by fatal signals.
-*   @tfield integer IDLE Task is idle, similar to UNINTERRUPTIBLE but avoids loadavg accounting.
-* @see linux.schedule
-*/
-static const lunatik_reg_t lualinux_task[] = {
-	{"INTERRUPTIBLE", TASK_INTERRUPTIBLE},
-	{"UNINTERRUPTIBLE", TASK_UNINTERRUPTIBLE},
-	{"KILLABLE", TASK_KILLABLE},
-	{"IDLE", TASK_IDLE},
-	{NULL, 0}
-};
-
-/***
 * Table of file mode constants.
 * Exports file permission flags from `<linux/stat.h>`. These can be used, for
 * example, with `device.new()` to set the mode of a character device.
@@ -302,7 +282,6 @@ static int lualinux_errname(lua_State *L)
 
 static const lunatik_namespace_t lualinux_flags[] = {
 	{"stat", lualinux_stat},
-	{"task", lualinux_task},
 	{NULL, NULL}
 };
 

--- a/lib/lualinux.c
+++ b/lib/lualinux.c
@@ -13,7 +13,6 @@
 */
 
 #include <linux/random.h>
-#include <linux/stat.h>
 #include <linux/sched.h>
 #include <linux/jiffies.h>
 #include <linux/ktime.h>
@@ -231,35 +230,6 @@ static int lualinux_ifaddr(lua_State *L)
 	return 1;
 }
 
-/***
-* Table of file mode constants.
-* Exports file permission flags from `<linux/stat.h>`. These can be used, for
-* example, with `device.new()` to set the mode of a character device.
-*/
-static const lunatik_reg_t lualinux_stat[] = {
-	/* user */
-	{"IRWXU", S_IRWXU},
-	{"IRUSR", S_IRUSR},
-	{"IWUSR", S_IWUSR},
-	{"IXUSR", S_IXUSR},
-	/* group */
-	{"IRWXG", S_IRWXG},
-	{"IRGRP", S_IRGRP},
-	{"IWGRP", S_IWGRP},
-	{"IXGRP", S_IXGRP},
-	/* other */
-	{"IRWXO", S_IRWXO},
-	{"IROTH", S_IROTH},
-	{"IWOTH", S_IWOTH},
-	{"IXOTH", S_IXOTH},
-	/* user, group, other */
-	{"IRWXUGO", (S_IRWXU|S_IRWXG|S_IRWXO)},
-	{"IALLUGO", (S_ISUID|S_ISGID|S_ISVTX|S_IRWXUGO)},
-	{"IRUGO", (S_IRUSR|S_IRGRP|S_IROTH)},
-	{"IWUGO", (S_IWUSR|S_IWGRP|S_IWOTH)},
-	{"IXUGO", (S_IXUSR|S_IXGRP|S_IXOTH)},
-	{NULL, 0}
-};
 
 /***
 * Returns the symbolic name of a kernel error number.
@@ -280,11 +250,6 @@ static int lualinux_errname(lua_State *L)
     return 1;
 }
 
-static const lunatik_namespace_t lualinux_flags[] = {
-	{"stat", lualinux_stat},
-	{NULL, NULL}
-};
-
 static const luaL_Reg lualinux_lib[] = {
 	{"random", lualinux_random},
 	{"schedule", lualinux_schedule},
@@ -298,7 +263,7 @@ static const luaL_Reg lualinux_lib[] = {
 	{NULL, NULL}
 };
 
-LUNATIK_NEWLIB(linux, lualinux_lib, NULL, lualinux_flags);
+LUNATIK_NEWLIB(linux, lualinux_lib, NULL, NULL);
 
 static int __init lualinux_init(void)
 {


### PR DESCRIPTION
Closes #435  
Here is phase 1 of the [PR](https://github.com/luainkernel/lunatik/pull/440)  
- Simplify configure.lua (remove stat, signal, eth, supplement logic)
- Restore lualinux_stat in lib/lualinux.c
- Update documentation for task access

Now `make configure` auto generates hexadecimal constants for both task and stat modules.  

Phase 2: Move stat constants  
Phase 3: Move OR'ed flags (composites)
Ready for the feedback.