### PR TITLE
Fix #435 : move lualinux_task and lualinux_stat to configure.lua.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ to generate random ASCII printable characters:
 
 local device = require("device")
 local linux  = require("linux")
+local s      = require("linux.stat")
 
-local s = linux.stat
 local driver = {name = "passwd", mode = s.IRUGO}
 
 function driver:read() -- read(2) callback

--- a/configure.lua
+++ b/configure.lua
@@ -19,11 +19,18 @@ local specs = {
 		header = "uapi/linux/stat.h",
 		prefix = "S_",
 		module_name = "stat",
+		supplement = "linux/stat.h",
 	},
 	{
 		header = "uapi/linux/signal.h",
 		prefix = "SIG",
 		module_name = "signal",
+	},
+	{
+		header = "linux/sched.h",
+		prefix = "TASK_",
+		module_name = "task",
+		internal = true,
 	}
 }
 
@@ -38,6 +45,12 @@ end
 
 local CC = os.getenv("CC") or "cc"
 local CPP = string.format("%s -E -dM -I%s", CC, INCLUDE)
+
+local function c_tonumber(s)
+	if s:match("^0[xX]%x+$") then return tonumber(s) end
+	if s:match("^0%d+$") then return tonumber(s, 8) end
+	return tonumber(s)
+end
 
 local function preprocess(header_path)
 	local cmd = string.format("%s %s/%s", CPP, INCLUDE, header_path)
@@ -61,8 +74,57 @@ local function collect_constants(cpp_output, prefix)
 	return constants, macro_names
 end
 
+local function grep_constants(header_path, prefix)
+	local filepath = string.format("%s/%s", INCLUDE, header_path)
+	local file <close>, err = io.open(filepath, "r")
+	if not file then
+		exit("cannot open " .. filepath .. ": " .. (err or ""))
+	end
+	local constants = {}
+	local macro_names = {}
+	for line in file:lines() do
+		local macro, value = line:match("^#define%s+(" .. prefix .. "%w+)%s+(.+)$")
+		if macro and value then
+			value = value:gsub("%s*\\?%s*$", "")
+			constants[macro] = value
+			table.insert(macro_names, macro)
+		end
+	end
+	table.sort(macro_names)
+	return constants, macro_names
+end
+
+local function resolve_grep_value(value, constants, seen)
+	local n = c_tonumber(value)
+	if n then return n end
+	seen = seen or {}
+	if seen[value] then return nil end
+	seen[value] = true
+	if constants[value] then
+		return resolve_grep_value(constants[value], constants, seen)
+	end
+	local expr = value:match("^%((.+)%)$")
+	if expr then
+		local result = 0
+		for part in expr:gmatch("[^|]+") do
+			part = part:match("^%s*(.-)%s*$")
+			local v = resolve_grep_value(part, constants, seen)
+			if not v then return nil end
+			result = result | v
+		end
+		return result
+	end
+	return nil
+end
+
 local function resolve_value(value, constants, prefix, module_name, seen)
-	if tonumber(value) then return value end
+	local n = c_tonumber(value)
+	if n then
+		if value:match("^0[xX]") then
+			return string.format("0x%04X", n)
+		end
+		return tostring(n)
+	end
 
 	if not constants[value] then return nil end
 
@@ -89,6 +151,33 @@ local function write_constants(file, module, spec, constants, macro_names)
 	end
 end
 
+local function write_grep_constants(file, module, spec, constants, macro_names)
+	for _, macro in ipairs(macro_names) do
+		local field_name = macro:gsub("^" .. spec.prefix, "")
+		local value = resolve_grep_value(constants[macro], constants)
+		if value then
+			file:write(string.format('%s["%s"]\t= 0x%08X\n', spec.module_name, field_name, value))
+		end
+	end
+end
+
+local function supplement_constants(constants, macro_names, spec)
+	local supp, supp_names = grep_constants(spec.supplement, spec.prefix)
+	local merged = {}
+	for k, v in pairs(constants) do merged[k] = v end
+	for k, v in pairs(supp) do merged[k] = v end
+	for _, name in ipairs(supp_names) do
+		if not constants[name] then
+			local value = resolve_grep_value(supp[name], merged)
+			if value then
+				constants[name] = tostring(value)
+				table.insert(macro_names, name)
+			end
+		end
+	end
+	table.sort(macro_names)
+end
+
 local function write_module(dir, module, writer, ...)
 	local filepath = string.format("%s/%s/%s.lua", OUTPUT_DIR, dir, module)
 	local file <close>, err = io.open(filepath, "w")
@@ -112,9 +201,18 @@ local function write_config(file, module)
 end
 
 for _, spec in ipairs(specs) do
-	local cpp_output = preprocess(spec.header)
-	local constants, macro_names = collect_constants(cpp_output, spec.prefix)
-	write_module("linux", spec.module_name, write_constants, spec, constants, macro_names)
+	local constants, macro_names
+	if spec.internal then
+		constants, macro_names = grep_constants(spec.header, spec.prefix)
+		write_module("linux", spec.module_name, write_grep_constants, spec, constants, macro_names)
+	else
+		local cpp_output = preprocess(spec.header)
+		constants, macro_names = collect_constants(cpp_output, spec.prefix)
+		if spec.supplement then
+			supplement_constants(constants, macro_names, spec)
+		end
+		write_module("linux", spec.module_name, write_constants, spec, constants, macro_names)
+	end
 end
 
 write_module("lunatik", "config", write_config)

--- a/examples/echod/daemon.lua
+++ b/examples/echod/daemon.lua
@@ -11,7 +11,6 @@ local linux   = require("linux")
 local data    = require("data")
 
 local shouldstop = thread.shouldstop
-local task = linux.task
 local sock = socket.sock
 
 local control = data.new(2)

--- a/examples/shared.lua
+++ b/examples/shared.lua
@@ -35,7 +35,6 @@ server:bind(inet.localhost, 90)
 server:listen()
 
 local shouldstop = thread.shouldstop
-local task = linux.task
 local sock = socket.sock
 
 local size = 1024

--- a/examples/systrack.lua
+++ b/examples/systrack.lua
@@ -7,10 +7,10 @@ local linux  = require("linux")
 local probe  = require("probe")
 local device = require("device")
 local systab = require("syscall.table")
+local s      = require("linux.stat")
 
 local syscalls = {"openat", "read", "write", "readv", "writev", "close"}
 
-local s = linux.stat
 local driver = {name = "systrack", mode = s.IRUGO}
 
 local track = {}

--- a/examples/tap.lua
+++ b/examples/tap.lua
@@ -6,10 +6,10 @@
 local device = require("device")
 local raw    = require("socket.raw")
 local linux  = require("linux")
+local s      = require("linux.stat")
 
 local MTU       = 1500
 
-local s = linux.stat
 local tap = {name = "tap", mode = s.IRUGO}
 
 local socket = raw.bind()

--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -303,18 +303,18 @@ static int luadevice_stop(lua_State *L)
 *     last file descriptor is closed). Signature: `function(driver_table)`.
 *     Expected to return nothing.
 *   - `mode` (integer): Optional file mode flags (e.g., permissions) for the device file.
-*     Use constants from the `linux.stat` table (e.g., `linux.stat.IRUGO`).
+*     Use constants from `require("linux.stat")` (e.g., `stat.IRUGO`).
 * @treturn userdata A Lunatik object representing the newly created device.
 *   This object can be used to explicitly stop the device using the `:stop()` method.
 * @raise Error if the device cannot be allocated or registered in the kernel,
 *   or if the `name` field is missing or not a string.
 * @usage
 *   local device = require("device")
-*   local linux = require("linux")
+*   local stat = require("linux.stat")
 *
 *   local my_driver = {
 *     name = "my_lua_device",
-*     mode = linux.stat.IRUGO, -- Read-only for all
+*     mode = stat.IRUGO, -- Read-only for all
 *     read = function(drv, len, off)
 *       local data = "Hello from " .. drv.name .. " at offset " .. tostring(off) .. "!"
 *       return data:sub(1, len), off + #data
@@ -322,7 +322,6 @@ static int luadevice_stop(lua_State *L)
 *   }
 *   local dev_obj = device.new(my_driver)
 *   -- To clean up: dev_obj:stop() or let it be garbage collected.
-* @see linux.stat
 */
 static const luaL_Reg luadevice_lib[] = {
 	{"new", luadevice_new},

--- a/lib/lualinux.c
+++ b/lib/lualinux.c
@@ -13,7 +13,6 @@
 */
 
 #include <linux/random.h>
-#include <linux/stat.h>
 #include <linux/sched.h>
 #include <linux/jiffies.h>
 #include <linux/ktime.h>
@@ -81,14 +80,14 @@ static int lualinux_random(lua_State *L)
 * @tparam[opt] integer timeout Duration in milliseconds to sleep.
 * Defaults to `MAX_SCHEDULE_TIMEOUT` (effectively indefinite sleep until woken).
 * @tparam[opt] integer state The task state to set before sleeping.
-* See `linux.task` for possible values. Defaults to `linux.task.INTERRUPTIBLE`.
+* See `require("linux.task")` for possible values. Defaults to `TASK_INTERRUPTIBLE`.
 * @treturn integer The remaining time in milliseconds
 * if the sleep was interrupted before the full timeout, or 0 if the full timeout elapsed.
 * @raise Error if an invalid task state is provided.
-* @see linux.task
 * @usage
+*   local task = require("linux.task")
 *   linux.schedule(1000) -- Sleep for 1 second (interruptible)
-*   linux.schedule(500, linux.task.UNINTERRUPTIBLE) -- Sleep for 0.5 seconds (uninterruptible)
+*   linux.schedule(500, task.UNINTERRUPTIBLE) -- Sleep for 0.5 seconds (uninterruptible)
 */
 static int lualinux_schedule(lua_State *L)
 {
@@ -231,57 +230,6 @@ static int lualinux_ifaddr(lua_State *L)
 }
 
 /***
-* Table of task state constants.
-* Exports task state flags from `<linux/sched.h>`. These are used with
-* `linux.schedule()`.
-*
-* @table task
-*   @tfield integer INTERRUPTIBLE Task is waiting for a signal or a resource (sleeping), can be interrupted.
-*   @tfield integer UNINTERRUPTIBLE Task is waiting (sleeping),
-*   cannot be interrupted by signals (except fatal ones if KILLABLE is also implied by context).
-*   @tfield integer KILLABLE Task is waiting (sleeping) like UNINTERRUPTIBLE, but can be interrupted by fatal signals.
-*   @tfield integer IDLE Task is idle, similar to UNINTERRUPTIBLE but avoids loadavg accounting.
-* @see linux.schedule
-*/
-static const lunatik_reg_t lualinux_task[] = {
-	{"INTERRUPTIBLE", TASK_INTERRUPTIBLE},
-	{"UNINTERRUPTIBLE", TASK_UNINTERRUPTIBLE},
-	{"KILLABLE", TASK_KILLABLE},
-	{"IDLE", TASK_IDLE},
-	{NULL, 0}
-};
-
-/***
-* Table of file mode constants.
-* Exports file permission flags from `<linux/stat.h>`. These can be used, for
-* example, with `device.new()` to set the mode of a character device.
-*/
-static const lunatik_reg_t lualinux_stat[] = {
-	/* user */
-	{"IRWXU", S_IRWXU},
-	{"IRUSR", S_IRUSR},
-	{"IWUSR", S_IWUSR},
-	{"IXUSR", S_IXUSR},
-	/* group */
-	{"IRWXG", S_IRWXG},
-	{"IRGRP", S_IRGRP},
-	{"IWGRP", S_IWGRP},
-	{"IXGRP", S_IXGRP},
-	/* other */
-	{"IRWXO", S_IRWXO},
-	{"IROTH", S_IROTH},
-	{"IWOTH", S_IWOTH},
-	{"IXOTH", S_IXOTH},
-	/* user, group, other */
-	{"IRWXUGO", (S_IRWXU|S_IRWXG|S_IRWXO)},
-	{"IALLUGO", (S_ISUID|S_ISGID|S_ISVTX|S_IRWXUGO)},
-	{"IRUGO", (S_IRUSR|S_IRGRP|S_IROTH)},
-	{"IWUGO", (S_IWUSR|S_IWGRP|S_IWOTH)},
-	{"IXUGO", (S_IXUSR|S_IXGRP|S_IXOTH)},
-	{NULL, 0}
-};
-
-/***
 * Returns the symbolic name of a kernel error number.
 * For example, it converts `2` to `"ENOENT"`.
 *
@@ -300,12 +248,6 @@ static int lualinux_errname(lua_State *L)
     return 1;
 }
 
-static const lunatik_namespace_t lualinux_flags[] = {
-	{"stat", lualinux_stat},
-	{"task", lualinux_task},
-	{NULL, NULL}
-};
-
 static const luaL_Reg lualinux_lib[] = {
 	{"random", lualinux_random},
 	{"schedule", lualinux_schedule},
@@ -319,7 +261,7 @@ static const luaL_Reg lualinux_lib[] = {
 	{NULL, NULL}
 };
 
-LUNATIK_NEWLIB(linux, lualinux_lib, NULL, lualinux_flags);
+LUNATIK_NEWLIB(linux, lualinux_lib, NULL, NULL);
 
 static int __init lualinux_init(void)
 {


### PR DESCRIPTION
**configure.lua:**

- Add c_tonumber() to correctly parse C octal/hex literals (e.g., C 00700 → Lua 448, not 700)
- Add grep_constants() for extracting #define values from kernel-internal headers (linux/sched.h, linux/stat.h) that cannot be preprocessed with cc -E -dM
- Add resolve_grep_value() to resolve OR-expression composites like (TASK_WAKEKILL | TASK_UNINTERRUPTIBLE)
- Add supplement_constants() to merge composites from linux/stat.h (e.g., S_IRWXUGO, S_IALLUGO) into the base constants from uapi/linux/stat.h

**lualinux.c:**
- Remove lualinux_task[], lualinux_stat[], lualinux_flags[]
- Remove #include <linux/stat.h> (no longer needed)
- Update LUNATIK_NEWLIB to pass NULL for flags

**Examples & docs:**
- Update tap.lua, systrack.lua to use require("linux.stat")
- Remove dead local task = linux.task from shared.lua, echod/daemon.lua
