### PR TITLE
Issue #403 : Add safe unregister methods to luanetfilter, luahid, and luaxdp

### DIFF
--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -70,8 +70,27 @@ static const luaL_Reg luahid_lib[] = {
 	{NULL, NULL},
 };
 
+static int luahid_unregister(lua_State *L)
+{
+	lunatik_object_t *object = lunatik_checkobject(L, 1);
+	luahid_t *hid = (luahid_t *)object->private;
+
+	lunatik_lock(object);
+	if (hid->registered) {
+		hid_unregister_driver(&hid->driver);
+		hid->registered = false;
+	}
+	lunatik_unlock(object);
+
+	if (lunatik_isruntime(L, hid))
+		lunatik_unregisterobject(L, object);
+
+	return 0;
+}
+
 static const luaL_Reg luahid_mt[] = {
 	{"__gc", lunatik_deleteobject},
+	{"unregister", luahid_unregister},
 	{NULL, NULL},
 };
 

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -132,8 +132,27 @@ static unsigned int luanetfilter_hook(void *priv, struct sk_buff *skb, const str
 	return luanetfilter_docall(luanf, skb);
 }
 
+static int luanetfilter_unregister(lua_State *L)
+{
+	lunatik_object_t *object = lunatik_checkobject(L, 1);
+	luanetfilter_t *nf = (luanetfilter_t *)object->private;
+
+	lunatik_lock(object);
+	if (nf->nfops.hook) {
+		nf_unregister_net_hook(&init_net, &nf->nfops);
+		nf->nfops.hook = NULL;
+	}
+	lunatik_unlock(object);
+
+	if (lunatik_isruntime(L, nf))
+		lunatik_unregisterobject(L, object);
+
+	return 0;
+}
+
 static const luaL_Reg luanetfilter_mt[] = {
 	{"__gc", lunatik_deleteobject},
+	{"unregister", luanetfilter_unregister},
 	{NULL, NULL}
 };
 
@@ -198,10 +217,14 @@ static void luanetfilter_release(void *private)
 {
 	luanetfilter_t *nf = (luanetfilter_t *)private;
 	lunatik_object_t *runtime = nf->runtime;
+
 	if (runtime == NULL)
 		return;
 
-	nf_unregister_net_hook(&init_net, &nf->nfops);
+	if (nf->nfops.hook) {
+		nf_unregister_net_hook(&init_net, &nf->nfops);
+		nf->nfops.hook = NULL;
+	}
 	luadata_detach(runtime, nf, skb);
 	lunatik_putobject(runtime);
 	nf->runtime = NULL;

--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -184,11 +184,9 @@ static void luanotifier_release(void *private)
 	lunatik_putobject(notifier->runtime);
 }
 
-#define luanotifier_isruntime(L, notifier)	(lunatik_toruntime(L) == (notifier)->runtime)
-
 static inline void luanotifier_checkrunning(lua_State *L, luanotifier_t *notifier)
 {
-	if (luanotifier_isruntime(L, notifier) && notifier->running)
+	if (lunatik_isruntime(L, notifier) && notifier->running)
 		luaL_error(L, "[%p] notifier cannot unregister itself (deadlock)", notifier);
 }
 
@@ -205,7 +203,6 @@ static int luanotifier_stop(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_checkobject(L, 1);
 	luanotifier_t *notifier = (luanotifier_t *)object->private;
-
 	luanotifier_checkrunning(L, notifier);
 
 	lunatik_lock(object);
@@ -215,7 +212,7 @@ static int luanotifier_stop(lua_State *L)
 	}
 	lunatik_unlock(object);
 
-	if (luanotifier_isruntime(L, notifier))
+	if (lunatik_isruntime(L, notifier))
 		lunatik_unregisterobject(L, object);
 	return 0;
 }

--- a/lunatik.h
+++ b/lunatik.h
@@ -62,6 +62,8 @@ do {									\
 	lunatik_unlock(runtime);					\
 } while(0)
 
+#define lunatik_isruntime(L, obj)	(lunatik_toruntime(L) == (obj)->runtime)
+
 typedef struct lunatik_reg_s {
 	const char *name;
 	lua_Integer value;


### PR DESCRIPTION
Fixes #403

this adds the explicit unregister() methods to luanetfilter, luahid, and luaxdp.