### PR TITLE
add lunatik_value_t and refactor luarcu to use it

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -32,7 +32,7 @@ lunatik-objs += lua/lapi.o lua/lcode.o lua/lctype.o lua/ldebug.o lua/ldo.o \
 	lua/lcorolib.o lua/ldblib.o lua/lstrlib.o \
 	lua/ltablib.o lua/lutf8lib.o lua/lmathlib.o lua/linit.o \
 	lua/loadlib.o $(KLIBC_USR)/klibc/arch/$(KLIBC_ARCH)/setjmp.o \
-	lunatik_aux.o lunatik_obj.o lunatik_core.o
+	lunatik_aux.o lunatik_obj.o lunatik_val.o lunatik_core.o
 
 ifeq ($(CONFIG_64BIT),)
 lunatik-objs += $(KLIBC_LIBGCC)/__udivmoddi4.o	\

--- a/lib/luarcu.c
+++ b/lib/luarcu.c
@@ -4,21 +4,12 @@
 */
 
 /***
-* Read-Copy-Update (RCU) synchronized hash table.
-* This library provides a Lua-accessible hash table that uses RCU (Read-Copy-Update)
-* for synchronization within the Linux kernel. RCU allows for very fast, lockless
-* read operations, while write operations (updates and deletions) are synchronized
-* to ensure data consistency. This makes it highly suitable for scenarios where
-* read operations significantly outnumber write operations and high concurrency
-* is required.
+* RCU-synchronized hash table.
+* Provides a concurrent hash table using Read-Copy-Update (RCU) synchronization.
+* Reads are lockless; writes are serialized. Keys are strings, values can be
+* booleans, integers, lunatik objects, or `nil` (to delete an entry).
 *
-* Keys in the RCU table must be strings. Values must be Lunatik objects
-* (i.e., userdata created by other Lunatik C modules like `data.new()`,
-* `lunatik.runtime()`, etc.) or `nil` to delete an entry.
-*
-* A practical example of its usage can be found in `examples/shared.lua`,
-* which implements an in-memory key-value store.
-*
+* See `examples/shared.lua` for a practical example.
 * @module rcu
 */
 
@@ -34,46 +25,23 @@
 #define LUARCU_MAXKEY	(LUAL_BUFFERSIZE)
 
 typedef struct luarcu_entry_s {
-	lunatik_object_t *object;
+	lunatik_value_t value;
 	struct hlist_node hlist;
 	struct rcu_head rcu;
 	char key[];
 } luarcu_entry_t;
 
 /***
-* Represents an RCU-synchronized hash table.
-* This is a userdata object returned by `rcu.table()`. It behaves like a
-* standard Lua table for get (`__index`) and set (`__newindex`) operations
-* but uses RCU internally for synchronization.
-*
-* Keys must be strings. Values stored must be Lunatik objects (e.g., created
-* via `data.new()`, `lunatik.runtime()`) or `nil` (to remove an entry).
-* When a Lunatik object is retrieved, it's a new reference to that object.
-*
+* RCU hash table object.
+* Supports table-like access via `__index` and `__newindex`.
 * @type rcu_table
 * @usage
-*  -- Assuming 'data' module is available for creating Lunatik objects
-*  -- and 'rcu' module is required.
-*  local rcu_store = rcu.table()
-*  local my_data = data.new(10) -- Create a Lunatik object
-*  my_data:setstring(0, "hello")
-*
-*  -- Set a value
-*  rcu_store["my_key"] = my_data
-*
-*  -- Get a value
-*  local retrieved_data = rcu_store["my_key"]
-*  if retrieved_data then
-*    print(retrieved_data:getstring(0)) -- Output: hello
-*  end
-*
-*  -- Remove a value
-*  rcu_store["my_key"] = nil
-*
-*  -- Iterate
-*  rcu_store:map(function(k, v_obj)
-*    print("Found key:", k, "Value object:", v_obj)
-*  end)
+*  local t = rcu.table()
+*  t["key"] = true        -- boolean
+*  t["n"]   = 42          -- integer
+*  t["obj"] = data.new(8) -- object
+*  print(t["key"])        -- true
+*  t["key"] = nil         -- delete
 */
 
 typedef struct luarcu_table_s {
@@ -96,9 +64,6 @@ typedef struct luarcu_table_s {
 			pos && ({ n = luarcu_entry(hlist_next_rcu(&(pos)->hlist), pos); 1; });	\
 			pos = n)
 
-#define luarcu_checkoptnil(L, i, checkopt, ...) \
-	(lua_type((L), (i)) == LUA_TNIL ? NULL : checkopt((L), (i), ## __VA_ARGS__))
-
 static int luarcu_table(lua_State *L);
 
 static inline luarcu_entry_t *luarcu_lookup(luarcu_table_t *table, unsigned int index,
@@ -112,7 +77,7 @@ static inline luarcu_entry_t *luarcu_lookup(luarcu_table_t *table, unsigned int 
 	return NULL;
 }
 
-static luarcu_entry_t *luarcu_newentry(const char *key, size_t keylen, lunatik_object_t *object)
+static luarcu_entry_t *luarcu_newentry(const char *key, size_t keylen, lunatik_value_t *value)
 {
 	luarcu_entry_t *entry;
 
@@ -121,46 +86,40 @@ static luarcu_entry_t *luarcu_newentry(const char *key, size_t keylen, lunatik_o
 
 	strncpy(entry->key, key, keylen);
 	entry->key[keylen] = '\0';
-	entry->object = object;
-	lunatik_getobject(object);
+	entry->value = *value;
+	if (lunatik_isuserdata(value))
+		lunatik_getobject(value->object);
 	return entry;
 }
 
 static inline void luarcu_free(luarcu_entry_t *entry)
 {
-	lunatik_putobject(entry->object);
+	if (lunatik_isuserdata(&entry->value))
+		lunatik_putobject(entry->value.object);
 	kfree_rcu(entry, rcu);
 }
 
 LUNATIK_OBJECTCHECKER(luarcu_checktable, luarcu_table_t *);
 
-static int luarcu_cloneobject(lua_State *L)
-{
-	lunatik_object_t *object = (lunatik_object_t *)lua_touserdata(L, 1);
-	lunatik_cloneobject(L, object);
-	return 1;
-}
-
-lunatik_object_t *luarcu_gettable(lunatik_object_t *table, const char *key, size_t keylen)
+void luarcu_getvalue(lunatik_object_t *table, const char *key, size_t keylen, lunatik_value_t *value)
 {
 	luarcu_table_t *_table = (luarcu_table_t *)table->private;
 	unsigned int index = luarcu_hash(_table, key, keylen);
-	lunatik_object_t *value = NULL;
 	luarcu_entry_t *entry;
 
 	rcu_read_lock();
-	entry = luarcu_lookup(_table, index, key, keylen);
-	if (entry != NULL) {
-		/* entry might be released after rcu_read_unlock */
-		value = entry->object; /* thus we need to store object pointer */
-		lunatik_getobject(value);
+	if ((entry = luarcu_lookup(_table, index, key, keylen)) == NULL)
+		value->type = LUA_TNIL;
+	else {
+		*value = entry->value;
+		if (lunatik_isuserdata(value))
+			lunatik_getobject(value->object);
 	}
 	rcu_read_unlock();
-	return value;
 }
-EXPORT_SYMBOL(luarcu_gettable);
+EXPORT_SYMBOL(luarcu_getvalue);
 
-int luarcu_settable(lunatik_object_t *table, const char *key, size_t keylen, lunatik_object_t *object)
+int luarcu_setvalue(lunatik_object_t *table, const char *key, size_t keylen, lunatik_value_t *value)
 {
 	int ret = 0;
 	luarcu_table_t *tab = (luarcu_table_t *)table->private;
@@ -171,8 +130,8 @@ int luarcu_settable(lunatik_object_t *table, const char *key, size_t keylen, lun
 	rcu_read_lock();
 	old = luarcu_lookup(tab, index, key, keylen);
 	rcu_read_unlock();
-	if (object) {
-		luarcu_entry_t *new = luarcu_newentry(key, keylen, object);
+	if (value->type != LUA_TNIL) {
+		luarcu_entry_t *new = luarcu_newentry(key, keylen, value);
 		if (new == NULL) {
 			ret = -ENOMEM;
 			goto unlock;
@@ -193,66 +152,43 @@ unlock:
 	lunatik_unlock(table);
 	return ret;
 }
-EXPORT_SYMBOL(luarcu_settable);
+EXPORT_SYMBOL(luarcu_setvalue);
 
 /***
-* Retrieves a value (a Lunatik object) from the RCU table.
-* This is the Lua `__index` metamethod, allowing table-like access `rcu_table[key]`.
-* Read operations are RCU-protected and lockless.
+* Retrieves a value from the table (RCU-protected, lockless).
 * @function __index
-* @tparam rcu_table self The RCU table instance.
-* @tparam string key The key to look up in the table.
-* @treturn lunatik_object The Lunatik object associated with the key, or `nil` if the key is not found.
-*   A new reference to the object is returned.
-* @usage
-*  local my_object = my_rcu_table["some_key"]
-*  if my_object then
-*    -- Use my_object
-*  end
+* @tparam string key
+* @treturn boolean|integer|object|nil
 */
 static int luarcu_index(lua_State *L)
 {
 	lunatik_object_t *table = lunatik_checkobject(L, 1);
 	size_t keylen;
 	const char *key = luaL_checklstring(L, 2, &keylen);
-	lunatik_object_t *value = luarcu_gettable(table, key, keylen);
+	lunatik_value_t value;
 
-	if (value == NULL)
-		lua_pushnil(L);
-	else {
-		lua_pushcfunction(L, luarcu_cloneobject);
-		lua_pushlightuserdata(L, value);
-		if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
-			lunatik_putobject(value);
-			lua_error(L);
-		}
-	}
+	luarcu_getvalue(table, key, keylen, &value);
+	lunatik_pushvalue(L, &value);
 	return 1; /* value */
 }
 
 /***
-* Sets or removes a value in the RCU table.
-* This is the Lua `__newindex` metamethod, allowing table-like assignment `rcu_table[key] = value`.
-* Write operations are synchronized.
+* Sets or removes a value in the table (serialized).
+* Assigning `nil` removes the entry.
 * @function __newindex
-* @tparam rcu_table self The RCU table instance.
-* @tparam string key The key to set or update.
-* @tparam lunatik_object|nil value The Lunatik object to associate with the key.
-*   If `nil`, the key-value pair is removed from the table.
-* @raise Error if memory allocation fails during new entry creation.
-* @usage
-*   local data_obj = data.new(5) -- Assuming 'data' module
-*   my_rcu_table["new_key"] = some_lunatik_object
-*   my_rcu_table["another_key"] = nil -- Removes 'another_key'
+* @tparam string key
+* @tparam boolean|integer|object|nil value
+* @raise Error on memory allocation failure.
 */
 static int luarcu_newindex(lua_State *L)
 {
 	lunatik_object_t *table = lunatik_checkobject(L, 1);
 	size_t keylen;
 	const char *key = luaL_checklstring(L, 2, &keylen);
-	lunatik_object_t *object = luarcu_checkoptnil(L, 3, lunatik_checkobject);
 
-	if (luarcu_settable(table, key, keylen, object) < 0)
+	lunatik_value_t value;
+	lunatik_checkvalue(L, 3, &value);
+	if (luarcu_setvalue(table, key, keylen, &value) < 0)
 		luaL_error(L, "not enough memory");
 	return 0;
 }
@@ -303,28 +239,11 @@ static inline int luarcu_map_call(lua_State *L, int cb, const char *key, lunatik
 }
 
 /***
-* Iterates over the RCU table and calls a callback for each key-value pair.
-* The iteration is RCU-protected. The order of iteration is not guaranteed.
-* For each entry, a new reference to the value (Lunatik object) is obtained
-* before calling the callback and released after the callback returns.
-*
+* Iterates over the table calling `callback(key, value)` for each entry.
+* Iteration is RCU-protected; order is not guaranteed.
 * @function map
-* @tparam rcu_table self The RCU table instance.
-* @tparam function callback A Lua function that will be called for each entry in the table.
-*   The callback receives two arguments:
-*
-*   1. `key` (string): The key of the current entry.
-*   2. `value` (lunatik_object): The Lunatik object associated with the key.
-*
-* @treturn nil
-* @raise Error if the callback function raises an error during its execution.
-* @usage
-*   -- Example: Iterating and printing content if values are 'data' objects
-*   my_rcu_table:map(function(k, v_obj)
-*     -- v_obj is the Lunatik object stored for the key.
-*     -- If it's a 'data' object (a common use case, see examples/shared.lua):
-*     print("Key:", k, "Content from data object:", v_obj:getstring(0))
-*   end)
+* @tparam function callback `function(key, value)`.
+* @raise Error if callback raises.
 */
 static int luarcu_map(lua_State *L)
 {
@@ -341,7 +260,7 @@ static int luarcu_map(lua_State *L)
 
 		strncpy(key, entry->key, LUARCU_MAXKEY);
 		key[LUARCU_MAXKEY - 1] = '\0';
-		lunatik_object_t *value = entry->object;
+		lunatik_object_t *value = entry->value.object;
 		lunatik_getobject(value);
 
 		rcu_read_unlock();
@@ -386,34 +305,13 @@ lunatik_object_t *luarcu_newtable(size_t size, bool sleep)
 EXPORT_SYMBOL(luarcu_newtable);
 
 /***
-* Creates a new RCU-synchronized hash table.
+* Creates a new RCU hash table.
 * @function table
-* @tparam[opt=1024] integer size Specifies the initial number of hash buckets (internal slots) for the table.
-*   This is **not** a hard limit on the number of entries the table can store.
-*   The provided `size` will be rounded up to the nearest power of two.
-*   Choosing an appropriate `size` involves a trade-off between memory usage and performance:
-*
-*   - more buckets (larger `size`): Consumes more memory for the table structure itself,
-*     even if many buckets remain empty. However, it reduces the probability of hash collisions,
-*     which can significantly speed up operations (lookups, insertions, deletions),
-*     especially when storing a large number of entries.
-*   - fewer buckets (smaller `size`): Uses less memory for the table's internal array.
-*     However, if the number of entries is high relative to the number of buckets,
-*     it increases the chance of hash collisions. This means more entries might end up
-*     in the same bucket, forming longer linked lists that need to be traversed,
-*     thereby slowing down operations.
-*
-*   **Guidance**: For optimal performance, aim for a `size` that is roughly in the order of,
-*   or somewhat larger than, the maximum number of entries you anticipate storing. This helps
-*   maintain a low average number of entries per bucket (a low "load factor," ideally close to 1).
-*   The table can hold more entries than its `size` (number of buckets), but performance
-*   will degrade as the load factor increases. The default is a general-purpose starting point
-*   suitable for many common use cases.
-* @treturn rcu_table A new RCU table object, or raises an error if memory allocation fails.
+* @tparam[opt=256] integer size Number of hash buckets (rounded up to power of two).
+* @treturn rcu_table
 * @usage
-*   local my_rcu_table = rcu.table() -- Default: 1024 buckets, good for moderate entries.
-*   local small_table = rcu.table(128) -- 128 buckets, for fewer expected entries.
-*   local large_table = rcu.table(8192) -- 8192 buckets, for many expected entries.
+*   local t = rcu.table()      -- 256 buckets (default)
+*   local t = rcu.table(8192)  -- 8192 buckets
 * @within rcu
 */
 static int luarcu_table(lua_State *L)
@@ -439,5 +337,5 @@ static void __exit luarcu_exit(void)
 module_init(luarcu_init);
 module_exit(luarcu_exit);
 MODULE_LICENSE("Dual MIT/GPL");
-MODULE_AUTHOR("Lourival Vieira Neto <lourival.neto@ring-0.io>");
+MODULE_AUTHOR("Lourival Vieira Neto <lourival.neto@ringzero.com.br>");
 

--- a/lib/luarcu.h
+++ b/lib/luarcu.h
@@ -9,8 +9,21 @@
 #define LUARCU_DEFAULT_SIZE	(256)
 
 lunatik_object_t *luarcu_newtable(size_t size, bool sleep);
-lunatik_object_t *luarcu_gettable(lunatik_object_t *table, const char *key, size_t keylen);
-int luarcu_settable(lunatik_object_t *table, const char *key, size_t keylen, lunatik_object_t *object);
+void luarcu_getvalue(lunatik_object_t *table, const char *key, size_t keylen, lunatik_value_t *value);
+int luarcu_setvalue(lunatik_object_t *table, const char *key, size_t keylen, lunatik_value_t *value);
+
+static inline lunatik_object_t *luarcu_getobject(lunatik_object_t *table, const char *key, size_t keylen)
+{
+	lunatik_value_t value;
+	luarcu_getvalue(table, key, keylen, &value);
+	return lunatik_isuserdata(&value) ? value.object : NULL;
+}
+
+static inline int luarcu_setobject(lunatik_object_t *table, const char *key, size_t keylen, lunatik_object_t *obj)
+{
+	lunatik_value_t value = {.type = LUA_TUSERDATA, .object = obj};
+	return luarcu_setvalue(table, key, keylen, &value);
+}
 
 #endif
 

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -98,7 +98,7 @@ static inline int luaxdp_checkruntimes(void)
 {
 	const char *key = "runtimes";
 	if (luaxdp_runtimes == NULL &&
-	   (luaxdp_runtimes = luarcu_gettable(lunatik_env, key, sizeof(key))) == NULL)
+	   (luaxdp_runtimes = luarcu_getobject(lunatik_env, key, sizeof(key))) == NULL)
 		return -1;
 	return 0;
 }
@@ -116,7 +116,7 @@ __bpf_kfunc int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *xdp_ctx
 	}
 
 	key[keylen] = '\0';
-	if ((runtime = luarcu_gettable(luaxdp_runtimes, key, keylen)) == NULL) {
+	if ((runtime = luarcu_getobject(luaxdp_runtimes, key, keylen)) == NULL) {
 		pr_err("couldn't find runtime '%s'\n", key);
 		goto out;
 	}

--- a/lib/luaxtable.c
+++ b/lib/luaxtable.c
@@ -157,7 +157,7 @@ static int luaxtable_##hook##_check(const struct xt_##hk##chk_param *par)	\
 {										\
 	int ret;								\
 	luaxtable_t *xtable;							\
-	lunatik_object_t *obj = luarcu_gettable(luaxtable_hooks.hook, par->hook->name, XT_EXTENSION_MAXNAMELEN);	\
+	lunatik_object_t *obj = luarcu_getobject(luaxtable_hooks.hook, par->hook->name, XT_EXTENSION_MAXNAMELEN);	\
 	if (obj == NULL) {							\
 		pr_err("could not find hook (%s)\n", par->hook->name);		\
 		return -EINVAL;							\
@@ -355,7 +355,7 @@ static int luaxtable_new##hook(lua_State *L) 				\
 	hook->checkentry = luaxtable_##hook##_check;			\
 	hook->destroy = luaxtable_##hook##_destroy;			\
 									\
-	if (luarcu_settable(luaxtable_hooks.hook, hook->name, XT_EXTENSION_MAXNAMELEN, object) != 0)	\
+	if (luarcu_setobject(luaxtable_hooks.hook, hook->name, XT_EXTENSION_MAXNAMELEN, object) != 0)	\
 		luaL_error(L, "unable to hook: %s\n", hook->name);	\
 									\
 	if (xt_register_##hook(hook) != 0)				\

--- a/lunatik.h
+++ b/lunatik.h
@@ -385,5 +385,7 @@ static inline void lunatik_unregisterobject(lua_State *L, lunatik_object_t *obje
 	lunatik_unregister(L, object); /* remove object, now it might be GC'ed */
 }
 
+#include "lunatik_val.h"
+
 #endif
 

--- a/lunatik_val.c
+++ b/lunatik_val.c
@@ -1,0 +1,60 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+#include "lunatik.h"
+
+void lunatik_checkvalue(lua_State *L, int ix, lunatik_value_t *value)
+{
+	value->type = lua_type(L, ix);
+	switch (value->type) {
+	case LUA_TNIL:
+		break;
+	case LUA_TBOOLEAN:
+		value->boolean = lua_toboolean(L, ix);
+		break;
+	case LUA_TNUMBER:
+		value->integer = lua_tointeger(L, ix);
+		break;
+	case LUA_TUSERDATA:
+		value->object = lunatik_checkobject(L, ix);
+		break;
+	default:
+		luaL_argerror(L, ix, "unsupported type");
+		break;
+	}
+}
+EXPORT_SYMBOL(lunatik_checkvalue);
+
+static int lunatik_doclone(lua_State *L)
+{
+	lunatik_object_t *object = (lunatik_object_t *)lua_touserdata(L, 1);
+	lunatik_cloneobject(L, object);
+	return 1;
+}
+
+void lunatik_pushvalue(lua_State *L, lunatik_value_t *value)
+{
+	switch (value->type) {
+	case LUA_TNIL:
+		lua_pushnil(L);
+		break;
+	case LUA_TBOOLEAN:
+		lua_pushboolean(L, value->boolean);
+		break;
+	case LUA_TNUMBER:
+		lua_pushinteger(L, value->integer);
+		break;
+	case LUA_TUSERDATA:
+		lua_pushcfunction(L, lunatik_doclone);
+		lua_pushlightuserdata(L, value->object);
+		if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
+			lunatik_putobject(value->object);
+			lua_error(L);
+		}
+		break;
+	}
+}
+EXPORT_SYMBOL(lunatik_pushvalue);
+

--- a/lunatik_val.h
+++ b/lunatik_val.h
@@ -1,0 +1,24 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+#ifndef lunatik_val_h
+#define lunatik_val_h
+
+typedef struct lunatik_value_s {
+	int type;
+	union {
+		int boolean;
+		lua_Integer integer;
+		lunatik_object_t *object;
+	};
+} lunatik_value_t;
+
+#define lunatik_isuserdata(v)	((v)->type == LUA_TUSERDATA)
+
+void lunatik_checkvalue(lua_State *L, int ix, lunatik_value_t *value);
+void lunatik_pushvalue(lua_State *L, lunatik_value_t *value);
+
+#endif
+


### PR DESCRIPTION
Introduce a generic tagged-union value container (lunatik_value_t) supporting nil, boolean, integer, and userdata types, with lunatik_checkvalue/lunatik_pushvalue helpers. Refactor luarcu to store lunatik_value_t in entries instead of raw lunatik_object_t pointers, renaming set/gettable to set/getvalue. Add convenience inlines luarcu_setobject/luarcu_getobject and update all callers (luaxdp, luaxtable).