### PR TITLE
prevent GC finalizers from running under spinlock in lunatik_monitor

### DIFF
--- a/lunatik_obj.c
+++ b/lunatik_obj.c
@@ -158,9 +158,11 @@ static int lunatik_monitor(lua_State *L)
 	lua_pushvalue(L, lua_upvalueindex(1)); /* method */
 	lua_insert(L, 1); /* stack: method, object, args */
 
+	lua_gc(L, LUA_GCSTOP);
 	lunatik_lock(object);
 	ret = lua_pcall(L, n, LUA_MULTRET, 0);
 	lunatik_unlock(object);
+	lua_gc(L, LUA_GCRESTART);
 
 	if (ret != LUA_OK) {
 		const char *method = lua_tostring(L, lua_upvalueindex(2));


### PR DESCRIPTION
Shared object methods are wrapped by lunatik_monitor(), which holds a spinlock during lua_pcall(). Any Lua allocation inside that call can trigger an incremental GC step, which may finalize objects whose release callbacks sleep (e.g. packet_release() calling synchronize_net()), causing "scheduling while atomic" crashes.

Stop the GC before acquiring the lock and restart it after releasing, so finalizers only run outside atomic context.