### PR TITLE
luathread: error on thread.run during module load

### DIFF
--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -216,6 +216,7 @@ static const lunatik_class_t luathread_class = {
 */
 static int luathread_run(lua_State *L)
 {
+	luaL_argcheck(L, lunatik_isready(L), 1, "not allowed during module load");
 	lunatik_object_t *runtime = lunatik_checkobject(L, 1);
 	luaL_argcheck(L, runtime->sleep, 1, "cannot use non-sleepable runtime in this context");
 	const char *name = luaL_checkstring(L, 2);


### PR DESCRIPTION
Calling thread.run() from a script's top-level code (during module load) causes a hang: kthread_run() blocks in wait_for_completion() before the scheduler can properly service it.

lunatik_isready() detects this via the registry entry set by lunatik_setready() at the end of lunatik_runscript().