### PR TITLE
lunatik: zero object private memory on allocation

### DIFF
--- a/lunatik.h
+++ b/lunatik.h
@@ -137,6 +137,7 @@ static inline void *lunatik_checknull(lua_State *L, void *ptr)
 }
 
 #define lunatik_checkalloc(L, s)	(lunatik_checknull((L), lunatik_malloc((L), (s))))
+#define lunatik_checkzalloc(L, s)	(memset(lunatik_checkalloc((L), (s)), 0, (s)))
 
 void lunatik_pusherrname(lua_State *L, int err);
 

--- a/lunatik_obj.c
+++ b/lunatik_obj.c
@@ -29,7 +29,7 @@ lunatik_object_t *lunatik_newobject(lua_State *L, const lunatik_class_t *class, 
 	lunatik_setobject(object, class, class->sleep, shared);
 	lunatik_setclass(L, class, shared);
 
-	object->private = class->pointer ? NULL : lunatik_checkalloc(L, size);
+	object->private = class->pointer ? NULL : lunatik_checkzalloc(L, size);
 
 	*pobject = object;
 	return object;
@@ -49,7 +49,7 @@ lunatik_object_t *lunatik_createobject(const lunatik_class_t *class, size_t size
 		return NULL;
 
 	lunatik_setobject(object, class, sleep, shared);
-	if ((object->private = kmalloc(size, gfp)) == NULL) {
+	if ((object->private = kzalloc(size, gfp)) == NULL) {
 		lunatik_putobject(object);
 		return NULL;
 	}


### PR DESCRIPTION
Callers no longer need to zero their private structs manually.