### PR TITLE
lunatik: add lunatik_assert for internal state checks

### DIFF
--- a/lib/luaskb.c
+++ b/lib/luaskb.c
@@ -28,9 +28,9 @@ LUNATIK_PRIVATECHECKER(luaskb_check, luaskb_t *,
 
 /* FRAGLIST GSO skbs hold segments in frag_list; skb_copy refuses to copy
  * them (ambiguous semantics: copy the container or the segments?). */
-#define luaskb_checkfraglist(L, lskb, ix)				\
-	luaL_argcheck(L, !(skb_shinfo((lskb)->skb)->gso_type &		\
-		SKB_GSO_FRAGLIST), (ix), "FRAGLIST GSO skbs cannot be copied")
+#define luaskb_checkfraglist(L, lskb)					\
+	lunatik_assert(L, !(skb_shinfo((lskb)->skb)->gso_type &		\
+		SKB_GSO_FRAGLIST), "FRAGLIST GSO skbs cannot be copied")
 
 #define luaskb_csum4(skb, iph, iphlen)					\
 	csum_tcpudp_magic((iph)->saddr, (iph)->daddr,			\
@@ -79,8 +79,8 @@ static int luaskb_vlan(lua_State *L)
 	return 1;
 }
 
-#define luaskb_checklinearize(L, lskb, ix)	\
-	luaL_argcheck(L, skb_linearize((lskb)->skb) == 0, (ix), "skb linearization failed")
+#define luaskb_checklinearize(L, lskb)	\
+	lunatik_assert(L, skb_linearize((lskb)->skb) == 0, "skb linearization failed")
 
 /***
 * @function data
@@ -91,7 +91,7 @@ static int luaskb_vlan(lua_State *L)
 static int luaskb_data(lua_State *L)
 {
 	luaskb_t *lskb = luaskb_check(L, 1);
-	luaskb_checklinearize(L, lskb, 1);
+	luaskb_checklinearize(L, lskb);
 
 	lunatik_object_t *data = lskb->data;
 	struct sk_buff *skb = lskb->skb;
@@ -237,8 +237,8 @@ static const lunatik_class_t luaskb_class = {
 static int luaskb_copy(lua_State *L)
 {
 	luaskb_t *lskb = luaskb_check(L, 1);
-	luaskb_checkfraglist(L, lskb, 1);
-	luaskb_checklinearize(L, lskb, 1);
+	luaskb_checkfraglist(L, lskb);
+	luaskb_checklinearize(L, lskb);
 
 	lunatik_object_t *object = lunatik_newobject(L, &luaskb_class, sizeof(luaskb_t), LUNATIK_OPT_NONE);
 	luaskb_t *copy = (luaskb_t *)object->private;

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -180,7 +180,7 @@ static const lunatik_class_t luathread_class = {
 */
 static int luathread_run(lua_State *L)
 {
-	luaL_argcheck(L, lunatik_isready(L), 1, "not allowed during module load");
+	lunatik_assert(L, lunatik_isready(L), "not allowed during module load");
 	lunatik_object_t *runtime = lunatik_checkobject(L, 1);
 	luaL_argcheck(L, !lunatik_issoftirq(runtime->opt), 1, "SOFTIRQ runtime cannot spawn threads");
 	const char *name = luaL_checkstring(L, 2);

--- a/lunatik.h
+++ b/lunatik.h
@@ -139,6 +139,12 @@ static inline void *lunatik_realloc(lua_State *L, void *ptr, size_t size)
 
 #define lunatik_enomem(L)	luaL_error((L), "not enough memory")
 
+static inline void lunatik_assert(lua_State *L, bool cond, const char *msg)
+{
+	if (!cond)
+		luaL_error(L, msg);
+}
+
 static inline void *lunatik_checknull(lua_State *L, void *ptr)
 {
 	if (ptr == NULL)


### PR DESCRIPTION
Replace luaL_argcheck(L, cond, 1, msg) used for internal object state checks with a new lunatik_assert(L, cond, msg) macro that calls luaL_error directly, avoiding the misleading "bad argument #1" prefix.

Applied to: skb not-set, FRAGLIST GSO, linearization failure, forward preconditions in luaskb; read-only check in luadata; module-load and softirq-context guards in luathread.