### PR TITLE
luarcu: add string support using external strings and kref

### DIFF
--- a/lib/luarcu.c
+++ b/lib/luarcu.c
@@ -89,6 +89,8 @@ static luarcu_entry_t *luarcu_newentry(const char *key, size_t keylen, lunatik_v
 	entry->value = *value;
 	if (lunatik_isuserdata(value))
 		lunatik_getobject(value->object);
+	else if (lunatik_isstring(value))
+		lunatik_getstring(value->string);
 	return entry;
 }
 
@@ -96,6 +98,8 @@ static inline void luarcu_free(luarcu_entry_t *entry)
 {
 	if (lunatik_isuserdata(&entry->value))
 		lunatik_putobject(entry->value.object);
+	else if (lunatik_isstring(&entry->value))
+		lunatik_putstring(entry->value.string);
 	kfree_rcu(entry, rcu);
 }
 
@@ -114,6 +118,8 @@ void luarcu_getvalue(lunatik_object_t *table, const char *key, size_t keylen, lu
 		*value = entry->value;
 		if (lunatik_isuserdata(value))
 			lunatik_getobject(value->object);
+		else if (lunatik_isstring(value))
+			lunatik_getstring(value->string);
 	}
 	rcu_read_unlock();
 }
@@ -169,6 +175,7 @@ static int luarcu_index(lua_State *L)
 
 	luarcu_getvalue(table, key, keylen, &value);
 	lunatik_pushvalue(L, &value);
+	lunatik_putvalue(&value);
 	return 1; /* value */
 }
 
@@ -188,7 +195,9 @@ static int luarcu_newindex(lua_State *L)
 
 	lunatik_value_t value;
 	lunatik_checkvalue(L, 3, &value);
-	if (luarcu_setvalue(table, key, keylen, &value) < 0)
+	int ret = luarcu_setvalue(table, key, keylen, &value);
+	lunatik_putvalue(&value);
+	if (ret < 0)
 		luaL_error(L, "not enough memory");
 	return 0;
 }
@@ -215,20 +224,23 @@ static inline void luarcu_inittable(luarcu_table_t *table, size_t size)
 static int luarcu_map_handle(lua_State *L)
 {
 	const char *key = (const char *)lua_touserdata(L, 2);
-	lunatik_object_t *value = (lunatik_object_t *)lua_touserdata(L, 3);
+	lunatik_value_t *value = (lunatik_value_t *)lua_touserdata(L, 3);
 
 	BUG_ON(!key || !value);
 
 	lua_pop(L, 2); /* key, value */
 
 	lua_pushstring(L, key);
-	lunatik_pushobject(L, value);
+	if (lunatik_isuserdata(value))
+		lunatik_pushobject(L, value->object);
+	else
+		lunatik_pushvalue(L, value);
 	lua_call(L, 2, 0);
 
 	return 0;
 }
 
-static inline int luarcu_map_call(lua_State *L, int cb, const char *key, lunatik_object_t *value)
+static inline int luarcu_map_call(lua_State *L, int cb, const char *key, lunatik_value_t *value)
 {
 	lua_pushcfunction(L, luarcu_map_handle);
 	lua_pushvalue(L, cb);
@@ -257,15 +269,22 @@ static int luarcu_map(lua_State *L)
 	rcu_read_lock();
 	luarcu_foreach(table, bucket, n, entry) {
 		char key[LUARCU_MAXKEY];
+		lunatik_value_t value = entry->value;
 
 		strncpy(key, entry->key, LUARCU_MAXKEY);
 		key[LUARCU_MAXKEY - 1] = '\0';
-		lunatik_object_t *value = entry->value.object;
-		lunatik_getobject(value);
+
+		if (lunatik_isuserdata(&value))
+			lunatik_getobject(value.object);
+		else if (lunatik_isstring(&value))
+			lunatik_getstring(value.string);
 
 		rcu_read_unlock();
-		int ret = luarcu_map_call(L, 1, key, value);
-		lunatik_putobject(value);
+		int ret = luarcu_map_call(L, 1, key, &value);
+		if (lunatik_isuserdata(&value))
+			lunatik_putobject(value.object);
+		else if (lunatik_isstring(&value))
+			lunatik_putstring(value.string);
 		if (ret != LUA_OK)
 			lua_error(L);
 		rcu_read_lock();

--- a/lib/luarcu.c
+++ b/lib/luarcu.c
@@ -87,19 +87,13 @@ static luarcu_entry_t *luarcu_newentry(const char *key, size_t keylen, lunatik_v
 	strncpy(entry->key, key, keylen);
 	entry->key[keylen] = '\0';
 	entry->value = *value;
-	if (lunatik_isuserdata(value))
-		lunatik_getobject(value->object);
-	else if (lunatik_isstring(value))
-		lunatik_getstring(value->string);
+	lunatik_holdvalue(value);
 	return entry;
 }
 
 static inline void luarcu_free(luarcu_entry_t *entry)
 {
-	if (lunatik_isuserdata(&entry->value))
-		lunatik_putobject(entry->value.object);
-	else if (lunatik_isstring(&entry->value))
-		lunatik_putstring(entry->value.string);
+	lunatik_dropvalue(&entry->value);
 	kfree_rcu(entry, rcu);
 }
 
@@ -116,10 +110,7 @@ void luarcu_getvalue(lunatik_object_t *table, const char *key, size_t keylen, lu
 		value->type = LUA_TNIL;
 	else {
 		*value = entry->value;
-		if (lunatik_isuserdata(value))
-			lunatik_getobject(value->object);
-		else if (lunatik_isstring(value))
-			lunatik_getstring(value->string);
+		lunatik_holdvalue(value);
 	}
 	rcu_read_unlock();
 }
@@ -274,17 +265,11 @@ static int luarcu_map(lua_State *L)
 		strncpy(key, entry->key, LUARCU_MAXKEY);
 		key[LUARCU_MAXKEY - 1] = '\0';
 
-		if (lunatik_isuserdata(&value))
-			lunatik_getobject(value.object);
-		else if (lunatik_isstring(&value))
-			lunatik_getstring(value.string);
+		lunatik_holdvalue(&value);
 
 		rcu_read_unlock();
 		int ret = luarcu_map_call(L, 1, key, &value);
-		if (lunatik_isuserdata(&value))
-			lunatik_putobject(value.object);
-		else if (lunatik_isstring(&value))
-			lunatik_putstring(value.string);
+		lunatik_dropvalue(&value);
 		if (ret != LUA_OK)
 			lua_error(L);
 		rcu_read_lock();

--- a/lunatik_val.c
+++ b/lunatik_val.c
@@ -7,25 +7,23 @@
 
 void lunatik_freestring(struct kref *kref)
 {
-	lunatik_free(container_of(kref, lunatik_string_t, kref));
+	lunatik_string_t *str = container_of(kref, lunatik_string_t, kref);
+	lunatik_free(str->data);
+	lunatik_free(str);
 }
 EXPORT_SYMBOL(lunatik_freestring);
 
-static void *lunatik_string_alloc(void *ud, void *ptr, size_t osize, size_t nsize)
-{
-	if (nsize == 0)
-		lunatik_putstring((lunatik_string_t *)ud);
-	return NULL;
-}
-
 static inline lunatik_string_t *lunatik_newstring(lua_State *L, int ix)
 {
-	size_t len;
-	const char *s = lua_tolstring(L, ix, &len);
-	lunatik_string_t *str = lunatik_checkalloc(L, sizeof(*str) + len + 1);
+	const char *s = luaL_checkstring(L, ix);
+	lunatik_string_t *str = lunatik_checkalloc(L, sizeof(*str));
+	str->data = lunatik_malloc(L, strlen(s) + 1);
+	if (unlikely(!str->data)) {
+		lunatik_free(str);
+		lunatik_enomem(L);
+	}
 	kref_init(&str->kref);
-	str->len = len;
-	memcpy(str->data, s, len + 1);
+	strncpy(str->data, s, strlen(s) + 1);
 	return str;
 }
 
@@ -77,8 +75,14 @@ void lunatik_pushvalue(lua_State *L, lunatik_value_t *value)
 		break;
 	case LUA_TSTRING: {
 		lunatik_string_t *s = value->string;
-		lunatik_getstring(s); /* for Lua's GC; released via lunatik_string_alloc */
-		lua_pushexternalstring(L, s->data, s->len, lunatik_string_alloc, s);
+		size_t len = strlen(s->data);
+		char *buf = lunatik_malloc(L, len + 1);
+		if (unlikely(!buf)) {
+			lunatik_putstring(s);
+			lunatik_enomem(L);
+		}
+		strncpy(buf, s->data, len + 1);
+		lunatik_pushstring(L, buf, len);
 		break;
 	}
 	case LUA_TUSERDATA:

--- a/lunatik_val.c
+++ b/lunatik_val.c
@@ -7,7 +7,7 @@
 
 void lunatik_freestring(struct kref *kref)
 {
-	kfree(container_of(kref, lunatik_string_t, kref));
+	lunatik_free(container_of(kref, lunatik_string_t, kref));
 }
 EXPORT_SYMBOL(lunatik_freestring);
 
@@ -16,6 +16,17 @@ static void *lunatik_string_alloc(void *ud, void *ptr, size_t osize, size_t nsiz
 	if (nsize == 0)
 		lunatik_putstring((lunatik_string_t *)ud);
 	return NULL;
+}
+
+static inline lunatik_string_t *lunatik_newstring(lua_State *L, int ix)
+{
+	size_t len;
+	const char *s = lua_tolstring(L, ix, &len);
+	lunatik_string_t *str = lunatik_checkalloc(L, sizeof(*str) + len + 1);
+	kref_init(&str->kref);
+	str->len = len;
+	memcpy(str->data, s, len + 1);
+	return str;
 }
 
 void lunatik_checkvalue(lua_State *L, int ix, lunatik_value_t *value)
@@ -30,18 +41,9 @@ void lunatik_checkvalue(lua_State *L, int ix, lunatik_value_t *value)
 	case LUA_TNUMBER:
 		value->integer = lua_tointeger(L, ix);
 		break;
-	case LUA_TSTRING: {
-		size_t len;
-		const char *s = lua_tolstring(L, ix, &len);
-		lunatik_string_t *str = kmalloc(sizeof(*str) + len + 1, GFP_ATOMIC);
-		if (unlikely(!str))
-			lunatik_enomem(L);
-		kref_init(&str->kref);
-		str->len = len;
-		memcpy(str->data, s, len + 1);
-		value->string = str;
+	case LUA_TSTRING:
+		value->string = lunatik_newstring(L, ix);
 		break;
-	}
 	case LUA_TUSERDATA:
 		value->object = lunatik_checkobject(L, ix);
 		if (lunatik_issingle(value->object->opt))

--- a/lunatik_val.c
+++ b/lunatik_val.c
@@ -35,7 +35,7 @@ void lunatik_checkvalue(lua_State *L, int ix, lunatik_value_t *value)
 		const char *s = lua_tolstring(L, ix, &len);
 		lunatik_string_t *str = kmalloc(sizeof(*str) + len + 1, GFP_ATOMIC);
 		if (unlikely(!str))
-			luaL_argerror(L, ix, "not enough memory");
+			lunatik_enomem(L);
 		kref_init(&str->kref);
 		str->len = len;
 		memcpy(str->data, s, len + 1);

--- a/lunatik_val.c
+++ b/lunatik_val.c
@@ -5,6 +5,19 @@
 
 #include "lunatik.h"
 
+void lunatik_freestring(struct kref *kref)
+{
+	kfree(container_of(kref, lunatik_string_t, kref));
+}
+EXPORT_SYMBOL(lunatik_freestring);
+
+static void *lunatik_string_alloc(void *ud, void *ptr, size_t osize, size_t nsize)
+{
+	if (nsize == 0)
+		lunatik_putstring((lunatik_string_t *)ud);
+	return NULL;
+}
+
 void lunatik_checkvalue(lua_State *L, int ix, lunatik_value_t *value)
 {
 	value->type = lua_type(L, ix);
@@ -17,6 +30,18 @@ void lunatik_checkvalue(lua_State *L, int ix, lunatik_value_t *value)
 	case LUA_TNUMBER:
 		value->integer = lua_tointeger(L, ix);
 		break;
+	case LUA_TSTRING: {
+		size_t len;
+		const char *s = lua_tolstring(L, ix, &len);
+		lunatik_string_t *str = kmalloc(sizeof(*str) + len + 1, GFP_ATOMIC);
+		if (unlikely(!str))
+			luaL_argerror(L, ix, "not enough memory");
+		kref_init(&str->kref);
+		str->len = len;
+		memcpy(str->data, s, len + 1);
+		value->string = str;
+		break;
+	}
 	case LUA_TUSERDATA:
 		value->object = lunatik_checkobject(L, ix);
 		if (lunatik_issingle(value->object->opt))
@@ -48,6 +73,12 @@ void lunatik_pushvalue(lua_State *L, lunatik_value_t *value)
 	case LUA_TNUMBER:
 		lua_pushinteger(L, value->integer);
 		break;
+	case LUA_TSTRING: {
+		lunatik_string_t *s = value->string;
+		lunatik_getstring(s); /* for Lua's GC; released via lunatik_string_alloc */
+		lua_pushexternalstring(L, s->data, s->len, lunatik_string_alloc, s);
+		break;
+	}
 	case LUA_TUSERDATA:
 		lua_pushcfunction(L, lunatik_doclone);
 		lua_pushlightuserdata(L, value->object);

--- a/lunatik_val.h
+++ b/lunatik_val.h
@@ -29,6 +29,22 @@ void lunatik_freestring(struct kref *kref);
 #define lunatik_getstring(s)	kref_get(&(s)->kref)
 #define lunatik_putstring(s)	kref_put(&(s)->kref, lunatik_freestring)
 
+static inline void lunatik_holdvalue(lunatik_value_t *value)
+{
+	if (lunatik_isuserdata(value))
+		lunatik_getobject(value->object);
+	else if (lunatik_isstring(value))
+		lunatik_getstring(value->string);
+}
+
+static inline void lunatik_dropvalue(lunatik_value_t *value)
+{
+	if (lunatik_isuserdata(value))
+		lunatik_putobject(value->object);
+	else if (lunatik_isstring(value))
+		lunatik_putstring(value->string);
+}
+
 /* release value's reference after lunatik_pushvalue (strings only; objects transfer their ref) */
 static inline void lunatik_putvalue(lunatik_value_t *value)
 {

--- a/lunatik_val.h
+++ b/lunatik_val.h
@@ -8,8 +8,7 @@
 
 typedef struct lunatik_string_s {
 	struct kref kref;
-	size_t len;
-	char data[];
+	char *data;
 } lunatik_string_t;
 
 typedef struct lunatik_value_s {

--- a/lunatik_val.h
+++ b/lunatik_val.h
@@ -6,16 +6,35 @@
 #ifndef lunatik_val_h
 #define lunatik_val_h
 
+typedef struct lunatik_string_s {
+	struct kref kref;
+	size_t len;
+	char data[];
+} lunatik_string_t;
+
 typedef struct lunatik_value_s {
 	int type;
 	union {
 		int boolean;
 		lua_Integer integer;
 		lunatik_object_t *object;
+		lunatik_string_t *string;
 	};
 } lunatik_value_t;
 
 #define lunatik_isuserdata(v)	((v)->type == LUA_TUSERDATA)
+#define lunatik_isstring(v)	((v)->type == LUA_TSTRING)
+
+void lunatik_freestring(struct kref *kref);
+#define lunatik_getstring(s)	kref_get(&(s)->kref)
+#define lunatik_putstring(s)	kref_put(&(s)->kref, lunatik_freestring)
+
+/* release value's reference after lunatik_pushvalue (strings only; objects transfer their ref) */
+static inline void lunatik_putvalue(lunatik_value_t *value)
+{
+	if (lunatik_isstring(value))
+		lunatik_putstring(value->string);
+}
 
 void lunatik_checkvalue(lua_State *L, int ix, lunatik_value_t *value);
 void lunatik_pushvalue(lua_State *L, lunatik_value_t *value);


### PR DESCRIPTION
- Add lunatik_string_t (kref + len + flexible char data[]) to lunatik_val.h
- Extend lunatik_value_t union with lunatik_string_t *string member
- lunatik_checkvalue: handle LUA_TSTRING by kmalloc'ing a lunatik_string_t, copying the string data out of Lua's GC reach, and kref_init'ing it
- lunatik_pushvalue: handle LUA_TSTRING via lua_pushexternalstring with a custom alloc callback (lunatik_string_alloc) that kref_put's on GC; kref_get is called before push so Lua's GC holds one reference
- Add lunatik_putvalue to release the caller's string reference after lunatik_pushvalue (no-op for objects, which transfer their ref)
- luarcu_newentry/luarcu_free/luarcu_getvalue: mirror existing object kref_get/kref_put pattern for string values
- luarcu_index: call lunatik_putvalue to release luarcu_getvalue's kref
- luarcu_newindex: save ret before releasing string ref via lunatik_putvalue
- luarcu_map: generalize to lunatik_value_t, handle string kref alongside existing object handling; refactor map_handle/map_call accordingly