### PR TITLE
lunatik: add IRQ runtime context

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>]
 * `status`: show which Lunatik kernel modules are currently loaded
 * `test [suite]`: run installed test suites (see [Testing](#testing))
 * `list`: show which runtime environments are currently running
-* `run [softirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in atomic context (netfilter, XDP)
+* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes)
 * `spawn`: create a new runtime environment and spawn a thread to run the script `/lib/modules/lua/<script>.lua`
 * `stop`: stop the runtime environment created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_

--- a/doc/capi.md
+++ b/doc/capi.md
@@ -23,9 +23,13 @@ Describes a Lunatik object class.
 - `opt`: bitmask of `LUNATIK_OPT_*` flags controlling class behaviour. Flags are inherited by
   every instance via `object->opt = opt | class->opt` (see `lunatik_newobject`). Flags differ
   in whether they act as **constraints** or **capabilities**:
-  - `LUNATIK_OPT_SOFTIRQ` *(constraint)*: all instances use a spinlock and `GFP_ATOMIC`; absence
-    means mutex and `GFP_KERNEL`. Because this flag is always inherited, a SOFTIRQ class can never
-    produce a non-SOFTIRQ instance.
+  - `LUNATIK_OPT_SOFTIRQ` *(constraint)*: all instances use a spinlock with bottom-half disabling
+    (`spin_lock_bh`) and `GFP_ATOMIC`; absence means mutex and `GFP_KERNEL`. Use for classes whose
+    handlers fire in softirq context (netfilter, XDP). Because this flag is always inherited, a
+    SOFTIRQ class can never produce a non-SOFTIRQ instance.
+  - `LUNATIK_OPT_HARDIRQ` *(constraint)*: like `SOFTIRQ` but uses `spin_lock_irqsave`, which
+    disables hardware interrupts. Required for classes whose handlers fire in hardirq context
+    (e.g. kprobes).
   - `LUNATIK_OPT_MONITOR` *(capability)*: the class supports a monitored metatable that wraps Lua
     method calls with the object lock, enabling safe concurrent access from multiple runtimes.
     Inherited by default but cancelled when an instance is created with `LUNATIK_OPT_SINGLE`.
@@ -188,6 +192,16 @@ Returns `true` if the script associated with `L` has finished loading (i.e., the
 chunk has returned). Use this to guard operations that must not run during module
 initialization — for example, spawning a kernel thread from a `runner.spawn` callback.
 
+### lunatik\_checkruntime
+```C
+lunatik_object_t *lunatik_checkruntime(lua_State *L, lunatik_opt_t opt);
+```
+Returns the runtime associated with `L` and raises a Lua error if its context does not match
+`opt`. Context is determined by the SOFTIRQ/HARDIRQ bits: a SOFTIRQ class must run in a
+`softirq` runtime, a HARDIRQ class in a `hardirq` runtime, and a process-context class in a
+process runtime. Typically called from `lunatik_new*` functions to enforce that a class is
+only instantiated in a compatible runtime.
+
 ---
 
 ## Object Lifecycle
@@ -200,7 +214,7 @@ _lunatik\_newobject()_ allocates a new Lunatik object and pushes a userdata
 containing a pointer to the object onto the Lua stack.
 
 `object->opt` is computed as `opt | class->opt`: all class flags are inherited by the instance.
-`opt` may add flags on top (e.g. `LUNATIK_OPT_SOFTIRQ` for a non-sleepable runtime instance).
+`opt` may add flags on top (e.g. `LUNATIK_OPT_SOFTIRQ` or `LUNATIK_OPT_HARDIRQ` for a non-sleepable runtime instance).
 
 - Pass `LUNATIK_OPT_MONITOR` to wrap method calls with the object lock, enabling safe concurrent
   access from multiple runtimes.

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -182,7 +182,7 @@ static int luathread_run(lua_State *L)
 {
 	luaL_argcheck(L, lunatik_isready(L), 1, "not allowed during module load");
 	lunatik_object_t *runtime = lunatik_checkobject(L, 1);
-	luaL_argcheck(L, !lunatik_issoftirq(runtime->opt), 1, "SOFTIRQ runtime cannot spawn threads");
+	luaL_argcheck(L, !lunatik_isirq(runtime->opt), 1, "IRQ runtime cannot spawn threads");
 	const char *name = luaL_checkstring(L, 2);
 	lunatik_object_t *object = luathread_new(L);
 	luathread_t *thread = object->private;

--- a/lunatik.h
+++ b/lunatik.h
@@ -18,33 +18,39 @@
 #define LUNATIK_VERSION	"Lunatik 4.2"
 
 typedef u8 __bitwise lunatik_opt_t;
-#define LUNATIK_OPT_SOFTIRQ	((__force lunatik_opt_t)(1U << 0))
-#define LUNATIK_OPT_MONITOR	((__force lunatik_opt_t)(1U << 1))
-#define LUNATIK_OPT_SINGLE	((__force lunatik_opt_t)(1U << 2))
-#define LUNATIK_OPT_EXTERNAL	((__force lunatik_opt_t)(1U << 3))
+#define LUNATIK_OPT_IRQ		((__force lunatik_opt_t)(1U << 0))
+#define LUNATIK_OPT_SOFTIRQ	(LUNATIK_OPT_IRQ | ((__force lunatik_opt_t)(1U << 1))) /* netfilter, XDP */
+#define LUNATIK_OPT_HARDIRQ	(LUNATIK_OPT_IRQ | ((__force lunatik_opt_t)(1U << 2))) /* kprobes */
+#define LUNATIK_OPT_MONITOR	((__force lunatik_opt_t)(1U << 3))
+#define LUNATIK_OPT_SINGLE	((__force lunatik_opt_t)(1U << 4))
+#define LUNATIK_OPT_EXTERNAL	((__force lunatik_opt_t)(1U << 5))
 #define LUNATIK_OPT_NONE	((__force lunatik_opt_t)0)
 
-#define lunatik_issoftirq(opt)		((opt) & LUNATIK_OPT_SOFTIRQ)
+#define lunatik_isirq(opt)		((opt) & LUNATIK_OPT_IRQ)
+#define lunatik_issoftirq(opt)		((opt) & ((__force lunatik_opt_t)(1U << 1)))
+#define lunatik_ishardirq(opt)		((opt) & ((__force lunatik_opt_t)(1U << 2)))
 #define lunatik_ismonitor(opt)		((opt) & LUNATIK_OPT_MONITOR)
 #define lunatik_issingle(opt)		((opt) & LUNATIK_OPT_SINGLE)
 #define lunatik_isexternal(opt)		((opt) & LUNATIK_OPT_EXTERNAL)
 
-#define lunatik_locker(o, mutex_op, spin_op)	\
-do {						\
-	if (!lunatik_issoftirq((o)->opt))	\
-		mutex_op(&(o)->mutex);		\
-	else					\
-		spin_op(&(o)->spin);		\
+#define lunatik_locker(o, mutex_op, softirq_op, hardirq_op, ...)	\
+do {									\
+	if (!lunatik_isirq((o)->opt))					\
+		mutex_op(&(o)->mutex);					\
+	else if (lunatik_ishardirq((o)->opt))				\
+		hardirq_op(&(o)->spin, ##__VA_ARGS__);			\
+	else								\
+		softirq_op(&(o)->spin);					\
 } while (0)
 
-#define lunatik_newlock(o)	lunatik_locker((o), mutex_init, spin_lock_init);
-#define lunatik_freelock(o)	lunatik_locker((o), mutex_destroy, (void));
-#define lunatik_lock(o)		lunatik_locker((o), mutex_lock, spin_lock_bh)
-#define lunatik_unlock(o)	lunatik_locker((o), mutex_unlock, spin_unlock_bh)
+#define lunatik_newlock(o)   lunatik_locker((o), mutex_init, spin_lock_init, spin_lock_init);
+#define lunatik_freelock(o)  lunatik_locker((o), mutex_destroy, (void), (void));
+#define lunatik_lock(o)      lunatik_locker((o), mutex_lock, spin_lock_bh, spin_lock_irqsave, (o)->flags)
+#define lunatik_unlock(o)    lunatik_locker((o), mutex_unlock, spin_unlock_bh, spin_unlock_irqrestore, (o)->flags)
 
 #define lunatik_toruntime(L)	(*(lunatik_object_t **)lua_getextraspace(L))
 
-#define lunatik_cannotsleep(L, s)	((s) && lunatik_issoftirq(lunatik_toruntime(L)->opt))
+#define lunatik_cannotsleep(L, s)	((s) && lunatik_isirq(lunatik_toruntime(L)->opt))
 #define lunatik_getstate(runtime)	((lua_State *)runtime->private)
 
 static inline bool lunatik_isready(lua_State *L)
@@ -101,14 +107,20 @@ typedef struct lunatik_object_s {
 	};
 	lunatik_opt_t opt;
 	gfp_t gfp;
+	unsigned long flags;
 } lunatik_object_t;
 
 extern lunatik_object_t *lunatik_env;
 
 static inline int lunatik_trylock(lunatik_object_t *object)
 {
-	return unlikely(lunatik_ismonitor(object->opt)) ?
-		(lunatik_issoftirq(object->opt) ? spin_trylock(&object->spin) : mutex_trylock(&object->mutex)) : 1;
+	if (likely(!lunatik_ismonitor(object->opt)))
+		return 1;
+	if (lunatik_issoftirq(object->opt))
+		return spin_trylock(&object->spin);
+	if (lunatik_isirq(object->opt))
+		return spin_trylock_irqsave(&object->spin, object->flags);
+	return mutex_trylock(&object->mutex);
 }
 
 int lunatik_runtime(lunatik_object_t **pruntime, const char *script, lunatik_opt_t opt);
@@ -183,10 +195,12 @@ static inline void lunatik_checkfield(lua_State *L, int idx, const char *field, 
 #define LUNATIK_ERR_CONTEXT	"process-context class in interrupt-context runtime"
 #define LUNATIK_ERR_RUNTIME	"runtime context mismatch"
 
+#define lunatik_context(opt)	((opt) & (LUNATIK_OPT_SOFTIRQ | LUNATIK_OPT_HARDIRQ))
+
 static inline lunatik_object_t *lunatik_checkruntime(lua_State *L, lunatik_opt_t opt)
 {
 	lunatik_object_t *runtime = lunatik_toruntime(L);
-	if (lunatik_issoftirq(runtime->opt) != lunatik_issoftirq(opt))
+	if (lunatik_context(runtime->opt) != lunatik_context(opt))
 		luaL_error(L, LUNATIK_ERR_RUNTIME);
 	return runtime;
 }
@@ -196,7 +210,7 @@ static inline lunatik_object_t *lunatik_checkruntime(lua_State *L, lunatik_opt_t
 
 static inline void lunatik_checkclass(lua_State *L, const lunatik_class_t *class)
 {
-	if (lunatik_cannotsleep(L, !lunatik_issoftirq(class->opt)))
+	if (lunatik_cannotsleep(L, !lunatik_isirq(class->opt)))
 		luaL_error(L, "'%s': %s", class->name, LUNATIK_ERR_CONTEXT);
 }
 
@@ -217,7 +231,7 @@ static inline void lunatik_setobject(lunatik_object_t *object, const lunatik_cla
 	object->private = NULL;
 	object->class = class;
 	object->opt = lunatik_issingle(opt) ? inherited & ~LUNATIK_OPT_MONITOR : inherited;
-	object->gfp = lunatik_issoftirq(object->opt) ? GFP_ATOMIC : GFP_KERNEL;
+	object->gfp = lunatik_isirq(object->opt) ? GFP_ATOMIC : GFP_KERNEL;
 	lunatik_newlock(object);
 }
 

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -202,7 +202,7 @@ static int lunatik_runscript(lua_State *L)
 
 	lunatik_setversion(L);
 
-	if (!(lunatik_issoftirq(lunatik_toruntime(L)->opt))) {
+	if (!(lunatik_isirq(lunatik_toruntime(L)->opt))) {
 		luaL_openlibs(L);
 		luaL_requiref(L, "lunatik", luaopen_lunatik, 0);
 	}
@@ -261,7 +261,7 @@ static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, con
 		return -ENOEXEC;
 	}
 
-	if (lunatik_issoftirq(opt))
+	if (lunatik_isirq(opt))
 		runtime->gfp = GFP_ATOMIC;
 
 	*pruntime = runtime;
@@ -279,18 +279,21 @@ EXPORT_SYMBOL(lunatik_runtime);
 * @function runtime
 * @tparam string script script name (e.g., `"mymod"` loads `/lib/modules/lua/mymod.lua`)
 * @tparam[opt="process"] string context execution context: `"process"` (sleepable,
-*   GFP\_KERNEL, mutex) or `"softirq"` (atomic, GFP\_ATOMIC, spinlock).
-*   Use `"softirq"` for hooks that fire in interrupt context (netfilter, XDP).
+*   GFP\_KERNEL, mutex), `"softirq"` (atomic, GFP\_ATOMIC, spinlock), or `"irq"`
+*   (atomic, GFP\_ATOMIC, spinlock with IRQs disabled).
+*   Use `"softirq"` for hooks that fire in softirq context (netfilter, XDP).
+*   Use `"hardirq"` for hooks that fire in hardirq context (kprobes).
 * @treturn runtime
 * @raise if allocation fails or the script errors on load
 * @within lunatik
 */
 static int lunatik_lruntime(lua_State *L)
 {
-	static const char *const contexts[] = {"process", "softirq", NULL};
+	static const char *const contexts[] = {"process", "softirq", "hardirq", NULL};
+	static const lunatik_opt_t opts[] = {LUNATIK_OPT_NONE, LUNATIK_OPT_SOFTIRQ, LUNATIK_OPT_HARDIRQ};
 	const char *script = luaL_checkstring(L, 1);
 	int context = luaL_checkoption(L, 2, "process", contexts);
-	lunatik_opt_t opt = context == 1 ? LUNATIK_OPT_SOFTIRQ : LUNATIK_OPT_NONE;
+	lunatik_opt_t opt = opts[context];
 
 	lunatik_object_t **pruntime = lunatik_newpobject(L, 1);
 	if (lunatik_newruntime(pruntime, L, script, opt) != 0)

--- a/lunatik_obj.c
+++ b/lunatik_obj.c
@@ -36,7 +36,7 @@ EXPORT_SYMBOL(lunatik_newobject);
 
 lunatik_object_t *lunatik_createobject(const lunatik_class_t *class, size_t size, lunatik_opt_t opt)
 {
-	gfp_t gfp = lunatik_issoftirq(opt | class->opt) ? GFP_ATOMIC : GFP_KERNEL;
+	gfp_t gfp = lunatik_isirq(opt | class->opt) ? GFP_ATOMIC : GFP_KERNEL;
 	lunatik_object_t *object = (lunatik_object_t *)kzalloc(sizeof(lunatik_object_t), gfp);
 
 	if (object == NULL)


### PR DESCRIPTION
Introduce LUNATIK_OPT_HARDIRQ for classes whose handlers fire in hardirq context (e.g. kprobes). HARDIRQ uses spin_lock_irqsave, which disables hardware interrupts, whereas SOFTIRQ uses spin_lock_bh.

LUNATIK_OPT_IRQ is a shared base flag for SOFTIRQ and HARDIRQ; lunatik_isirq() tests for either. lunatik_checkruntime enforces context matching: a HARDIRQ class can only be instantiated in a hardirq runtime.