### PR TITLE
lunatik: drop unused lunatik_namespace_t from public API

### DIFF
--- a/doc/capi.md
+++ b/doc/capi.md
@@ -38,25 +38,6 @@ Describes a Lunatik object class.
   - `LUNATIK_OPT_EXTERNAL` *(constraint)*: `object->private` holds an external pointer — Lunatik
     will not free it on release.
 
-### lunatik\_reg\_t
-```C
-typedef struct lunatik_reg_s {
-	const char  *name;
-	lua_Integer  value;
-} lunatik_reg_t;
-```
-A name–integer-value pair used to export constants to Lua. Arrays must be terminated by `{NULL, 0}`.
-
-### lunatik\_namespace\_t
-```C
-typedef struct lunatik_namespace_s {
-	const char          *name;
-	const lunatik_reg_t *reg;
-} lunatik_namespace_t;
-```
-A named table of `lunatik_reg_t` constants. Passed to `LUNATIK_NEWLIB` to create sub-tables
-in the module table. Terminated by `{NULL, NULL}`.
-
 ---
 
 ## Runtime
@@ -426,18 +407,16 @@ to be passed as the `classes` argument of `LUNATIK_NEWLIB`.
 
 ### LUNATIK\_NEWLIB
 ```C
-#define LUNATIK_NEWLIB(libname, funcs, classes, namespaces)
+#define LUNATIK_NEWLIB(libname, funcs, classes)
 ```
 Defines and exports the `luaopen_<libname>` entry point using `EXPORT_SYMBOL_GPL`.
 
 - `funcs`: `luaL_Reg[]` of Lua-callable functions (the module table).
 - `classes`: NULL-terminated `const lunatik_class_t **` array declared with
   `LUNATIK_CLASSES`, or `NULL` if the module defines no object type.
-- `namespaces`: `lunatik_namespace_t[]` of constant sub-tables, or `NULL`.
 
 When `classes != NULL`, `LUNATIK_NEWLIB` registers the metatable(s) for every
-class in the array. When `namespaces != NULL`, it creates constant sub-tables
-inside the module table.
+class in the array.
 
 #### Example — single class
 ```C
@@ -447,13 +426,13 @@ static const luaL_Reg luafoo_lib[] = {
 };
 
 LUNATIK_CLASSES(foo, &luafoo_class);
-LUNATIK_NEWLIB(foo, luafoo_lib, luafoo_classes, NULL);
+LUNATIK_NEWLIB(foo, luafoo_lib, luafoo_classes);
 ```
 
 #### Example — multiple classes
 ```C
 LUNATIK_CLASSES(foo, &luafoo_class, &luafoo_bar_class);
-LUNATIK_NEWLIB(foo, luafoo_lib, luafoo_classes, NULL);
+LUNATIK_NEWLIB(foo, luafoo_lib, luafoo_classes);
 ```
 
 ---

--- a/lib/luabyteorder.c
+++ b/lib/luabyteorder.c
@@ -174,7 +174,7 @@ static const luaL_Reg luabyteorder_lib[] = {
 	{NULL, NULL}
 };
 
-LUNATIK_NEWLIB(byteorder, luabyteorder_lib, NULL, NULL);
+LUNATIK_NEWLIB(byteorder, luabyteorder_lib, NULL);
 
 static int __init luabyteorder_init(void)
 {

--- a/lib/luacompletion.c
+++ b/lib/luacompletion.c
@@ -136,7 +136,7 @@ static int luacompletion_new(lua_State *L)
 }
 
 LUNATIK_CLASSES(completion, &luacompletion_class);
-LUNATIK_NEWLIB(completion, luacompletion_lib, luacompletion_classes, NULL);
+LUNATIK_NEWLIB(completion, luacompletion_lib, luacompletion_classes);
 
 static int __init luacompletion_init(void)
 {

--- a/lib/luacpu.c
+++ b/lib/luacpu.c
@@ -125,7 +125,7 @@ static const luaL_Reg luacpu_lib[] = {
 	{NULL, NULL}
 };
 
-LUNATIK_NEWLIB(cpu, luacpu_lib, NULL, NULL);
+LUNATIK_NEWLIB(cpu, luacpu_lib, NULL);
 
 static int __init luacpu_init(void)
 {

--- a/lib/luacrypto_core.c
+++ b/lib/luacrypto_core.c
@@ -34,7 +34,7 @@ static const lunatik_class_t *luacrypto_classes[] = {
 	NULL
 };
 
-LUNATIK_NEWLIB(crypto, luacrypto_lib, luacrypto_classes, NULL);
+LUNATIK_NEWLIB(crypto, luacrypto_lib, luacrypto_classes);
 
 static int __init luacrypto_init(void)
 {

--- a/lib/luadarken.c
+++ b/lib/luadarken.c
@@ -133,7 +133,7 @@ static const luaL_Reg luadarken_lib[] = {
 	{NULL, NULL}
 };
 
-LUNATIK_NEWLIB(darken, luadarken_lib, NULL, NULL);
+LUNATIK_NEWLIB(darken, luadarken_lib, NULL);
 
 static int __init luadarken_init(void)
 {

--- a/lib/luadata.c
+++ b/lib/luadata.c
@@ -353,7 +353,7 @@ static int luadata_lnew(lua_State *L)
 }
 
 LUNATIK_CLASSES(data, &luadata_class);
-LUNATIK_NEWLIB(data, luadata_lib, luadata_classes, NULL);
+LUNATIK_NEWLIB(data, luadata_lib, luadata_classes);
 
 lunatik_object_t *luadata_new(lua_State *L, lunatik_opt_t opt)
 {

--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -388,7 +388,7 @@ static int luadevice_new(lua_State *L)
 }
 
 LUNATIK_CLASSES(device, &luadevice_class);
-LUNATIK_NEWLIB(device, luadevice_lib, luadevice_classes, NULL);
+LUNATIK_NEWLIB(device, luadevice_lib, luadevice_classes);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
 static char *luadevice_devnode(const struct device *dev, umode_t *mode)

--- a/lib/luafib.c
+++ b/lib/luafib.c
@@ -139,7 +139,7 @@ static const lunatik_class_t luafib_class = {
 };
 
 LUNATIK_CLASSES(fib, &luafib_class);
-LUNATIK_NEWLIB(fib, luafib_lib, luafib_classes, NULL);
+LUNATIK_NEWLIB(fib, luafib_lib, luafib_classes);
 
 static int __init luafib_init(void)
 {

--- a/lib/luafifo.c
+++ b/lib/luafifo.c
@@ -138,7 +138,7 @@ static int luafifo_new(lua_State *L)
 }
 
 LUNATIK_CLASSES(fifo, &luafifo_class);
-LUNATIK_NEWLIB(fifo, luafifo_lib, luafifo_classes, NULL);
+LUNATIK_NEWLIB(fifo, luafifo_lib, luafifo_classes);
 
 static int __init luafifo_init(void)
 {

--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -313,7 +313,7 @@ static int luahid_register(lua_State *L)
 }
 
 LUNATIK_CLASSES(hid, &luahid_class);
-LUNATIK_NEWLIB(hid, luahid_lib, luahid_classes, NULL);
+LUNATIK_NEWLIB(hid, luahid_lib, luahid_classes);
 
 static int __init luahid_init(void)
 {

--- a/lib/lualinux.c
+++ b/lib/lualinux.c
@@ -262,7 +262,7 @@ static const luaL_Reg lualinux_lib[] = {
 	{NULL, NULL}
 };
 
-LUNATIK_NEWLIB(linux, lualinux_lib, NULL, NULL);
+LUNATIK_NEWLIB(linux, lualinux_lib, NULL);
 
 static int __init lualinux_init(void)
 {

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -174,7 +174,7 @@ static void luanetfilter_release(void *private)
 }
 
 LUNATIK_CLASSES(netfilter, &luanetfilter_class);
-LUNATIK_NEWLIB(netfilter, luanetfilter_lib, luanetfilter_classes, NULL);
+LUNATIK_NEWLIB(netfilter, luanetfilter_lib, luanetfilter_classes);
 
 static int __init luanetfilter_init(void)
 {

--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -275,7 +275,7 @@ static int luanotifier_new(lua_State *L, luanotifier_register_t register_fn, lua
 }
 
 LUNATIK_CLASSES(notifier, &luanotifier_class);
-LUNATIK_NEWLIB(notifier, luanotifier_lib, luanotifier_classes, NULL);
+LUNATIK_NEWLIB(notifier, luanotifier_lib, luanotifier_classes);
 
 static int __init luanotifier_init(void)
 {

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -219,7 +219,7 @@ static int luaprobe_new(lua_State *L)
 }
 
 LUNATIK_CLASSES(probe, &luaprobe_class);
-LUNATIK_NEWLIB(probe, luaprobe_lib, luaprobe_classes, NULL);
+LUNATIK_NEWLIB(probe, luaprobe_lib, luaprobe_classes);
 
 static int __init luaprobe_init(void)
 {

--- a/lib/luarcu.c
+++ b/lib/luarcu.c
@@ -325,7 +325,7 @@ static int luarcu_table(lua_State *L)
 }
 
 LUNATIK_CLASSES(rcu, &luarcu_class);
-LUNATIK_NEWLIB(rcu, luarcu_lib, luarcu_classes, NULL);
+LUNATIK_NEWLIB(rcu, luarcu_lib, luarcu_classes);
 
 static int __init luarcu_init(void)
 {

--- a/lib/luasignal.c
+++ b/lib/luasignal.c
@@ -131,7 +131,7 @@ static const luaL_Reg luasignal_lib[] = {
 	{NULL, NULL}
 };
 
-LUNATIK_NEWLIB(signal, luasignal_lib, NULL, NULL);
+LUNATIK_NEWLIB(signal, luasignal_lib, NULL);
 
 static int __init luasignal_init(void)
 {

--- a/lib/luaskb.c
+++ b/lib/luaskb.c
@@ -264,7 +264,7 @@ lunatik_object_t *luaskb_new(lua_State *L)
 EXPORT_SYMBOL(luaskb_new);
 
 LUNATIK_CLASSES(skb, &luaskb_class);
-LUNATIK_NEWLIB(skb, luaskb_lib, luaskb_classes, NULL);
+LUNATIK_NEWLIB(skb, luaskb_lib, luaskb_classes);
 
 static int __init luaskb_init(void)
 {

--- a/lib/luaskel.c
+++ b/lib/luaskel.c
@@ -55,7 +55,7 @@ static int luaskel_new(lua_State *L)
 }
 
 LUNATIK_CLASSES(skel, &luaskel_class);
-LUNATIK_NEWLIB(skel, luaskel_lib, luaskel_classes, NULL);
+LUNATIK_NEWLIB(skel, luaskel_lib, luaskel_classes);
 
 static int __init luaskel_init(void)
 {

--- a/lib/luasocket.c
+++ b/lib/luasocket.c
@@ -458,7 +458,7 @@ static int luasocket_new(lua_State *L)
 }
 
 LUNATIK_CLASSES(socket, &luasocket_class);
-LUNATIK_NEWLIB(socket, luasocket_lib, luasocket_classes, NULL);
+LUNATIK_NEWLIB(socket, luasocket_lib, luasocket_classes);
 
 static int __init luasocket_init(void)
 {

--- a/lib/luasyscall.c
+++ b/lib/luasyscall.c
@@ -46,7 +46,7 @@ static const luaL_Reg luasyscall_lib[] = {
 	{NULL, NULL}
 };
 
-LUNATIK_NEWLIB(syscall, luasyscall_lib, NULL, NULL);
+LUNATIK_NEWLIB(syscall, luasyscall_lib, NULL);
 
 static int __init luasyscall_init(void)
 {

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -218,7 +218,7 @@ static int luathread_current(lua_State *L)
 }
 
 LUNATIK_CLASSES(thread, &luathread_class);
-LUNATIK_NEWLIB(thread, luathread_lib, luathread_classes, NULL);
+LUNATIK_NEWLIB(thread, luathread_lib, luathread_classes);
 
 static int __init luathread_init(void)
 {

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -231,7 +231,7 @@ static const luaL_Reg luaxdp_lib[] = {
 	{NULL, NULL}
 };
 
-LUNATIK_NEWLIB(xdp, luaxdp_lib, NULL, NULL);
+LUNATIK_NEWLIB(xdp, luaxdp_lib, NULL);
 
 static int __init luaxdp_init(void)
 {

--- a/lunatik.h
+++ b/lunatik.h
@@ -80,16 +80,6 @@ do {									\
 	lunatik_unlock(runtime);					\
 } while(0)
 
-typedef struct lunatik_reg_s {
-	const char *name;
-	lua_Integer value;
-} lunatik_reg_t;
-
-typedef struct lunatik_namespace_s {
-	const char *name;
-	const lunatik_reg_t *reg;
-} lunatik_namespace_t;
-
 typedef struct lunatik_class_s {
 	const char *name;
 	const luaL_Reg *methods;
@@ -313,19 +303,6 @@ static inline lunatik_object_t **lunatik_checkpobject(lua_State *L, int ix)
 	return pobject;
 }
 
-static inline void lunatik_newnamespaces(lua_State *L, const lunatik_namespace_t *namespaces)
-{
-	for (; namespaces->name; namespaces++) {
-		const lunatik_reg_t *reg;
-		lua_newtable(L); /* namespace = {} */
-		for (reg = namespaces->reg; reg->name; reg++) {
-			lua_pushinteger(L, reg->value);
-			lua_setfield(L, -2, reg->name); /* namespace[name] = value */
-		}
-		lua_setfield(L, -2, namespaces->name); /* lib.namespace = namespace */
-	}
-}
-
 #define LUNATIK_CLASSES(name, ...)	\
 static const lunatik_class_t *lua##name##_classes[] = { __VA_ARGS__, NULL }
 
@@ -340,17 +317,14 @@ static inline void lunatik_newclasses(lua_State *L, const lunatik_class_t **clas
 	}
 }
 
-#define LUNATIK_NEWLIB(libname, funcs, classes, namespaces)			\
+#define LUNATIK_NEWLIB(libname, funcs, classes)					\
 int luaopen_##libname(lua_State *L);						\
 int luaopen_##libname(lua_State *L)						\
 {										\
 	const lunatik_class_t **clss = classes; /* avoid -Waddress */		\
-	const lunatik_namespace_t *nss = namespaces; /* avoid -Waddress */	\
 	luaL_newlib(L, funcs);							\
 	if (clss)								\
 		lunatik_newclasses(L, clss);					\
-	if (nss)								\
-		lunatik_newnamespaces(L, nss);					\
 	return 1;								\
 }										\
 EXPORT_SYMBOL_GPL(luaopen_##libname)

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -301,8 +301,8 @@ static int lunatik_lruntime(lua_State *L)
 
 static const lunatik_class_t *lunatik_classes[] = { &lunatik_class, NULL };
 
-LUNATIK_NEWLIB(lunatik, lunatik_lib, lunatik_classes, NULL);
-LUNATIK_NEWLIB(lunatik_stub, lunatik_stub_lib, NULL, NULL);
+LUNATIK_NEWLIB(lunatik, lunatik_lib, lunatik_classes);
+LUNATIK_NEWLIB(lunatik_stub, lunatik_stub_lib, NULL);
 #endif /* LUNATIK_RUNTIME */
 
 static int __init lunatik_init(void)


### PR DESCRIPTION
After the autogen migration, no module creates constant sub-tables via `LUNATIK_NEWLIB`'s namespace parameter -- every site now passes NULL. Remove the unused scaffolding:

- `lunatik_reg_t` and `lunatik_namespace_t` typedefs
- `lunatik_newnamespaces()` helper
- the fourth parameter of `LUNATIK_NEWLIB`

All 24 call sites drop the trailing NULL.