### PR TITLE
luanotifier: guard release against NULL runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,10 @@ tests_install:
 	${INSTALL} -m 0755 tests/probe/run.sh tests/probe/kprobe_concurrent.sh ${LUNATIK_TESTS_INSTALL_PATH}/probe
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/tests/probe
 	${INSTALL} -m 0644 tests/probe/*.lua ${SCRIPTS_INSTALL_PATH}/tests/probe
+	${MKDIR} ${LUNATIK_TESTS_INSTALL_PATH}/notifier
+	${INSTALL} -m 0755 tests/notifier/*.sh ${LUNATIK_TESTS_INSTALL_PATH}/notifier
+	${MKDIR} ${SCRIPTS_INSTALL_PATH}/tests/notifier
+	${INSTALL} -m 0644 tests/notifier/*.lua ${SCRIPTS_INSTALL_PATH}/tests/notifier
 
 tests_uninstall:
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/tests

--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -104,8 +104,8 @@ static void luanotifier_release(void *private)
 	 * so unregister_*_notifier can safely sleep on synchronize_rcu */
 	if (notifier->unregister)
 		notifier->unregister(&notifier->nb);
-
-	lunatik_putobject(notifier->runtime);
+	if (notifier->runtime) /* NULL if checkruntime errored in init */
+		lunatik_putobject(notifier->runtime);
 }
 
 /***

--- a/tests/notifier/context_mismatch.lua
+++ b/tests/notifier/context_mismatch.lua
@@ -1,0 +1,15 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Regression: hardirq-class notifier constructor called from a process
+-- runtime must fail cleanly. luanotifier_new runs lunatik_newobject before
+-- lunatik_checkruntime; when checkruntime errors the object is already
+-- allocated with runtime still NULL, and the subsequent __gc -> release
+-- would oops on lunatik_putobject(NULL). This script provokes exactly that
+-- path; the companion shell test asserts no kernel oops lands in dmesg.
+--
+
+local notifier = require("notifier")
+notifier.keyboard(function() end)
+

--- a/tests/notifier/context_mismatch.sh
+++ b/tests/notifier/context_mismatch.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for NULL-deref in luanotifier_release on context-mismatch
+# cleanup.
+#
+# luanotifier_new calls lunatik_newobject (which kzallocs the notifier)
+# before lunatik_checkruntime. Running a hardirq-class constructor from a
+# process runtime makes checkruntime raise luaL_error with notifier->runtime
+# still NULL. lua_close on the failing runtime then triggers __gc -> release,
+# which without the guard oopses on lunatik_putobject(NULL).
+#
+# The Lua script invokes notifier.keyboard() from the default process
+# runtime. Expected: Lua error "runtime context mismatch" in the script
+# output and zero kernel oops entries in dmesg.
+#
+# Usage: sudo bash tests/notifier/context_mismatch.sh
+
+SCRIPT="tests/notifier/context_mismatch"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() {
+	lunatik stop "$SCRIPT" 2>/dev/null
+}
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 2
+
+mark_dmesg
+mark_ts=$(awk '{print $1}' /proc/uptime)
+
+output=$(lunatik run "$SCRIPT" 2>&1)
+echo "$output" | grep -q "runtime context mismatch" || \
+	fail "expected 'runtime context mismatch' error, got: $output"
+ktap_pass "hardirq-class constructor in process runtime errors cleanly"
+
+oops=$(dmesg | awk -v ts="$mark_ts" \
+	'match($0, /\[[ ]*([0-9]+\.[0-9]+)/, a) && a[1]+0 >= ts+0' | \
+	grep -E "Oops:|BUG:|kernel BUG at|NULL pointer dereference|general protection" || true)
+[ -n "$oops" ] && fail "kernel oops during context-mismatch cleanup: ${oops%%$'\n'*}"
+ktap_pass "no kernel oops during context-mismatch cleanup"
+
+ktap_totals
+

--- a/tests/notifier/run.sh
+++ b/tests/notifier/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Runs all notifier regression tests.
+#
+# Usage: sudo bash tests/notifier/run.sh
+
+DIR="$(dirname "$(readlink -f "$0")")"
+FAILED=0
+
+SEP=$'\n'
+for t in "$DIR"/context_mismatch.sh; do
+	echo "${SEP}# --- $(basename "$t") ---"
+	bash "$t" || FAILED=$((FAILED+1))
+done
+
+exit $FAILED
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -33,6 +33,7 @@ run_suite "$DIR/rcu/run.sh"
 run_suite "$DIR/crypto/run.sh"
 run_suite "$DIR/io/test.sh"
 run_suite "$DIR/probe/run.sh"
+run_suite "$DIR/notifier/run.sh"
 
 echo ""
 echo "# Grand Totals: pass:$TOTAL_PASS fail:$TOTAL_FAIL skip:$TOTAL_SKIP"


### PR DESCRIPTION
If lunatik_checkruntime fails in luanotifier_new (e.g. constructor called from a runtime whose context does not match the class), notifier->runtime is never assigned. The object userdata stays on the Lua stack until GC, at which point __gc invokes release — which dereferences NULL on the lunatik_putobject(notifier->runtime) call and oopses the kernel.

Easily reproduced by running a keyboard-notifier example (hardirq class) without a hardirq runtime, e.g. `lunatik run examples/keylocker` without the "hardirq" context argument — the script fails to load, the Lua state is torn down, and release fires on the half-initialized notifier.

Mirror the guard luaprobe_release already had for the same reason.