### PR TITLE
Makefile: install and uninstall cover examples and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,13 @@ LUNATIK_MODULES := \
 	$(foreach c,$(LUNATIK_MODULES),\
 		$(if $(filter y m,$(CONFIG_LUNATIK_$(c))),$(c)))
 
+.PHONY: all clean install uninstall autogen doc-site \
+	scripts_install scripts_uninstall \
+	modules_install modules_uninstall btf_install \
+	examples_install examples_uninstall \
+	tests_install tests_uninstall \
+	ebpf ebpf_install ebpf_uninstall
+
 all: lunatik_sym.h autogen
 	${MAKE} -C ${MODULES_BUILD_PATH} M=${PWD} $(LUNATIK_CONFIG_FLAGS)
 
@@ -100,7 +107,6 @@ scripts_uninstall:
 	${RM} ${LUNATIK_INSTALL_PATH}/lunatik
 	${RM} -r ${LUA_PATH}/lunatik
 
-.PHONY: ebpf defines
 ebpf:
 	${MAKE} -C examples/filter
 
@@ -201,7 +207,6 @@ uninstall: scripts_uninstall modules_uninstall examples_uninstall tests_uninstal
 lunatik_sym.h: $(LUA_API) gensymbols.sh
 	${shell CC='$(CC)' ./gensymbols.sh $(LUA_API) > lunatik_sym.h}
 
-.PHONY: autogen
 autogen:
 	CC='$(CC)' "$(LUA)" autogen.lua "$(MODULES_BUILD_PATH)" "$(KERNEL_RELEASE)" "$(LUNATIK_MODULES)"
 

--- a/Makefile
+++ b/Makefile
@@ -185,14 +185,14 @@ btf_install:
 modules_uninstall:
 	${RM} -r ${MODULES_INSTALL_PATH}/lunatik
 
-install: scripts_install modules_install
+install: scripts_install modules_install examples_install tests_install
 	for mod in $(MODULES_ORDER_LIST); do \
 		sed -i "\|^$$mod$$|d" $(MODULES_ORDER_FILE); \
 		echo "$$mod" >> $(MODULES_ORDER_FILE); \
 	done
 	depmod -a
 
-uninstall: scripts_uninstall modules_uninstall
+uninstall: scripts_uninstall modules_uninstall examples_uninstall tests_uninstall
 	for mod in $(MODULES_ORDER_LIST); do \
 		sed -i "\|^$$mod$$|d" $(MODULES_ORDER_FILE); \
 	done


### PR DESCRIPTION
  So `sudo make install` alone is enough — no more manual
  `examples_install` / `tests_install` on every iteration.

  Also consolidates the scattered `.PHONY` declarations into a single
  block covering every real non-file target (the old `defines` entry was
  dead).