### PR TITLE
luahid: avoid self-deadlock during synchronous probe from register_dr…

### DIFF
--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -122,10 +122,22 @@ static inline int luahid_pcall(lua_State *L, lua_CFunction op, luahid_ctx_t *ctx
 	return ctx->ret;
 }
 
+/*
+ * hid_register_driver synchronously probes already-connected matching devices
+ * from the caller's context, so hid->probe fires with the runtime lock still
+ * held by luahid_register. Re-entering lunatik_run would deadlock on the
+ * (non-recursive) runtime spinlock. hid->registered doubles as the sentinel:
+ * it is false until hid_register_driver returns, so the in-registration case
+ * routes through lunatik_handle (no lock re-acquire); every firing afterwards
+ * takes the lock normally.
+ */
 #define luahid_run(op, ctx, hid, hdev, ret)					\
 do {										\
 	(ctx)->cb = #op; (ctx)->hid = hid; (ctx)->hdev = hdev;			\
-	lunatik_run(hid->runtime, luahid_pcall, ret, luahid_do##op, ctx);	\
+	if ((hid)->registered)							\
+		lunatik_run(hid->runtime, luahid_pcall, ret, luahid_do##op, ctx); \
+	else									\
+		lunatik_handle(hid->runtime, luahid_pcall, ret, luahid_do##op, ctx); \
 } while (0)
 
 #define luahid_pushid(L, id, extra)		\


### PR DESCRIPTION
…iver

hid_register_driver walks existing HID devices and synchronously invokes the driver's probe for each matching one. That callback fires from the caller's context, so our luahid_probe runs while luahid_register is still on the stack holding the runtime lock.

The existing luahid_run macro always re-enters lunatik_run, which tries to re-acquire the runtime lock. For LUNATIK_OPT_SOFTIRQ (luahid's class) that means recursive spin_lock_bh on the same CPU, which is a hard deadlock. This happens in practice as soon as the registered id_table matches any already-connected HID device.

Use hid->registered as the in-registration sentinel, mirroring the notifier->unregister pattern luanotifier uses for register_netdevice_ notifier's synchronous dispatch. hid->registered is false until hid_register_driver returns, so in-registration firings take the lunatik_handle path (no lock re-acquire, caller already holds it); every subsequent firing takes the lock normally via lunatik_run.