### PR TITLE
autogen: generate LDoc stubs for linux.* modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ moontastik*
 dnstest
 doc/*
 !doc/capi.md
-/lib/linux/
+/lib/linux.lua
 

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ clean:
 	${RM} autogen/extract.c autogen/extract.s
 	${RM} autogen/targets.mk
 	${RM} ${AUTOGEN_STAMP} ${AUTOGEN_CONFIG}
-	${RM} -r lib/linux
+	${RM} lib/linux.lua
 
 scripts_install:
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}
@@ -95,7 +95,7 @@ scripts_install:
 	${INSTALL} -m 0644 lib/socket/*.lua ${SCRIPTS_INSTALL_PATH}/socket
 	${INSTALL} -m 0644 lib/syscall/*.lua ${SCRIPTS_INSTALL_PATH}/syscall
 	${INSTALL} -m 0644 lib/crypto/*.lua ${SCRIPTS_INSTALL_PATH}/crypto
-	# NOTE: `lib/linux/` exists only as LDoc stubs (see doc-stubs); never install it.
+	# NOTE: `lib/linux.lua` is an LDoc stub (see doc-stubs); never install it.
 	${INSTALL} -m 0644 autogen/linux/*.lua ${SCRIPTS_INSTALL_PATH}/linux
 	${INSTALL} -m 0644 autogen/lunatik/*.lua ${SCRIPTS_INSTALL_PATH}/lunatik
 	${LN} ${SCRIPTS_INSTALL_PATH}/lunatik/config.lua ${LUA_PATH}/lunatik/config.lua

--- a/autogen/ldoc.lua
+++ b/autogen/ldoc.lua
@@ -2,44 +2,30 @@
 -- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
 -- SPDX-License-Identifier: MIT OR GPL-2.0-only
 --
--- Generate LDoc stubs from autogen/specs.lua.
+-- Generate an LDoc stub from autogen/specs.lua.
 --
 -- The real autogen output (`autogen/linux/*.lua`) only exists after a
 -- kernel build and its contents depend on the kernel version/arch. LDoc
--- runs in CI without a kernel build, so these stubs provide the stable
--- API surface (module names, grouping, description, provenance) that
--- LDoc can render independently of any build artefact.
+-- runs in CI without a kernel build, so this stub provides the stable
+-- API surface (sub-table names, description, provenance) that LDoc can
+-- render independently of any build artefact.
 --
--- Stubs live at `lib/linux/` because LDoc deduces module names from the
--- source path (stripping the `lib/` base) before honoring `@module`
--- tags; a file at `lib/linux/nf.lua` resolves to `linux.nf`, which is
--- what we want. They are gitignored, cleaned by `make clean`, and not
--- copied by `scripts_install` -- only `autogen/linux/*.lua` goes to the
--- runtime path at `/lib/modules/lua/linux/`.
+-- The stub is emitted at `lib/linux.lua` with `@submodule linux`;
+-- combined with `merge = true` in `config.ld`, LDoc folds its tables
+-- into the `linux` module page (alongside what `lib/lualinux.c`
+-- documents) instead of polluting the index with one page per group.
+--
+-- Gitignored, cleaned by `make clean`, and not copied by
+-- `scripts_install` -- only `autogen/linux/*.lua` goes to the runtime
+-- path at `/lib/modules/lua/linux/`.
 --
 -- @script autogen/ldoc
--- @usage lua5.4 autogen/ldoc.lua [<out-dir>]
+-- @usage lua5.4 autogen/ldoc.lua [<out-file>]
 
-local OUT = arg[1] or "lib/linux"
+local OUT = arg[1] or "lib/linux.lua"
 local SPECS = "autogen/specs.lua"
 
 local specs = dofile(SPECS)
-
-local tops, order = {}, {}
-for _, spec in ipairs(specs) do
-	local top = spec.module:match("^[^.]+")
-	if not tops[top] then
-		tops[top] = {}
-		table.insert(order, top)
-	end
-	table.insert(tops[top], spec)
-end
-
-assert(os.execute("mkdir -p '" .. OUT .. "'"))
-
-local function provenance(spec)
-	return ("`%s*` constants from `<%s>`."):format(spec.prefix, spec.header)
-end
 
 local function write_block(f, lines)
 	f:write("---\n")
@@ -47,35 +33,15 @@ local function write_block(f, lines)
 	f:write("\n")
 end
 
-local HEADER = "-- auto-generated LDoc stub (see autogen/ldoc.lua) -- do not edit\n\n"
+local f <close> = assert(io.open(OUT, "w"))
+f:write("-- auto-generated LDoc stub (see autogen/ldoc.lua) -- do not edit\n\n")
+write_block(f, { "@submodule linux" })
 
-for _, top in ipairs(order) do
-	local group = tops[top]
-	local f <close> = assert(io.open(OUT .. "/" .. top .. ".lua", "w"))
-
-	f:write(HEADER)
+for _, s in ipairs(specs) do
 	write_block(f, {
-		"Linux kernel constants exposed under `linux." .. top .. "`.",
-		"Values are populated at build time from the kernel headers.",
-		"@module linux." .. top,
+		s.desc or ("`%s*` from `<%s>`."):format(s.prefix, s.header),
+		"Mirrors `" .. s.prefix .. "*` in `<" .. s.header .. ">`.",
+		"@table " .. s.module,
 	})
-	f:write(("local %s = {}\n"):format(top))
-
-	for _, s in ipairs(group) do
-		local name
-		if s.module == top then
-			name = "constants"
-		else
-			name = s.module:sub(#top + 2)
-		end
-		write_block(f, {
-			s.desc or provenance(s),
-			"Mirrors `" .. s.prefix .. "*` defines in `<" .. s.header .. ">`.",
-			"@table " .. name,
-		})
-		f:write(("%s.%s = {}\n"):format(top, name))
-	end
-
-	f:write(("\nreturn %s\n\n"):format(top))
 end
 

--- a/config.ld
+++ b/config.ld
@@ -33,7 +33,7 @@ file = {
 	'./lunatik_core.c',
 	'./lib/lunatik/runner.lua',
 	'./lib/lualinux.c',
-	'./lib/linux',
+	'./lib/linux.lua',
 	'./lib/mailbox.lua',
 	'./lib/net.lua',
 	'./lib/luanetfilter.c',

--- a/lib/luasocket.c
+++ b/lib/luasocket.c
@@ -182,7 +182,7 @@ static int luasocket_send(lua_State *L)
 *   -- For a UDP socket, getting sender info:
 *   local data, sender_ip_int, sender_port = udp_sock:receive(1500, 0, true)
 *   if data then print("Received from " .. net.ntoa(sender_ip_int) .. ":" .. sender_port .. ": " .. data) end
-* @see linux.socket.msg
+* @see linux
 * @see net.ntoa
 */
 static int luasocket_receive(lua_State *L)
@@ -441,9 +441,7 @@ static int luasocket_accept(lua_State *L)
 * @usage
 *   -- TCP/IPv4 socket
 *   local tcp_sock = socket.new(linux.socket.af.INET, linux.socket.sock.STREAM, linux.socket.ipproto.TCP)
-* @see linux.socket.af
-* @see linux.socket.sock
-* @see linux.socket.ipproto
+* @see linux
 * @within socket
 */
 static int luasocket_new(lua_State *L)

--- a/lib/syscall/table.lua
+++ b/lib/syscall/table.lua
@@ -11,7 +11,7 @@
 --
 -- @module syscall.table
 -- @see syscall
--- @see linux.syscall.numbers
+-- @see linux
 -- @see syscall.address
 -- @usage
 --   local syscall_addrs = require("syscall.table")


### PR DESCRIPTION
The autogen output in `autogen/linux/*.lua` only materializes after a kernel build and its shape depends on the target kernel/arch. LDoc runs in CI without a kernel build, so the real module tables were invisible in the rendered docs.

Add `autogen/ldoc.lua`, a pure-Lua script that reads `autogen/specs.lua` and emits a single LDoc stub at `lib/linux.lua` declaring `@submodule linux` with one `@table` per spec. Combined with `merge = true` in `config.ld`, LDoc folds the stub into the existing `linux` module page (from `lib/lualinux.c`) instead of polluting the module index with one page per constant group.

Stubs are generated at doc-build time (`make doc-stubs`, pulled in by `doc-site`), committed nowhere, and cleaned alongside the autogen output. `config.ld` picks them up via `./lib/linux.lua`. No kernel build is needed; CI's existing `make doc-site` workflow already handles it.

Each spec in `autogen/specs.lua` gains a one-line `desc` describing what the constants represent. Cross-references (`@see linux.socket.X`, `@see linux.syscall.numbers`) are simplified to `@see linux` since the individual `linux.X` modules no longer exist as standalone pages.