### PR TITLE
luadevice: guard release against NULL runtime

### DIFF
--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -232,7 +232,8 @@ static void luadevice_release(void *private)
 
 	/* device might have never been stopped */
 	luadevice_delete(luadev);
-	lunatik_putobject(luadev->runtime);
+	if (luadev->runtime) /* NULL if setruntime errored in init */
+		lunatik_putobject(luadev->runtime);
 }
 
 /***


### PR DESCRIPTION
Match the pattern already present in luaprobe, luahid, luanetfilter and luanotifier: skip lunatik_putobject when runtime is NULL — reachable when setruntime errors between lunatik_newobject (which kzallocs the private) and the runtime assignment.

No behavioural change today: luadevice is a process-context class and lunatik_checkclass in lunatik_newobject rejects IRQ-runtime callers before setruntime runs. The guard is defense-in-depth.