### PR TITLE
examples/ifquarantine: compose notifier.netdevice with netfilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,37 @@ write: 438
 sudo lunatik stop examples/systrack/device            # stops device and probe runtimes
 ```
 
+### ifquarantine
+
+[ifquarantine](examples/ifquarantine) composes two notifier chains to build
+an interface-level default-deny policy: every new network interface
+(NETDEV_REGISTER) is automatically added to a shared RCU set whose contents
+a netfilter hook uses to decide the verdict on each packet. An interface is
+released from quarantine by writing `allow=<name>` to `/dev/ifquarantine`;
+re-denied with `deny=<name>`; inspected with `cat /dev/ifquarantine`.
+
+The control runtime (process context) owns `notifier.netdevice` and the
+device; it spawns a child softirq runtime with the netfilter hook, sharing
+the quarantine set via `rcu.table` through `runtime:resume()`. Illustrates
+cross-subsystem composition between two notifier chains of different
+execution contexts.
+
+#### Usage
+
+```
+sudo make examples_install                         # installs examples
+sudo lunatik spawn examples/ifquarantine/control   # starts control+filter
+sudo cat /dev/ifquarantine                         # lists known interfaces and verdict
+sudo sh -c "echo 'allow=eth0' > /dev/ifquarantine" # lift quarantine on eth0
+sudo sh -c "echo 'deny=eth0'  > /dev/ifquarantine" # re-apply quarantine
+sudo lunatik stop examples/ifquarantine/control    # stops both runtimes
+```
+
+Pre-existing interfaces are covered as well: `register_netdevice_notifier`
+synchronously replays `NETDEV_REGISTER` (and `NETDEV_UP`) for each existing
+netdev when the notifier block is registered, so they enter quarantine at
+script start too.
+
 ### filter
 
 [filter](examples/filter) is a kernel extension composed by

--- a/examples/ifquarantine/control.lua
+++ b/examples/ifquarantine/control.lua
@@ -1,0 +1,89 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+local device   = require("device")
+local linux    = require("linux")
+local notifier = require("notifier")
+local rcu      = require("rcu")
+local runner   = require("lunatik.runner")
+local netdev   = require("linux.netdev")
+local notify   = require("linux.notify")
+local stat     = require("linux.stat")
+
+local filter      <const> = "examples/ifquarantine/filter"
+local quarantined         = rcu.table()   -- tostring(ifindex) -> true
+local known               = {}            -- name -> ifindex
+
+local function info(...)
+	print("ifquarantine: " .. string.format(...))
+end
+
+local function quarantine(name, idx)
+	known[name] = idx
+	quarantined[tostring(idx)] = true
+	info("%s (ifindex=%d) quarantined", name, idx)
+end
+
+local function release(name)
+	local idx = known[name]
+	if idx then
+		quarantined[tostring(idx)] = nil
+		info("%s released", name)
+	end
+end
+
+local function callback(event, name)
+	if event == netdev.REGISTER then
+		local ok, idx = pcall(linux.ifindex, name)
+		if ok and idx then
+			quarantine(name, idx)
+		end
+	elseif event == netdev.UNREGISTER then
+		release(name)
+		known[name] = nil
+	end
+	return notify.OK
+end
+
+local driver = {name = "ifquarantine", mode = stat.IRUGO | stat.IWUGO}
+
+function driver:read()
+	local lines = {}
+	for name, idx in pairs(known) do
+		local state = quarantined[tostring(idx)] and "DROP" or "ALLOW"
+		table.insert(lines, string.format("%s %d %s", name, idx, state))
+	end
+	if #lines == 0 then
+		return ""
+	end
+	return table.concat(lines, "\n") .. "\n"
+end
+
+function driver:write(buf)
+	for cmd, name in string.gmatch(buf, "(%w+)=(%g+)") do
+		local idx = known[name]
+		if idx then
+			if cmd == "allow" then
+				quarantined[tostring(idx)] = nil
+				info("%s allowed", name)
+			elseif cmd == "deny" then
+				quarantined[tostring(idx)] = true
+				info("%s denied", name)
+			end
+		end
+	end
+end
+
+device.new(driver)
+
+local rt = runner.run(filter, "softirq")
+rt:resume(quarantined)
+
+driver.sentinel = setmetatable({}, {__gc = function()
+	runner.stop(filter)
+end})
+
+notifier.netdevice(callback)
+

--- a/examples/ifquarantine/filter.lua
+++ b/examples/ifquarantine/filter.lua
@@ -1,0 +1,45 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+local netfilter = require("netfilter")
+local nf        = require("linux.nf")
+
+local family   = nf.proto
+local action   = nf.action
+local hooks    = nf.inet
+local priority = nf.ip.pri
+
+local quarantined
+
+local function verdict(skb)
+	if not quarantined then
+		return action.ACCEPT
+	end
+	local idx = skb:ifindex()
+	if idx and quarantined[tostring(idx)] then
+		return action.DROP
+	end
+	return action.ACCEPT
+end
+
+netfilter.register{
+	hook     = verdict,
+	pf       = family.INET,
+	hooknum  = hooks.PRE_ROUTING,
+	priority = priority.RAW,
+}
+
+netfilter.register{
+	hook     = verdict,
+	pf       = family.INET,
+	hooknum  = hooks.POST_ROUTING,
+	priority = priority.RAW,
+}
+
+local function attacher(shared)
+	quarantined = shared
+end
+return attacher
+


### PR DESCRIPTION
New example demonstrating cross-subsystem composition of two notifier
chains in different execution contexts. Every network interface
(NETDEV_REGISTER) is added to a shared rcu.table set; a netfilter hook
in a softirq child runtime drops any packet whose ifindex is in that
set. Users can release/re-apply quarantine per interface via
/dev/ifquarantine.

- examples/ifquarantine/control.lua (process runtime): registers the
  netdevice notifier, exposes /dev/ifquarantine, spawns the filter
  child runtime and passes the quarantine set through runtime:resume().
- examples/ifquarantine/filter.lua (softirq runtime): registers two
  netfilter hooks (PRE_ROUTING and POST_ROUTING, IPv4) that consult the
  shared set to decide DROP vs ACCEPT per packet.

Pre-existing interfaces are covered via the synchronous NETDEV_REGISTER
replay that register_netdevice_notifier performs at registration time;
no daemon thread is needed.
