### PR TITLE
lunatik: allow sync-dispatch during runtime init

### DIFF
--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -180,7 +180,7 @@ static const lunatik_class_t luathread_class = {
 */
 static int luathread_run(lua_State *L)
 {
-	luaL_argcheck(L, lunatik_isready(L), 1, "not allowed during module load");
+	luaL_argcheck(L, lunatik_isready(lunatik_toruntime(L)), 1, "not allowed during module load");
 	lunatik_object_t *runtime = lunatik_checkobject(L, 1);
 	luaL_argcheck(L, !lunatik_isirq(runtime->opt), 1, "IRQ runtime cannot spawn threads");
 	const char *name = luaL_checkstring(L, 2);

--- a/lunatik.h
+++ b/lunatik.h
@@ -48,19 +48,14 @@ do {									\
 #define lunatik_lock(o)      lunatik_locker((o), mutex_lock, spin_lock_bh, spin_lock_irqsave, (o)->flags)
 #define lunatik_unlock(o)    lunatik_locker((o), mutex_unlock, spin_unlock_bh, spin_unlock_irqrestore, (o)->flags)
 
-#define lunatik_toruntime(L)	(*(lunatik_object_t **)lua_getextraspace(L))
+#define lunatik_extra(L)	((lunatik_runtime_t *)lua_getextraspace(L))
+#define lunatik_toruntime(L)	(lunatik_extra(L)->runtime)
 
 #define lunatik_cannotsleep(L, s)	((s) && lunatik_isirq(lunatik_toruntime(L)->opt))
-#define lunatik_getstate(runtime)	((lua_State *)runtime->private)
 
-static inline bool lunatik_isready(lua_State *L)
-{
-	bool ready;
-	lua_rawgetp(L, LUA_REGISTRYINDEX, L);
-	ready = lua_toboolean(L, -1);
-	lua_pop(L, 1);
-	return ready;
-}
+#define lunatik_getstate(runtime)	((lua_State *)(runtime)->private)
+#define lunatik_isready(runtime)	\
+	((runtime)->private && lunatik_extra(lunatik_getstate(runtime))->ready)
 
 #define lunatik_handle(runtime, handler, ret, ...)	\
 do {							\
@@ -73,7 +68,7 @@ do {							\
 #define lunatik_run(runtime, handler, ret, ...)				\
 do {									\
 	lunatik_lock(runtime);						\
-	if (unlikely(!lunatik_getstate(runtime)))			\
+	if (unlikely(!lunatik_isready(runtime)))			\
 		ret = -ENXIO;						\
 	else								\
 		lunatik_handle(runtime, handler, ret, ## __VA_ARGS__);	\

--- a/lunatik_aux.c
+++ b/lunatik_aux.c
@@ -39,7 +39,7 @@ int lunatik_loadfile(lua_State *L, const char *filename, const char *mode)
 	int status = LUA_ERRFILE;
 	int fnameindex = lua_gettop(L) + 1;  /* index of filename on the stack */
 
-	if (unlikely(lunatik_cannotsleep(L, lunatik_isready(L)))) {
+	if (unlikely(lunatik_cannotsleep(L, lunatik_isready(lunatik_toruntime(L))))) {
 		lua_pushfstring(L, "cannot load file on non-sleepable runtime");
 		goto error;
 	}

--- a/lunatik_conf.h
+++ b/lunatik_conf.h
@@ -73,6 +73,16 @@ int lunatik_loadfile(lua_State *L, const char *filename, const char *mode);
 #undef LUAI_MAXSTACK
 #define LUAI_MAXSTACK  200
 
+/* stored in L's extraspace; gates lunatik_run */
+struct lunatik_object_s;
+typedef struct lunatik_runtime_s {
+	struct lunatik_object_s *runtime;
+	bool ready;
+} lunatik_runtime_t;
+
+#undef LUA_EXTRASPACE
+#define LUA_EXTRASPACE	sizeof(lunatik_runtime_t)
+
 #ifdef LUNATIK_RUNTIME
 unsigned int luaS_hash(const char *str, size_t l, unsigned int seed); /* required by luarcu */
 #define	lunatik_hash(str, l, seed)	luaS_hash((str), (l), (seed))

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -189,10 +189,11 @@ static const lunatik_class_t lunatik_class = {
 int luaopen_lunatik(lua_State *L);
 int luaopen_lunatik_stub(lua_State *L);
 
-static inline void lunatik_setready(lua_State *L)
+static inline void lunatik_setready(lunatik_object_t *runtime)
 {
-	lua_pushboolean(L, true);
-	lua_rawsetp(L, LUA_REGISTRYINDEX, L);
+	lunatik_lock(runtime); /* publish ready under the same lock readers take */
+	lunatik_extra(lunatik_getstate(runtime))->ready = true;
+	lunatik_unlock(runtime);
 }
 
 static int lunatik_runscript(lua_State *L)
@@ -222,7 +223,6 @@ static int lunatik_runscript(lua_State *L)
 
 	lua_call(L, 0, 1);
 	lua_remove(L, scriptix);
-	lunatik_setready(L);
 	return 1; /* callback */
 }
 
@@ -244,14 +244,18 @@ static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, con
 
 	lunatik_setobject(runtime, &lunatik_class, opt);
 	lunatik_toruntime(L) = runtime;
+	lunatik_extra(L)->ready = false;
 
 	runtime->gfp = GFP_KERNEL; /* might use kvmalloc while running in process */
 	lua_setallocf(L, lunatik_alloc, runtime);
+
+	runtime->private = L;
 
 	lua_pushcfunction(L, lunatik_runscript);
 	lua_pushlightuserdata(L, (void *)script);
 	if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
 		lunatik_runerror(Lfrom, lua_tostring(L, -1));
+		runtime->private = NULL;
 		lua_close(L); /* hooks hold extra krefs; putobject alone won't reach 0 */
 		lunatik_putobject(runtime);
 		return -ENOEXEC;
@@ -260,7 +264,8 @@ static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, con
 	if (lunatik_isirq(opt))
 		runtime->gfp = GFP_ATOMIC;
 
-	runtime->private = L; /* NULL until here: lunatik_run returns -ENXIO during init */
+	lunatik_setready(runtime); /* lunatik_run returns -ENXIO until here */
+
 	*pruntime = runtime;
 	return 0;
 }

--- a/tests/notifier/init_dispatch.lua
+++ b/tests/notifier/init_dispatch.lua
@@ -1,0 +1,27 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Regression: register_netdevice_notifier synchronously replays NETDEV_REGISTER
+-- (and NETDEV_UP) for each existing netdev under the new notifier_block. When
+-- `notifier.netdevice(cb)` is called directly from script init, the replay
+-- fires luanotifier_call while runtime->private was still NULL under the old
+-- "defer private until after pcall" design, causing lua_gettop(NULL) via the
+-- islocked sentinel path in lunatik_handle. The framework now wraps L with a
+-- readiness flag published under the runtime lock: sync handlers dispatched
+-- during register_fn find a valid L, while async handlers (kprobes) still see
+-- -ENXIO via !lunatik_isready(runtime) until init finishes.
+--
+
+local notifier = require("notifier")
+local seen = 0
+
+local function cb(event, name)
+	seen = seen + 1
+	return 0
+end
+
+local n = notifier.netdevice(cb)
+assert(seen >= 1, "expected at least one replayed NETDEV event during init (got " .. seen .. ")")
+n:stop()
+

--- a/tests/notifier/init_dispatch.sh
+++ b/tests/notifier/init_dispatch.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for sync-dispatch during script init.
+#
+# register_netdevice_notifier replays NETDEV_REGISTER (+ NETDEV_UP) synchronously
+# for each existing netdev when a new notifier block is registered. Calling
+# notifier.netdevice(cb) directly at script init triggers this replay while the
+# script is still inside lua_pcall. Under the old design (private published only
+# after pcall), luanotifier_call took the islocked sentinel path and entered
+# lunatik_handle with runtime->private = NULL, oopsing on lua_gettop(NULL).
+#
+# Expected: script runs without Lua error, callback fires at least once (lo is
+# always present), and no kernel oops lands in dmesg.
+#
+# Usage: sudo bash tests/notifier/init_dispatch.sh
+
+SCRIPT="tests/notifier/init_dispatch"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() {
+	lunatik stop "$SCRIPT" 2>/dev/null
+}
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 2
+
+mark_dmesg
+mark_ts=$(awk '{print $1}' /proc/uptime)
+
+output=$(lunatik run "$SCRIPT" 2>&1)
+echo "$output" | grep -qE "\.lua:[0-9]+:" && \
+	fail "Lua error during init-time notifier registration: $output"
+ktap_pass "notifier.netdevice() at script init runs without Lua error"
+
+oops=$(dmesg | awk -v ts="$mark_ts" \
+	'match($0, /\[[ ]*([0-9]+\.[0-9]+)/, a) && a[1]+0 >= ts+0' | \
+	grep -E "Oops:|BUG:|kernel BUG at|NULL pointer dereference|general protection" || true)
+[ -n "$oops" ] && fail "kernel oops during init-time notifier replay: ${oops%%$'\n'*}"
+ktap_pass "no kernel oops during init-time NETDEV_REGISTER replay"
+
+ktap_totals
+

--- a/tests/notifier/run.sh
+++ b/tests/notifier/run.sh
@@ -11,7 +11,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
 SEP=$'\n'
-for t in "$DIR"/context_mismatch.sh; do
+for t in "$DIR"/context_mismatch.sh "$DIR"/init_dispatch.sh; do
 	echo "${SEP}# --- $(basename "$t") ---"
 	bash "$t" || FAILED=$((FAILED+1))
 done


### PR DESCRIPTION
register_netdevice_notifier replays NETDEV_REGISTER synchronously for existing netdevs. A script calling notifier.netdevice(cb) at init triggers this replay inside lua_pcall; luanotifier_call takes the islocked sentinel and crashes on lua_gettop(NULL) because runtime->private was deferred until after pcall.

The deferred publish exists to keep async kprobe handlers out of L during init: lunatik_run saw private=NULL and bailed -ENXIO. But sync handlers dispatched from register_fn on the same thread also need L, and the NULL sentinel killed them too.

Split the signals. Publish runtime->private = L immediately, and gate lunatik_run on a separate ready flag stored in L's extraspace next to the runtime pointer. ready flips under the runtime lock after lua_pcall, so async handlers still observe -ENXIO during init.

This folds the previous L-registry readiness flag (lunatik_setready / lunatik_isready(L)) into the same bit; luathread.run and lunatik_loadfile now use lunatik_isready(runtime).

Regression: tests/notifier/init_dispatch.