### PR TITLE
autogen: skip rewriting kbuild inputs when unchanged

### DIFF
--- a/autogen.lua
+++ b/autogen.lua
@@ -71,10 +71,17 @@ function util.slurp(path)
 	return f:read("a")
 end
 
---- Write a string to a file, creating/replacing it.
+local function unchanged(path, text)
+	local f <close> = io.open(path, "r")
+	return f and f:read("a") == text
+end
+
+--- Write a string to a file. No-op if its current contents match,
+-- so downstream tools (notably kbuild) can skip rebuilds.
 -- @tparam string path
 -- @tparam string text
 function util.spit(path, text)
+	if unchanged(path, text) then return end
 	local f <close>, err = io.open(path, "w")
 	if not f then util.die("cannot write %s: %s", path, err) end
 	f:write(text)


### PR DESCRIPTION
`util.spit` always rewrote the file, advancing the mtime of `targets.mk`, `dump_N.c` and `extract.c` even when their content hadn't changed. That defeated kbuild's incremental tracking: every autogen run forced cpp + cc to re-emit `dump_N.pp` and `extract.s`.

Add `util.spit_if_changed` and use it at those three sites so the sub-make becomes a no-op when inputs are stable, e.g. when a kernel module is toggled (`extract.c` body is stable across module sets).