### PR TITLE
examples/ifquarantine: use lunatik run, not spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ execution contexts.
 
 ```
 sudo make examples_install                         # installs examples
-sudo lunatik spawn examples/ifquarantine/control   # starts control+filter
+sudo lunatik run examples/ifquarantine/control     # starts control+filter
 sudo cat /dev/ifquarantine                         # lists known interfaces and verdict
 sudo sh -c "echo 'allow=eth0' > /dev/ifquarantine" # lift quarantine on eth0
 sudo sh -c "echo 'deny=eth0'  > /dev/ifquarantine" # re-apply quarantine


### PR DESCRIPTION
control.lua is a setup script: it creates the device, spawns the filter runtime via runner.run, registers the notifier, and returns nothing. `lunatik spawn` requires the script to return a function that becomes the kernel thread body (via thread.run); with a nil return, spawn would fail. Use `lunatik run`, matching the systrack/device pattern which has the same shape.