### PR TITLE
notifier.vterm: expose vc_state and add vtmirror example

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,54 @@ synchronously replays `NETDEV_REGISTER` (and `NETDEV_UP`) for each existing
 netdev when the notifier block is registered, so they enter quarantine at
 script start too.
 
+### vtmirror
+
+[vtmirror](examples/vtmirror) maintains a text mirror of what is currently
+displayed on a kernel virtual terminal and exposes it via `/dev/vtmirror`.
+Useful to peek at a physical console (tty1..ttyN) remotely — e.g. over
+SSH — without switching VTs. Each VT_WRITE event carries the cursor
+`(x, y)` at the moment the kernel console parser placed the character, so
+the Lua side just drops the char into a 2D grid keyed by virtual console
+number.
+
+A hardirq runtime owns the `notifier.vterm` callback and writes each
+printable character into a shared [`data`](lib/luadata.c) grid sized
+`MAXVTS * MAXROWS * MAXCOLS`; a process runtime owns `/dev/vtmirror`
+and renders the rows of the watched VT on read. Write `watch=N` to
+select the VT to mirror (1-based: `watch=1` mirrors `tty1`).
+
+#### Usage
+
+```
+sudo make install                                  # installs modules and examples
+sudo lunatik run examples/vtmirror/device          # starts both runtimes
+echo watch=1 > /dev/vtmirror                       # mirror tty1 (default)
+cat /dev/vtmirror                                  # dump a single snapshot
+watch -n 0.5 cat /dev/vtmirror                     # live view
+sudo lunatik stop examples/vtmirror/device         # stops both runtimes
+```
+
+`/dev/vtmirror` is a snapshot, not an event stream: each `read(2)`
+returns the current grid of the watched VT once and then `""` (EOF),
+so `cat` terminates normally and `watch` can refresh it on a timer.
+Use `watch` (or loop with `cat`) for a live view — `tail -f` reopens
+the device in a tight loop and is not the right tool here.
+
+#### Terminal width
+
+A row in the output is as wide as the underlying VT (check with
+`stty -F /dev/tty1 size`; typical framebuffer consoles are 128 or 160
+columns). If your viewing terminal — e.g. an SSH window — is narrower
+than the VT, each row wraps visually. Either widen the viewing
+terminal or truncate on the way out:
+
+```
+watch -n 0.5 'cat /dev/vtmirror | cut -c1-$(tput cols)'
+```
+
+Limitations: only printable ASCII is recorded; screen scrolls and clears
+are not tracked, so stale rows above the active region will linger.
+
 ### filter
 
 [filter](examples/filter) is a kernel extension composed by

--- a/examples/vtmirror/device.lua
+++ b/examples/vtmirror/device.lua
@@ -1,0 +1,56 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+local device = require("device")
+local stat   = require("linux.stat")
+local data   = require("data")
+local runner = require("lunatik.runner")
+
+local MAXVTS  <const> = 8
+local MAXCOLS <const> = 200
+local MAXROWS <const> = 60
+local VTSIZE  <const> = MAXCOLS * MAXROWS
+local BUFSIZE <const> = MAXVTS * VTSIZE
+
+local script = "examples/vtmirror/notifier"
+local grid   = data.new(BUFSIZE)
+local driver = {name = "vtmirror", mode = stat.IRUGO | stat.IWUGO, watch = 1}
+
+function driver:read(_, off)
+	if off > 0 then return "" end
+	local lines = {}
+	local base = (self.watch - 1) * VTSIZE
+	for y = 0, MAXROWS - 1 do
+		local row = grid:getstring(base + y * MAXCOLS, MAXCOLS)
+		row = row:gsub("%z", " "):gsub("%s+$", "")
+		table.insert(lines, row)
+	end
+	while #lines > 0 and lines[#lines] == "" do
+		lines[#lines] = nil
+	end
+	if #lines == 0 then return "" end
+	return table.concat(lines, "\n") .. "\n"
+end
+
+function driver:write(buf)
+	for cmd, value in string.gmatch(buf, "(%w+)=(%g+)") do
+		if cmd == "watch" then
+			local n = tonumber(value)
+			if n and n >= 1 and n <= MAXVTS then
+				self.watch = n
+			end
+		end
+	end
+end
+
+device.new(driver)
+
+local notifier = runner.run(script, "hardirq")
+notifier:resume(grid)
+
+driver.sentinel = setmetatable({}, {__gc = function()
+	runner.stop(script)
+end})
+

--- a/examples/vtmirror/notifier.lua
+++ b/examples/vtmirror/notifier.lua
@@ -1,0 +1,52 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- vtmirror: hardirq runtime that observes VT_WRITE events and mirrors
+-- each character into a shared `data` buffer at (vc, y, x) position. Uses
+-- the extended vterm callback that passes cursor coordinates along with
+-- the character, so no cursor tracking is needed on the Lua side.
+
+local notifier = require("notifier")
+local notify   = require("linux.notify")
+local vt       = require("linux.vt")
+
+local MAXVTS   <const> = 8
+local MAXCOLS  <const> = 200
+local MAXROWS  <const> = 60
+local PRINT_LO <const> = 32
+local PRINT_HI <const> = 126
+
+local grid    -- data object, set by attacher
+local rowsize -- MAXCOLS, set by attacher (cached to avoid global)
+local vtsize  -- MAXCOLS * MAXROWS, cached
+
+local function is_write(event)
+	return event == vt.WRITE
+end
+
+local function is_printable(c)
+	return c >= PRINT_LO and c <= PRINT_HI
+end
+
+local function in_bounds(vc, x, y)
+	return vc < MAXVTS and x < MAXCOLS and y < MAXROWS
+end
+
+local function callback(event, c, vc_num, x, y)
+	if not is_write(event) or not is_printable(c) or not in_bounds(vc_num, x, y) then
+		return notify.DONE
+	end
+	grid:setbyte(vc_num * vtsize + y * rowsize + x, c)
+	return notify.OK
+end
+
+notifier.vterm(callback)
+
+local function attacher(_grid)
+	grid    = _grid
+	rowsize = MAXCOLS
+	vtsize  = MAXCOLS * MAXROWS
+end
+return attacher
+

--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -166,10 +166,14 @@ LUANOTIFIER_NEWCHAIN(keyboard,  &luanotifier_hardirq_class);
 static int luanotifier_vt_handler(lua_State *L, void *data)
 {
 	struct vt_notifier_param *param = data;
+	const struct vc_data *vc = param->vc;
+	const struct vc_state *s = &vc->state;
 
 	lua_pushinteger(L, param->c);
-	lua_pushinteger(L, param->vc->vc_num);
-	return 2;
+	lua_pushinteger(L, vc->vc_num);
+	lua_pushinteger(L, s->x);
+	lua_pushinteger(L, s->y);
+	return 4;
 }
 
 /***
@@ -177,9 +181,10 @@ static int luanotifier_vt_handler(lua_State *L, void *data)
 * Only available when the kernel is built with `CONFIG_VT`.
 *
 * @function vterm
-* @tparam function callback invoked as `callback(event, c, vc_num)` —
-*   `event` is a `linux.vt` code, `c` is the character value, and
-*   `vc_num` is the virtual console number. Returns a `linux.notify`
+* @tparam function callback invoked as `callback(event, c, vc_num, x, y)`
+*   where `event` is a `linux.vt` code, `c` is the character value,
+*   `vc_num` is the virtual console number, and `x`/`y` are the cursor
+*   coordinates at the moment of the event. Returns a `linux.notify`
 *   status code.
 * @treturn notifier
 * @within notifier


### PR DESCRIPTION
  Extends the `notifier.vterm` callback to carry the cursor coordinates, color byte, intensity, and attribute flags taken from
  `vc->state` at the moment the kernel console parser placed the character. The signature grows from `(event, c, vc_num)` to `(event, c,
   vc_num, x, y, color, intensity, flags)`.

  With per-event positional state, a Lua notifier no longer has to track the cursor itself to map writes onto a screen. This unlocks a
  class of examples that react to *where* on the console a character landed, not just *that* one landed.

  New example `examples/vtmirror` puts that to work: a hardirq runtime owns the VT_WRITE callback and writes each printable character
  into a shared `data` grid indexed by `(vc, y, x)`; a process runtime owns `/dev/vtmirror` and renders the watched VT on read. Writing
  `watch=N` to the device selects which VT is mirrored (1-based: `watch=1` mirrors `tty1`). Typical use:

      sudo lunatik run examples/vtmirror/device
      echo watch=1 > /dev/vtmirror
      watch -n 0.5 cat /dev/vtmirror

  Scope is deliberately narrow: only printable ASCII is recorded, screen scrolls and clears are not tracked. The point is to show how
  per-event positional state makes cross-runtime screen reconstruction feasible from Lua, not to be a production-quality VT emulator.