### PR TITLE
lunatik: require classes via class opener to avoid file I/O

### DIFF
--- a/lib/luacompletion.c
+++ b/lib/luacompletion.c
@@ -110,9 +110,11 @@ static const luaL_Reg luacompletion_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(completion);
 static const lunatik_class_t luacompletion_class = {
 	.name = "completion",
 	.methods = luacompletion_mt,
+	.opener = luaopen_completion,
 	.opt = LUNATIK_OPT_SOFTIRQ,
 };
 

--- a/lib/luadata.c
+++ b/lib/luadata.c
@@ -325,10 +325,12 @@ static const luaL_Reg luadata_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(data);
 static const lunatik_class_t luadata_class = {
 	.name = "data",
 	.methods = luadata_mt,
 	.release = luadata_release,
+	.opener = luaopen_data,
 	.opt = LUNATIK_OPT_SOFTIRQ | LUNATIK_OPT_MONITOR,
 };
 
@@ -357,7 +359,7 @@ LUNATIK_NEWLIB(data, luadata_lib, luadata_classes);
 
 lunatik_object_t *luadata_new(lua_State *L, lunatik_opt_t opt)
 {
-	lunatik_require(L, "data");
+	lunatik_require(L, &luadata_class);
 	lunatik_object_t *object = lunatik_newobject(L, &luadata_class, sizeof(luadata_t), opt);
 	return object;
 }

--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -336,10 +336,12 @@ static const luaL_Reg luadevice_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(device);
 static const lunatik_class_t luadevice_class = {
 	.name = "device",
 	.methods = luadevice_mt,
 	.release = luadevice_release,
+	.opener = luaopen_device,
 	.opt = LUNATIK_OPT_SINGLE,
 };
 

--- a/lib/luafib.c
+++ b/lib/luafib.c
@@ -134,7 +134,9 @@ static const luaL_Reg luafib_lib[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(fib);
 static const lunatik_class_t luafib_class = {
+	.opener = luaopen_fib,
 	.opt = LUNATIK_OPT_NONE,
 };
 

--- a/lib/luafifo.c
+++ b/lib/luafifo.c
@@ -118,10 +118,12 @@ static const luaL_Reg luafifo_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(fifo);
 static const lunatik_class_t luafifo_class = {
 	.name = "fifo",
 	.methods = luafifo_mt,
 	.release = luafifo_release,
+	.opener = luaopen_fifo,
 	.opt = LUNATIK_OPT_SOFTIRQ | LUNATIK_OPT_MONITOR,
 };
 

--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -68,10 +68,12 @@ static const luaL_Reg luahid_mt[] = {
 	{NULL, NULL},
 };
 
+LUNATIK_OPENER(hid);
 static const lunatik_class_t luahid_class = {
 	.name = "hid",
 	.methods = luahid_mt,
 	.release = luahid_release,
+	.opener = luaopen_hid,
 	.opt = LUNATIK_OPT_SOFTIRQ | LUNATIK_OPT_SINGLE,
 };
 

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -112,10 +112,12 @@ static const luaL_Reg luanetfilter_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(netfilter);
 static const lunatik_class_t luanetfilter_class = {
 	.name = "netfilter",
 	.methods = luanetfilter_mt,
 	.release = luanetfilter_release,
+	.opener = luaopen_netfilter,
 	.opt = LUNATIK_OPT_SOFTIRQ | LUNATIK_OPT_SINGLE,
 };
 

--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -202,10 +202,12 @@ static const luaL_Reg luanotifier_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(notifier);
 static const lunatik_class_t luanotifier_process_class = {
 	.name = "notifier",
 	.methods = luanotifier_mt,
 	.release = luanotifier_release,
+	.opener = luaopen_notifier,
 	.opt = LUNATIK_OPT_SINGLE,
 };
 
@@ -213,6 +215,7 @@ static const lunatik_class_t luanotifier_hardirq_class = {
 	.name = "notifier",
 	.methods = luanotifier_mt,
 	.release = luanotifier_release,
+	.opener = luaopen_notifier,
 	.opt = LUNATIK_OPT_HARDIRQ | LUNATIK_OPT_SINGLE,
 };
 

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -174,10 +174,12 @@ static const luaL_Reg luaprobe_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(probe);
 static const lunatik_class_t luaprobe_class = {
 	.name = "probe",
 	.methods = luaprobe_mt,
 	.release = luaprobe_release,
+	.opener = luaopen_probe,
 	.opt = LUNATIK_OPT_HARDIRQ | LUNATIK_OPT_SINGLE,
 };
 

--- a/lib/luarcu.c
+++ b/lib/luarcu.c
@@ -287,10 +287,12 @@ static const struct luaL_Reg luarcu_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(rcu);
 static const lunatik_class_t luarcu_class = {
 	.name = "rcu",
 	.methods = luarcu_mt,
 	.release = luarcu_release,
+	.opener = luaopen_rcu,
 	.opt = LUNATIK_OPT_SOFTIRQ,
 };
 

--- a/lib/luaskb.c
+++ b/lib/luaskb.c
@@ -223,10 +223,12 @@ static const luaL_Reg luaskb_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(skb);
 static const lunatik_class_t luaskb_class = {
 	.name    = "skb",
 	.methods = luaskb_mt,
 	.release = luaskb_release,
+	.opener = luaopen_skb,
 	.opt = LUNATIK_OPT_SOFTIRQ | LUNATIK_OPT_SINGLE,
 };
 
@@ -252,7 +254,7 @@ static int luaskb_copy(lua_State *L)
 
 lunatik_object_t *luaskb_new(lua_State *L)
 {
-	lunatik_require(L, "skb");
+	lunatik_require(L, &luaskb_class);
 	lunatik_object_t *object = lunatik_newobject(L, &luaskb_class, sizeof(luaskb_t), LUNATIK_OPT_NONE);
 	luaskb_t *lskb = (luaskb_t *)object->private;
 	lskb->data = luadata_new(L, LUNATIK_OPT_SINGLE);

--- a/lib/luaskel.c
+++ b/lib/luaskel.c
@@ -39,10 +39,12 @@ static const luaL_Reg luaskel_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(skel);
 static const lunatik_class_t luaskel_class = {
 	.name = "skel",
 	.methods = luaskel_mt,
 	.release = luaskel_release,
+	.opener = luaopen_skel,
 	.opt = LUNATIK_OPT_MONITOR,
 };
 

--- a/lib/luasocket.c
+++ b/lib/luasocket.c
@@ -394,10 +394,12 @@ static const luaL_Reg luasocket_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(socket);
 static const lunatik_class_t luasocket_class = {
 	.name = "socket",
 	.methods = luasocket_mt,
 	.release = luasocket_release,
+	.opener = luaopen_socket,
 	.opt = LUNATIK_OPT_MONITOR | LUNATIK_OPT_EXTERNAL,
 };
 

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -159,9 +159,11 @@ static const luaL_Reg luathread_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(thread);
 static const lunatik_class_t luathread_class = {
 	.name = "thread",
 	.methods = luathread_mt,
+	.opener = luaopen_thread,
 	.opt = LUNATIK_OPT_MONITOR,
 };
 

--- a/lunatik.h
+++ b/lunatik.h
@@ -79,6 +79,7 @@ typedef struct lunatik_class_s {
 	const char *name;
 	const luaL_Reg *methods;
 	void (*release)(void *);
+	lua_CFunction opener;
 	lunatik_opt_t opt;
 } lunatik_class_t;
 
@@ -235,11 +236,12 @@ void lunatik_monitorobject(lua_State *L, const lunatik_class_t *class);
 #define lunatik_getobject(o)		kref_get(&(o)->kref)
 #define lunatik_putobject(o)		kref_put(&(o)->kref, lunatik_releaseobject)
 
-static inline void lunatik_require(lua_State *L, const char *libname)
+static inline void lunatik_require(lua_State *L, const lunatik_class_t *class)
 {
-	lua_getglobal(L, "require");
-	lua_pushstring(L, libname);
-	lua_call(L, 1, 0);
+	if (class->opener) {
+		luaL_requiref(L, class->name, class->opener, 0);
+		lua_pop(L, 1);
+	}
 }
 
 static inline void lunatik_pushobject(lua_State *L, lunatik_object_t *object)
@@ -310,6 +312,8 @@ static inline void lunatik_newclasses(lua_State *L, const lunatik_class_t **clas
 		lunatik_newclass(L, cls, false);
 	}
 }
+
+#define LUNATIK_OPENER(libname)		int luaopen_##libname(lua_State *L)
 
 #define LUNATIK_NEWLIB(libname, funcs, classes)					\
 int luaopen_##libname(lua_State *L);						\

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -178,16 +178,15 @@ static const luaL_Reg lunatik_mt[] = {
 	{NULL, NULL}
 };
 
+LUNATIK_OPENER(lunatik);
+LUNATIK_OPENER(lunatik_stub);
 static const lunatik_class_t lunatik_class = {
 	.name = "lunatik",
 	.methods = lunatik_mt,
 	.release = lunatik_releaseruntime,
+	.opener = luaopen_lunatik,
 	.opt = LUNATIK_OPT_MONITOR | LUNATIK_OPT_EXTERNAL,
 };
-
-/* used for luaL_requiref() */
-int luaopen_lunatik(lua_State *L);
-int luaopen_lunatik_stub(lua_State *L);
 
 static inline void lunatik_setready(lunatik_object_t *runtime)
 {

--- a/lunatik_obj.c
+++ b/lunatik_obj.c
@@ -59,7 +59,7 @@ void lunatik_cloneobject(lua_State *L, lunatik_object_t *object)
 	if (lunatik_issingle(object->opt))
 		luaL_error(L, "'%s': %s", class->name, LUNATIK_ERR_SINGLE);
 
-	lunatik_require(L, class->name);
+	lunatik_require(L, class);
 	lunatik_object_t **pobject = lunatik_newpobject(L, 1);
 
 	lunatik_checkclass(L, class);

--- a/tests/README.md
+++ b/tests/README.md
@@ -91,3 +91,7 @@ Regression tests for `lunatik_newruntime`.
   `completion` to a sub-runtime that sends a message; the main runtime
   receives and asserts the value.
 
+- **require_cloneobject**: `lunatik_cloneobject` must load a class into
+  the receiving runtime via the class opener (`luaL_requiref`) even when
+  that runtime never called `require()` for the module.
+

--- a/tests/runtime/require_cloneobject.lua
+++ b/tests/runtime/require_cloneobject.lua
@@ -1,0 +1,18 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the require_cloneobject regression test (see require_cloneobject.sh).
+
+local lunatik = require("lunatik")
+local data    = require("data")
+
+local d = data.new(4)
+d:setuint32(0, 0xdeadbeef)
+
+local rt = lunatik.runtime("tests/runtime/require_cloneobject_recv", "softirq")
+local ok, err = pcall(rt.resume, rt, d)
+if not ok then
+	error("lunatik_require failed: " .. tostring(err))
+end
+

--- a/tests/runtime/require_cloneobject.sh
+++ b/tests/runtime/require_cloneobject.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for lunatik_require using luaL_requiref (no file I/O).
+# A data object is passed via resume() to a softirq receiver that never
+# called require("data"). lunatik_cloneobject runs under the spinlock held
+# by lunatik_monitorobject and must load the class via lunatik_require
+# (opener field) without sleeping — otherwise "scheduling while atomic".
+#
+# Usage: sudo bash tests/runtime/require_cloneobject.sh
+
+SCRIPT="tests/runtime/require_cloneobject"
+MODULE="luadata"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() { lunatik stop "$SCRIPT" 2>/dev/null; }
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+cat /sys/module/$MODULE/refcnt > /dev/null 2>&1 || {
+	echo "# SKIP: $MODULE not loaded"
+	ktap_totals
+	exit 0
+}
+
+mark_dmesg
+
+run_script "$SCRIPT"
+
+check_dmesg || { ktap_totals; exit 1; }
+ktap_pass "lunatik_require loads class via opener without file I/O"
+
+ktap_totals
+

--- a/tests/runtime/require_cloneobject_recv.lua
+++ b/tests/runtime/require_cloneobject_recv.lua
@@ -1,0 +1,20 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Receiver sub-script for the require_cloneobject regression test.
+-- Deliberately does NOT require("data") — the class must be loaded by
+-- lunatik_cloneobject via lunatik_require (luaL_requiref, no file I/O).
+--
+-- Clear package.searchers so that require() cannot locate any module.
+-- luaL_requiref calls the opener directly and ignores searchers; the
+-- broken path (lua_getglobal "require") will fail with "module not found",
+-- propagating an error back to the sender and causing the test to fail.
+package.searchers = {}
+
+local function recv(d)
+	assert(d:getuint32(0) == 0xdeadbeef)
+end
+
+return recv
+

--- a/tests/runtime/run.sh
+++ b/tests/runtime/run.sh
@@ -10,11 +10,21 @@
 DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
+TESTS=(
+	refcnt_leak.sh
+	resume_shared.sh
+	resume_mailbox.sh
+	rcu_shared.sh
+	opt_guards.sh
+	opt_skb_single.sh
+	require_cloneobject.sh
+)
+
 SEP=""
-for t in "$DIR"/refcnt_leak.sh "$DIR"/resume_shared.sh "$DIR"/resume_mailbox.sh "$DIR"/rcu_shared.sh "$DIR"/opt_guards.sh "$DIR"/opt_skb_single.sh; do
-	echo "${SEP}# --- $(basename "$t") ---"
+for t in "${TESTS[@]}"; do
+	echo "${SEP}# --- $t ---"
 	SEP=$'\n'
-	bash "$t" || FAILED=$((FAILED+1))
+	bash "$DIR/$t" || FAILED=$((FAILED+1))
 done
 
 exit $FAILED


### PR DESCRIPTION
`lunatik_require` used Lua's global `require()` via the package file
  searcher, which can sleep (file I/O on SquashFS). This caused
  "scheduling while atomic" when reached from atomic context (e.g.
  `lunatik_monitorobject` holding a spinlock).

  Add an `opener` field to `lunatik_class_t` and a `LUNATIK_OPENER(libname)`
  macro to forward-declare it. `lunatik_require` now calls `luaL_requiref`
  with `class->opener` — it respects `package.loaded` (still idempotent)
  but invokes the C opener directly, no searchers, no I/O.

  Includes a regression test (`tests/runtime/require_cloneobject`) that
  clears `package.searchers` in the receiving softirq runtime and checks
  that cloneobject still loads the class.