### PR TITLE
tests: timestamp-based dmesg filter, reload around lunatik test, doc refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,16 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>]
 Install and run the test suites:
 
 ```sh
-sudo make tests_install
+sudo make install
 sudo lunatik test           # run all suites
-sudo lunatik test thread    # run a specific suite (monitor, thread, runtime)
+sudo lunatik test thread    # run a specific suite (crypto, io, monitor,
+                            # notifier, probe, rcu, runtime, socket, thread)
 ```
+
+`lunatik test` reloads the modules before the run and unloads them
+afterwards, so each invocation exercises the currently-installed kernel
+code. See [tests/README.md](tests/README.md) for the full list of suites
+and individual tests.
 
 ## Lua Version
 

--- a/bin/lunatik
+++ b/bin/lunatik
@@ -76,14 +76,16 @@ end
 local tests_path = "/usr/local/share/lunatik/tests"
 
 local function test_modules()
-	ensure_loaded()
 	local suite  = arg[2]
 	local target = suite and (tests_path .. "/" .. suite .. "/run.sh")
 	                      or (tests_path .. "/run.sh")
 	if not os.execute("[ -f " .. target .. " ]") then
 		error("tests not installed; run: sudo make tests_install")
 	end
+	reload_modules()
+	ensure_loaded()
 	os.execute("bash " .. target)
+	unload_modules()
 end
 
 local commands = {

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,93 +5,124 @@ Integration tests for lunatik kernel modules. Output follows
 
 ## Requirements
 
-- Lunatik modules loaded: `sudo lunatik load`
-- Lua scripts installed: `sudo make tests_install`
+- Lunatik installed: `sudo make install`
 - Root privileges
 
 ## Running
 
-All suites:
+All suites (reloads the modules before and unloads after):
 
 ```
-sudo bash tests/run.sh
+sudo lunatik test
 ```
 
 Individual suite:
 
 ```
-sudo bash tests/monitor/run.sh
-sudo bash tests/thread/run.sh
+sudo lunatik test <suite>          # e.g. runtime, socket, thread, ...
+```
+
+Or invoke the harness directly (no reload):
+
+```
+sudo bash tests/run.sh
 sudo bash tests/runtime/run.sh
-```
-
-Individual test:
-
-```
-sudo bash tests/monitor/gc.sh
-sudo bash tests/thread/shouldstop.sh
-sudo bash tests/thread/run_during_load.sh
 sudo bash tests/runtime/refcnt_leak.sh
-sudo bash tests/runtime/resume_shared.sh
-sudo bash tests/runtime/resume_mailbox.sh
 ```
 
 ## Suites
+
+### crypto
+
+Covers the `crypto` module: `shash`, `skcipher`, `aead`, `rng`, `hkdf`,
+`comp`.
+
+### io
+
+- **test**: kernel `io` library (open/read/write/seek/lines/type); also
+  asserts `io` is absent from softirq runtimes.
 
 ### monitor
 
 Regression tests for `lunatik_monitor` (spinlock + GC interaction).
 
-- **gc**: GC running under spinlock triggers "scheduling while atomic".
-  A spawned thread uses a `sleep=false` fifo from a `sleep=true` runtime;
-  `f:pop()` allocates inside `spin_lock_bh`, forcing GC that finalizes a
-  dropped AF_PACKET socket.
+- **gc**: a spawned thread uses a `sleep=false` fifo from a `sleep=true`
+  runtime; `f:pop()` allocates inside `spin_lock_bh`, forcing GC that
+  finalizes a dropped AF_PACKET socket. Must not trigger "scheduling
+  while atomic".
+
+### notifier
+
+- **context_mismatch**: calling a hardirq-class constructor (e.g.
+  `notifier.keyboard`) from a process runtime must error with "runtime
+  context mismatch" without oopsing during `__gc`.
+
+- **init_dispatch**: `notifier.netdevice(cb)` at script init must handle
+  the synchronous `NETDEV_REGISTER` replay `register_netdevice_notifier`
+  performs for existing devices.
+
+### probe
+
+- **kprobe_concurrent**: registers kprobes on every syscall and runs
+  one load generator per CPU; `lunatik stop` must complete within 5s
+  with no kernel errors under concurrent handler firings.
+
+### rcu
+
+- **map_values**: `rcu.map()` iterates booleans, integers, userdata,
+  mixed types, and skips nil (deleted) entries.
+
+- **map_sync**: `rcu.map()` remains safe when called while another
+  kthread is modifying the table.
+
+### runtime
+
+Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
+
+- **refcnt_leak**: module use-count leak when a script errors after a
+  successful `netfilter.register()` call. The fix, under the runtime
+  spinlock, nulls `runtime->private`, calls `lua_close(L)` to fire the
+  hook finalizer (`nf_unregister_net_hook` + `symbol_put_addr`), and
+  then releases the runtime.
+
+- **resume_shared**: `runtime:resume()` passes shared (monitored) objects
+  across runtime boundaries. Push into a shared `fifo`, resume a
+  sub-runtime with it, assert the value pops on the other side.
+
+- **resume_mailbox**: `completion` objects pass through `runtime:resume()`
+  to enable the mailbox pattern. Sub-runtime sends via `fifo` +
+  `completion`; main runtime receives.
+
+- **rcu_shared**: `rcu.table()` is clonable into `lunatik._ENV` and
+  retrievable from another runtime.
+
+- **opt_guards**: `lunatik_opt_t` guards reject `SINGLE` objects in
+  `resume()` / `_ENV[key] = obj` and accept `MONITOR`/`NONE`.
+
+- **opt_skb_single**: `skb` and `skb:data()` are `SINGLE`, cannot be
+  stored in `_ENV`; exercised through a `LOCAL_OUT` netfilter hook on
+  loopback.
+
+- **require_cloneobject**: `lunatik_cloneobject` loads the class into
+  the receiving runtime via `class->opener` (`luaL_requiref`), even when
+  that runtime never called `require()` for the module.
+
+### socket
+
+- **unix/stream**: `socket.unix` STREAM server (bind/listen/accept) and
+  client (connect/send/receive), both using the path stored at
+  construction.
+
+- **unix/dgram**: `socket.unix` DGRAM server (`receivefrom` with
+  `DONTWAIT`) and client (`sendto` using the stored path).
 
 ### thread
 
 Regression tests for `luathread`.
 
-- **shouldstop**: `thread.shouldstop()` must return `false` in a `run`
-  (non-kthread) context without crashing, and `true` when stop is requested
-  in a `spawn` (kthread) context.
+- **shouldstop**: `thread.shouldstop()` returns `false` in a `run`
+  (non-kthread) context without crashing, and `true` in a `spawn`
+  (kthread) context when stop is requested.
 
 - **run_during_load**: `runner.spawn()` called from a script's top-level
-  code (during module load) must error instead of hanging the kernel.
-
-### runtime
-
-Regression tests for `lunatik_newruntime`.
-
-- **refcnt_leak**: module use-count leak when a script errors after a
-  successful `netfilter.register()` call.
-
-  `require("netfilter")` creates an LSTRMEM string in the Lua state via
-  `__symbol_get("luaopen_netfilter")`.  Each `netfilter.register()` call
-  increments the runtime kref (via `lunatik_getobject`), so after one
-  successful register the kref is 2.  If the script then errors,
-  `lunatik_newruntime`'s error path calls `lunatik_putobject(runtime)`
-  (kref 2→1), but never reaches 0 — `lua_close()` is never called.
-  The LSTRMEM string is never freed, `symbol_put_addr()` is never invoked,
-  and luanetfilter's use-count stays elevated.  `lunatik reload` then fails
-  with "Module luanetfilter is in use".
-
-  Fix: in the error path, set `runtime->private = NULL` under the spinlock
-  (so any in-flight hook sees NULL and bails), call `lua_close(L)` explicitly
-  (GC runs, hook finalizer fires: `nf_unregister_net_hook` +
-  `lunatik_putobject` kref 2→1, LSTRMEM freed → `symbol_put_addr` restores
-  refcnt), then `lunatik_putobject(runtime)` kref 1→0 → `kfree`.
-
-- **resume_shared**: `runtime:resume()` must correctly pass shared (monitored)
-  objects across runtime boundaries. Pushes a value into a shared `fifo`,
-  passes it to a sub-runtime via `resume()`, and asserts the value can be
-  popped.
-
-- **resume_mailbox**: `completion` objects must be passable via
-  `runtime:resume()` to enable the mailbox pattern. Passes a `fifo` and
-  `completion` to a sub-runtime that sends a message; the main runtime
-  receives and asserts the value.
-
-- **require_cloneobject**: `lunatik_cloneobject` must load a class into
-  the receiving runtime via the class opener (`luaL_requiref`) even when
-  that runtime never called `require()` for the module.
-
+  code must error instead of hanging the kernel.

--- a/tests/crypto/run.sh
+++ b/tests/crypto/run.sh
@@ -23,7 +23,7 @@ for t in $TESTS; do
 		ktap_fail "crypto/$t: script execution failed"
 		continue
 	fi
-	errs=$(dmesg | tail -n +$((DMESG_LINE+1)) | grep -iE "^[^:]+: FAIL	|\.lua:[0-9]+:" || true)
+	errs=$(dmesg_since | grep -iE "^[^:]+: FAIL	|\.lua:[0-9]+:" || true)
 	if [ -z "$errs" ]; then
 		ktap_pass "crypto/$t"
 	else

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -16,11 +16,15 @@ ktap_pass()   { KTAP_COUNT=$((KTAP_COUNT+1)); KTAP_PASS=$((KTAP_PASS+1)); echo "
 ktap_fail()   { KTAP_COUNT=$((KTAP_COUNT+1)); KTAP_FAIL=$((KTAP_FAIL+1)); echo "not ok $KTAP_COUNT $*"; }
 ktap_totals() { echo "# Totals: pass:$KTAP_PASS fail:$KTAP_FAIL skip:0"; }
 
-DMESG_LINE=0
-mark_dmesg()  { DMESG_LINE=$(dmesg | wc -l); }
+DMESG_TS=0
+mark_dmesg() { DMESG_TS=$(awk '{print $1}' /proc/uptime); }
+dmesg_since() {
+	dmesg | awk -v ts="$DMESG_TS" \
+		'match($0, /\[[ ]*([0-9]+\.[0-9]+)/, a) && a[1]+0 >= ts+0'
+}
 check_dmesg() {
 	local errs
-	errs=$(dmesg | tail -n +$((DMESG_LINE+1)) | grep -E "\.lua:[0-9]+:" || true)
+	errs=$(dmesg_since | grep -E "\.lua:[0-9]+:" || true)
 	[ -z "$errs" ] && return 0
 	ktap_fail "no Lua errors in kernel"
 	echo "# $errs"

--- a/tests/monitor/gc.sh
+++ b/tests/monitor/gc.sh
@@ -26,17 +26,13 @@ ktap_header
 ktap_plan 1
 
 mark_dmesg
-mark_ts=$(awk '{print $1}' /proc/uptime)
 
 lunatik spawn "$SCRIPT"
 sleep $SLEEP
 lunatik stop "$SCRIPT"
 
 check_dmesg || exit 1
-# scan dmesg since mark_ts for "scheduling while atomic" (GC-under-spinlock panic)
-sched=$(dmesg | awk -v ts="$mark_ts" \
-	'match($0, /\[[ ]*([0-9]+\.[0-9]+)/, a) && a[1]+0 >= ts+0' | \
-	grep "scheduling while atomic" || true)
+sched=$(dmesg_since | grep "scheduling while atomic" || true)
 [ -n "$sched" ] && fail "GC ran under spinlock: scheduling while atomic"
 ktap_pass "GC did not run under spinlock"
 

--- a/tests/notifier/context_mismatch.sh
+++ b/tests/notifier/context_mismatch.sh
@@ -32,16 +32,13 @@ ktap_header
 ktap_plan 2
 
 mark_dmesg
-mark_ts=$(awk '{print $1}' /proc/uptime)
 
 output=$(lunatik run "$SCRIPT" 2>&1)
 echo "$output" | grep -q "runtime context mismatch" || \
 	fail "expected 'runtime context mismatch' error, got: $output"
 ktap_pass "hardirq-class constructor in process runtime errors cleanly"
 
-oops=$(dmesg | awk -v ts="$mark_ts" \
-	'match($0, /\[[ ]*([0-9]+\.[0-9]+)/, a) && a[1]+0 >= ts+0' | \
-	grep -E "Oops:|BUG:|kernel BUG at|NULL pointer dereference|general protection" || true)
+oops=$(dmesg_since | grep -E "Oops:|BUG:|kernel BUG at|NULL pointer dereference|general protection" || true)
 [ -n "$oops" ] && fail "kernel oops during context-mismatch cleanup: ${oops%%$'\n'*}"
 ktap_pass "no kernel oops during context-mismatch cleanup"
 

--- a/tests/notifier/init_dispatch.sh
+++ b/tests/notifier/init_dispatch.sh
@@ -31,16 +31,13 @@ ktap_header
 ktap_plan 2
 
 mark_dmesg
-mark_ts=$(awk '{print $1}' /proc/uptime)
 
 output=$(lunatik run "$SCRIPT" 2>&1)
 echo "$output" | grep -qE "\.lua:[0-9]+:" && \
 	fail "Lua error during init-time notifier registration: $output"
 ktap_pass "notifier.netdevice() at script init runs without Lua error"
 
-oops=$(dmesg | awk -v ts="$mark_ts" \
-	'match($0, /\[[ ]*([0-9]+\.[0-9]+)/, a) && a[1]+0 >= ts+0' | \
-	grep -E "Oops:|BUG:|kernel BUG at|NULL pointer dereference|general protection" || true)
+oops=$(dmesg_since | grep -E "Oops:|BUG:|kernel BUG at|NULL pointer dereference|general protection" || true)
 [ -n "$oops" ] && fail "kernel oops during init-time notifier replay: ${oops%%$'\n'*}"
 ktap_pass "no kernel oops during init-time NETDEV_REGISTER replay"
 

--- a/tests/probe/kprobe_concurrent.sh
+++ b/tests/probe/kprobe_concurrent.sh
@@ -46,7 +46,6 @@ ktap_header
 ktap_plan 2
 
 mark_dmesg
-mark_ts=$(awk '{print $1}' /proc/uptime)
 
 run_script "$SCRIPT" hardirq
 
@@ -73,9 +72,7 @@ ktap_pass "runtime stop completed within timeout"
 
 check_dmesg || { ktap_totals; exit 1; }
 
-sched=$(dmesg | awk -v ts="$mark_ts" \
-	'match($0, /\[[ ]*([0-9]+\.[0-9]+)/, a) && a[1]+0 >= ts+0' | \
-	grep -E "scheduling while atomic|BUG:|Oops:|kernel BUG at|general protection" || true)
+sched=$(dmesg_since | grep -E "scheduling while atomic|BUG:|Oops:|kernel BUG at|general protection" || true)
 [ -n "$sched" ] && fail "kernel error during concurrent kprobe handler firings: ${sched%%$'\n'*}"
 ktap_pass "no kernel errors during concurrent kprobe handler firings"
 

--- a/tests/rcu/run.sh
+++ b/tests/rcu/run.sh
@@ -23,7 +23,7 @@ for t in $TESTS; do
 		ktap_fail "rcu/$t: script execution failed"
 		continue
 	fi
-	errs=$(dmesg | tail -n +$((DMESG_LINE+1)) | grep -iE "^[^:]+: FAIL	|\.lua:[0-9]+:" || true)
+	errs=$(dmesg_since | grep -iE "^[^:]+: FAIL	|\.lua:[0-9]+:" || true)
 	if [ -z "$errs" ]; then
 		ktap_pass "rcu/$t"
 	else

--- a/tests/socket/unix/dgram.sh
+++ b/tests/socket/unix/dgram.sh
@@ -43,11 +43,11 @@ sleep $SLEEP
 lunatik stop "$SCRIPT_SERVER" 2>/dev/null
 check_dmesg || { ktap_totals; exit 1; }
 
-found=$(dmesg | tail -n +$((DMESG_LINE+1)) | grep "unix dgram: server ok" || true)
+found=$(dmesg_since | grep "unix dgram: server ok" || true)
 [ -z "$found" ] && fail "server did not receive expected datagram"
 ktap_pass "unix.dgram server: receivefrom with DONTWAIT"
 
-found=$(dmesg | tail -n +$((DMESG_LINE+1)) | grep "unix dgram: client ok" || true)
+found=$(dmesg_since | grep "unix dgram: client ok" || true)
 [ -z "$found" ] && fail "client did not complete successfully"
 ktap_pass "unix.dgram client: sendto using stored path (no explicit address)"
 

--- a/tests/socket/unix/stream.sh
+++ b/tests/socket/unix/stream.sh
@@ -44,11 +44,11 @@ sleep $SLEEP
 lunatik stop "$SCRIPT_SERVER" 2>/dev/null
 check_dmesg || { ktap_totals; exit 1; }
 
-found=$(dmesg | tail -n +$((DMESG_LINE+1)) | grep "unix stream: server ok" || true)
+found=$(dmesg_since | grep "unix stream: server ok" || true)
 [ -z "$found" ] && fail "server did not receive expected message"
 ktap_pass "unix.stream server: bind/listen/accept via stored path"
 
-found=$(dmesg | tail -n +$((DMESG_LINE+1)) | grep "unix stream: client ok" || true)
+found=$(dmesg_since | grep "unix stream: client ok" || true)
 [ -z "$found" ] && fail "client did not complete successfully"
 ktap_pass "unix.stream client: connect/send/receive via stored path"
 

--- a/tests/thread/shouldstop.sh
+++ b/tests/thread/shouldstop.sh
@@ -41,7 +41,7 @@ lunatik spawn "$SCRIPT_SPAWN"
 sleep $SLEEP
 lunatik stop "$SCRIPT_SPAWN"
 check_dmesg || { ktap_totals; exit 1; }
-found=$(dmesg | tail -n +$((DMESG_LINE+1)) | grep "shouldstop: ok" || true)
+found=$(dmesg_since | grep "shouldstop: ok" || true)
 [ -z "$found" ] && fail "shouldstop() did not return true in spawn context"
 ktap_pass "shouldstop() returns true in spawn context"
 


### PR DESCRIPTION
  - **Filter dmesg by timestamp instead of line count.** `mark_dmesg`
    recorded the current line count and callers did `tail -n +N+1` to
    skip it. Once the kernel ring buffer rolled between mark and check
    the expected "ok" prints were silently dropped — `shouldstop`,
    `socket/unix`, and friends went flaky on long-uptime boxes.
    Record the uptime timestamp instead and provide `dmesg_since`.
    Existing ad-hoc timestamp scans (`monitor/gc`, `notifier/*`,
    `probe/kprobe_concurrent`) collapse onto the same helper.

  - **`lunatik test` reloads around the run.** Force a clean slate —
    reload the modules before the suite and unload after — so each
    invocation exercises the currently-installed kernel code.

  - **READMEs caught up.** `README.md` lists every suite and drops the
    redundant `tests_install` step; `tests/README.md` covers the new
    runtime tests (`opt_guards`, `opt_skb_single`, `rcu_shared`,
    `require_cloneobject`) plus the suites that were previously
    undocumented (`crypto`, `io`, `notifier`, `probe`, `rcu`, `socket`).