### PR TITLE
README: update passwd example to require("linux.stat")

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ to generate random ASCII printable characters:
 
 local device = require("device")
 local linux  = require("linux")
+local stat   = require("linux.stat")
 
-local s = linux.stat
-local driver = {name = "passwd", mode = s.IRUGO}
+local driver = {name = "passwd", mode = stat.IRUGO}
 
 function driver:read() -- read(2) callback
 	-- generate random ASCII printable characters


### PR DESCRIPTION
Stat constants moved from the hardcoded linux.stat namespace table to an autogen module (a12c0eac); callers now require "linux.stat" directly.