### PR TITLE
autogen: alias always-y onto always for kernel < 5.10

### DIFF
--- a/autogen/Kbuild
+++ b/autogen/Kbuild
@@ -3,6 +3,10 @@
 
 -include $(src)/targets.mk
 
+# Kernel < 5.10 has no `always-y`; alias it onto the legacy `always` so the
+# targets in targets.mk are still picked up by kbuild there.
+always := $(always-y)
+
 quiet_cmd_cpp_dD = CPP -dD $@
       cmd_cpp_dD = $(CPP) $(c_flags) -E -dD -o $@ $<
 


### PR DESCRIPTION
autogen.lua writes `always-y := dump_N.pp extract.s` to targets.mk so kbuild builds those targets alongside the usual obj-y/obj-m chain. `always-y` was introduced in 5.10 (f9a4210b1ab9); earlier kernels only honor the legacy `always`. Without this alias the declaration is a no-op on 5.4, kbuild only links built-in.a, and the first .pp file autogen tries to read doesn't exist:

autogen.lua: cannot read .../autogen/dump_1.pp: No such file or directory