### PR TITLE
lunatik_aux: fix IBT #CP fault on sealed kallsyms_lookup_name

### DIFF
--- a/lunatik_aux.c
+++ b/lunatik_aux.c
@@ -84,6 +84,8 @@ EXPORT_SYMBOL(lunatik_pusherrname);
 #ifdef MODULE /* see https://lwn.net/Articles/813350/ */
 #include <linux/kprobes.h>
 
+#include "lunatik_cfi.h"
+
 #ifdef CONFIG_KPROBES
 static unsigned long (*__lunatik_lookup)(const char *) = NULL;
 #endif /* CONFIG_KPROBES */
@@ -97,12 +99,12 @@ void *lunatik_lookup(const char *symbol)
 		if (register_kprobe(&kp) != 0)
 			return NULL;
 
-		__lunatik_lookup = (unsigned long (*)(const char *))kp.addr;
+		__lunatik_lookup = (unsigned long (*)(const char *))lunatik_cfi_entry(kp.addr);
 		unregister_kprobe(&kp);
 
 		BUG_ON(__lunatik_lookup == NULL);
 	}
-	return (void *)__lunatik_lookup(symbol);
+	return (void *)lunatik_cfi_call(__lunatik_lookup(symbol));
 #else /* CONFIG_KPROBES */
 	return NULL;
 #endif /* CONFIG_KPROBES */

--- a/lunatik_cfi.h
+++ b/lunatik_cfi.h
@@ -1,0 +1,70 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+/*
+* Indirect calls under hardware Control-Flow Integrity (x86 IBT).
+*/
+
+#ifndef lunatik_cfi_h
+#define lunatik_cfi_h
+
+#ifdef CONFIG_X86_KERNEL_IBT
+#include <asm/ibt.h>
+#include <asm/msr.h>
+#include <asm/cpufeature.h>
+#include <linux/irqflags.h>
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+#define is_endbr	__is_endbr
+#endif
+
+static inline void *lunatik_cfi_entry(void *addr)
+{
+	u32 *prefix = (u32 *)((unsigned long)addr - ENDBR_INSN_SIZE);
+	return is_endbr(*prefix) ? (void *)prefix : addr;
+}
+
+/* MSR_IA32_S_CET is per-CPU; caller must pin the task. */
+static inline u64 lunatik_cfi_disable(void)
+{
+	u64 msr;
+
+	if (!cpu_feature_enabled(X86_FEATURE_IBT))
+		return 0;
+	rdmsrl(MSR_IA32_S_CET, msr);
+	wrmsrl(MSR_IA32_S_CET, msr & ~CET_ENDBR_EN);
+	return msr;
+}
+
+static inline void lunatik_cfi_restore(u64 saved)
+{
+	u64 msr;
+
+	if (!cpu_feature_enabled(X86_FEATURE_IBT))
+		return;
+	rdmsrl(MSR_IA32_S_CET, msr);
+	wrmsrl(MSR_IA32_S_CET, (msr & ~CET_ENDBR_EN) | (saved & CET_ENDBR_EN));
+}
+
+#define lunatik_cfi_call(expr) ({					\
+	unsigned long __flags;						\
+	u64 __cfi;							\
+	typeof(expr) __ret;						\
+									\
+	local_irq_save(__flags);					\
+	__cfi = lunatik_cfi_disable();					\
+	__ret = (expr);							\
+	lunatik_cfi_restore(__cfi);					\
+	local_irq_restore(__flags);					\
+	__ret;								\
+})
+#else
+#define lunatik_cfi_entry(addr)	(addr)
+#define lunatik_cfi_call(expr)		(expr)
+#endif
+
+#endif
+


### PR DESCRIPTION
On Linux 7.0 with CONFIG_X86_KERNEL_IBT=y, kallsyms_lookup_name has its ENDBR64 replaced with ENDBR poison, so an indirect call into it triggers a #CP exception (visible as segfault when loading luaprobe or luasyscall).

Add lunatik_cfi.h with lunatik_cfi_entry() (steps past the ENDBR prefix) and lunatik_cfi_call() (disables ENDBR enforcement around an indirect call).  ibt_save()/ibt_restore() are not exported to modules, so the MSR logic is reimplemented; is_endbr() and ENDBR_INSN_SIZE are reused from <asm/ibt.h>.

Reported-by: jperon <cataclop@hotmail.com>
Fix #564