### PR TITLE
AEAD: remove temporary buffer.

### DIFF
--- a/lib/luacrypto_aead.c
+++ b/lib/luacrypto_aead.c
@@ -75,7 +75,8 @@ static int luacrypto_aead_authsize(lua_State *L)
 }
 
 typedef struct luacrypto_aead_request_s {
-	struct scatterlist sg;
+	struct scatterlist src[2];
+	struct scatterlist dst[2];
 	struct aead_request *aead;
 	const char *data;
 	const char *aad;
@@ -97,7 +98,7 @@ static inline void luacrypto_aead_newrequest(lua_State *L, luacrypto_aead_reques
 
 	request->data = luaL_checklstring(L, 3, &request->crypt_len);
 	request->aad = luaL_optlstring(L, 4, "", &request->aad_len);
-	request->authsize = (size_t)crypto_aead_authsize(tfm);
+	request->authsize = crypto_aead_authsize(tfm);
 
 	request->iv = (u8 *)lunatik_checkalloc(L, iv_len);
 	memcpy(request->iv, iv, iv_len);
@@ -110,19 +111,40 @@ static inline void luacrypto_aead_newrequest(lua_State *L, luacrypto_aead_reques
 	}
 }
 
-static inline void luacrypto_aead_setrequest(luacrypto_aead_request_t *request, char *buffer, size_t buffer_len)
+static inline void luacrypto_aead_setrequest(luacrypto_aead_request_t *request, char *buffer, size_t output_len)
 {
 	struct aead_request *aead = request->aead;
-	struct scatterlist *sg = &request->sg;
+	struct scatterlist *src = request->src;
+	struct scatterlist *dst = request->dst;
+	unsigned int src_nents = request->aad_len ? 2 : 1;
+	unsigned int dst_nents = request->aad_len && output_len ? 2 : 1;
 
-	/* Build combined = aad || data in buffer */
-	memcpy(buffer, request->aad, request->aad_len);
-	memcpy(buffer + request->aad_len, request->data, request->crypt_len);
+	/* Source is mapped directly from Lua strings (no aad||data concatenation). */
+	sg_init_table(src, src_nents);
+	if (request->aad_len)
+		sg_set_buf(&src[0], request->aad, request->aad_len);
+	sg_set_buf(&src[src_nents - 1], request->data, request->crypt_len);
 
-	sg_init_one(sg, buffer, buffer_len);
+	/* Destination is a dedicated output buffer. */
+	sg_init_table(dst, dst_nents);
+	if (request->aad_len) {
+		memcpy(buffer, request->aad, request->aad_len);
+		if (dst_nents == 2) {
+			sg_set_buf(&dst[0], buffer, request->aad_len);
+			sg_set_buf(&dst[1], buffer + request->aad_len, output_len);
+		} else {
+			/*
+			 * Empty-plaintext decrypt still needs room for AD in dst.
+			 * Keep a single segment on the AD area, no zero-length SG.
+			 */
+			sg_set_buf(&dst[0], buffer, request->aad_len);
+		}
+	} else {
+		sg_set_buf(&dst[0], buffer, output_len ? output_len : 1);
+	}
 
 	aead_request_set_ad(aead, request->aad_len);
-	aead_request_set_crypt(aead, sg, sg, request->crypt_len, request->iv);
+	aead_request_set_crypt(aead, src, dst, request->crypt_len, request->iv);
 	aead_request_set_callback(aead, 0, NULL, NULL);
 }
 
@@ -132,19 +154,19 @@ static inline void luacrypto_aead_request_free(luacrypto_aead_request_t *request
 	lunatik_free(request->iv);
 }
 
-static inline char *luacrypto_aead_prepare(lua_State *L, luacrypto_aead_request_t *request, size_t buffer_len)
+static inline char *luacrypto_aead_prepare(lua_State *L, luacrypto_aead_request_t *request, size_t output_len)
 {
+	size_t buffer_len = request->aad_len + (output_len ? output_len : 1);
 	char *buffer = (char *)lunatik_malloc(L, buffer_len);
 	if (buffer == NULL) {
 		luacrypto_aead_request_free(request);
 		lunatik_enomem(L);
 	}
-	luacrypto_aead_setrequest(request, buffer, buffer_len);
+	luacrypto_aead_setrequest(request, buffer, output_len);
 	return buffer;
 }
 
-static inline int luacrypto_aead_finish(lua_State *L, luacrypto_aead_request_t *request,
-	char *buffer, int ret, size_t output_len)
+static inline int luacrypto_aead_finish(lua_State *L, luacrypto_aead_request_t *request, char *buffer, int ret, size_t output_len)
 {
 	luacrypto_aead_request_free(request);
 	if (ret < 0) {
@@ -170,10 +192,10 @@ static int luacrypto_aead_encrypt(lua_State *L)
 {
 	luacrypto_aead_request_t request;
 	luacrypto_aead_newrequest(L, &request);
-	size_t buffer_len = request.aad_len + request.crypt_len + request.authsize;
-	char *buffer = luacrypto_aead_prepare(L, &request, buffer_len);
+	size_t output_len = request.crypt_len + request.authsize;
+	char *buffer = luacrypto_aead_prepare(L, &request, output_len);
 	int ret = crypto_aead_encrypt(request.aead);
-	return luacrypto_aead_finish(L, &request, buffer, ret, request.crypt_len + request.authsize);
+	return luacrypto_aead_finish(L, &request, buffer, ret, output_len);
 }
 
 /***
@@ -194,10 +216,10 @@ static int luacrypto_aead_decrypt(lua_State *L)
 		luacrypto_aead_request_free(&request);
 		lunatik_throw(L, -EBADMSG);
 	}
-	size_t buffer_len = request.aad_len + request.crypt_len;
-	char *buffer = luacrypto_aead_prepare(L, &request, buffer_len);
+	size_t output_len = request.crypt_len - request.authsize;
+	char *buffer = luacrypto_aead_prepare(L, &request, output_len);
 	int ret = crypto_aead_decrypt(request.aead);
-	return luacrypto_aead_finish(L, &request, buffer, ret, request.crypt_len - request.authsize);
+	return luacrypto_aead_finish(L, &request, buffer, ret, output_len);
 }
 
 static int luacrypto_aead_algname(lua_State *L)


### PR DESCRIPTION
While implementing QUIC parsing for ipparse, I had ENOMEM problem with temporary buffer. This PR fixes it.