### PR TITLE
crypto: avoid source staging buffer in aead and skcipher

### DIFF
--- a/lib/luacrypto.h
+++ b/lib/luacrypto.h
@@ -30,6 +30,34 @@ static void luacrypto_##name##_release(void *private)		\
 		obj_free(obj);					\
 }
 
+static inline u8 *luacrypto_checkiv(lua_State *L, int idx, size_t expected)
+{
+	size_t iv_len;
+	const char *iv = luaL_checklstring(L, idx, &iv_len);
+	if (iv_len != expected)
+		lunatik_throw(L, -EINVAL);
+
+	u8 *out = (u8 *)lunatik_checkalloc(L, iv_len);
+	memcpy(out, iv, iv_len);
+	return out;
+}
+
+#define LUACRYPTO_REQUEST_ALLOC(L, request, name, tfm)				\
+do {										\
+	gfp_t __gfp = lunatik_gfp(lunatik_toruntime(L));			\
+	(request)->name = name##_request_alloc((tfm), __gfp);			\
+	if ((request)->name == NULL) {						\
+		lunatik_free((request)->iv);					\
+		lunatik_enomem(L);						\
+	}									\
+} while (0)
+
+#define LUACRYPTO_REQUEST_FREE(request, name)					\
+do {										\
+	name##_request_free((request)->name);					\
+	lunatik_free((request)->iv);						\
+} while (0)
+
 extern const lunatik_class_t luacrypto_shash_class;
 extern const lunatik_class_t luacrypto_skcipher_class;
 extern const lunatik_class_t luacrypto_aead_class;

--- a/lib/luacrypto_aead.c
+++ b/lib/luacrypto_aead.c
@@ -75,7 +75,8 @@ static int luacrypto_aead_authsize(lua_State *L)
 }
 
 typedef struct luacrypto_aead_request_s {
-	struct scatterlist sg;
+	struct scatterlist src[2];	/* AAD + data, mapped from Lua strings */
+	struct scatterlist dst[2];	/* AAD prefix + output, in allocated buffer */
 	struct aead_request *aead;
 	const char *data;
 	const char *aad;
@@ -90,56 +91,53 @@ static inline void luacrypto_aead_newrequest(lua_State *L, luacrypto_aead_reques
 	memset(request, 0, sizeof(luacrypto_aead_request_t));
 	struct crypto_aead *tfm = luacrypto_aead_check(L, 1);
 
-	size_t iv_len;
-	const char *iv = luaL_checklstring(L, 2, &iv_len);
-	if (iv_len != crypto_aead_ivsize(tfm))
-		lunatik_throw(L, -EINVAL);
-
+	request->iv = luacrypto_checkiv(L, 2, crypto_aead_ivsize(tfm));
 	request->data = luaL_checklstring(L, 3, &request->crypt_len);
 	request->aad = luaL_optlstring(L, 4, "", &request->aad_len);
-	request->authsize = (size_t)crypto_aead_authsize(tfm);
+	request->authsize = crypto_aead_authsize(tfm);
 
-	request->iv = (u8 *)lunatik_checkalloc(L, iv_len);
-	memcpy(request->iv, iv, iv_len);
-
-	gfp_t gfp = lunatik_gfp(lunatik_toruntime(L));
-	request->aead = aead_request_alloc(tfm, gfp);
-	if (request->aead == NULL) {
-		lunatik_free(request->iv);
-		lunatik_enomem(L);
-	}
+	LUACRYPTO_REQUEST_ALLOC(L, request, aead, tfm);
 }
 
-static inline void luacrypto_aead_setrequest(luacrypto_aead_request_t *request, char *buffer, size_t buffer_len)
+static inline void luacrypto_aead_setrequest(luacrypto_aead_request_t *request, char *buffer, size_t output_len)
 {
 	struct aead_request *aead = request->aead;
-	struct scatterlist *sg = &request->sg;
+	struct scatterlist *src = request->src;
+	struct scatterlist *dst = request->dst;
+	unsigned int n = request->aad_len ? 2 : 1;
 
-	/* Build combined = aad || data in buffer */
+	/* src maps the Lua input strings directly (no copy). */
+	sg_init_table(src, n);
+	if (request->aad_len)
+		sg_set_buf(&src[0], request->aad, request->aad_len);
+	sg_set_buf(&src[n - 1], request->data, request->crypt_len);
+
+	/* dst mirrors the AAD prefix and reserves room for the output. */
 	memcpy(buffer, request->aad, request->aad_len);
-	memcpy(buffer + request->aad_len, request->data, request->crypt_len);
-
-	sg_init_one(sg, buffer, buffer_len);
+	sg_init_table(dst, n);
+	if (request->aad_len)
+		sg_set_buf(&dst[0], buffer, request->aad_len);
+	sg_set_buf(&dst[n - 1], buffer + request->aad_len, output_len ? output_len : 1);
 
 	aead_request_set_ad(aead, request->aad_len);
-	aead_request_set_crypt(aead, sg, sg, request->crypt_len, request->iv);
+	aead_request_set_crypt(aead, src, dst, request->crypt_len, request->iv);
 	aead_request_set_callback(aead, 0, NULL, NULL);
 }
 
 static inline void luacrypto_aead_request_free(luacrypto_aead_request_t *request)
 {
-	aead_request_free(request->aead);
-	lunatik_free(request->iv);
+	LUACRYPTO_REQUEST_FREE(request, aead);
 }
 
-static inline char *luacrypto_aead_prepare(lua_State *L, luacrypto_aead_request_t *request, size_t buffer_len)
+static inline char *luacrypto_aead_prepare(lua_State *L, luacrypto_aead_request_t *request, size_t output_len)
 {
+	size_t buffer_len = request->aad_len + (output_len ? output_len : 1);
 	char *buffer = (char *)lunatik_malloc(L, buffer_len);
 	if (buffer == NULL) {
 		luacrypto_aead_request_free(request);
 		lunatik_enomem(L);
 	}
-	luacrypto_aead_setrequest(request, buffer, buffer_len);
+	luacrypto_aead_setrequest(request, buffer, output_len);
 	return buffer;
 }
 
@@ -170,10 +168,10 @@ static int luacrypto_aead_encrypt(lua_State *L)
 {
 	luacrypto_aead_request_t request;
 	luacrypto_aead_newrequest(L, &request);
-	size_t buffer_len = request.aad_len + request.crypt_len + request.authsize;
-	char *buffer = luacrypto_aead_prepare(L, &request, buffer_len);
+	size_t output_len = request.crypt_len + request.authsize;
+	char *buffer = luacrypto_aead_prepare(L, &request, output_len);
 	int ret = crypto_aead_encrypt(request.aead);
-	return luacrypto_aead_finish(L, &request, buffer, ret, request.crypt_len + request.authsize);
+	return luacrypto_aead_finish(L, &request, buffer, ret, output_len);
 }
 
 /***
@@ -194,10 +192,10 @@ static int luacrypto_aead_decrypt(lua_State *L)
 		luacrypto_aead_request_free(&request);
 		lunatik_throw(L, -EBADMSG);
 	}
-	size_t buffer_len = request.aad_len + request.crypt_len;
-	char *buffer = luacrypto_aead_prepare(L, &request, buffer_len);
+	size_t output_len = request.crypt_len - request.authsize;
+	char *buffer = luacrypto_aead_prepare(L, &request, output_len);
 	int ret = crypto_aead_decrypt(request.aead);
-	return luacrypto_aead_finish(L, &request, buffer, ret, request.crypt_len - request.authsize);
+	return luacrypto_aead_finish(L, &request, buffer, ret, output_len);
 }
 
 static int luacrypto_aead_algname(lua_State *L)

--- a/lib/luacrypto_skcipher.c
+++ b/lib/luacrypto_skcipher.c
@@ -61,7 +61,8 @@ static int luacrypto_skcipher_blocksize(lua_State *L)
 }
 
 typedef struct luacrypto_skcipher_request_s {
-	struct scatterlist sg;
+	struct scatterlist src;
+	struct scatterlist dst;
 	struct skcipher_request *skcipher;
 	const char *data;
 	size_t data_len;
@@ -73,35 +74,21 @@ static inline void luacrypto_skcipher_newrequest(lua_State *L, luacrypto_skciphe
 	memset(request, 0, sizeof(luacrypto_skcipher_request_t));
 	struct crypto_skcipher *tfm = luacrypto_skcipher_check(L, 1);
 
-	size_t iv_len;
-	const char *iv = luaL_checklstring(L, 2, &iv_len);
-	if (iv_len != crypto_skcipher_ivsize(tfm))
-		lunatik_throw(L, -EINVAL);
-
+	request->iv = luacrypto_checkiv(L, 2, crypto_skcipher_ivsize(tfm));
 	request->data = luaL_checklstring(L, 3, &request->data_len);
 
-	request->iv = (u8 *)lunatik_checkalloc(L, iv_len);
-	memcpy(request->iv, iv, iv_len);
-
-	gfp_t gfp = lunatik_gfp(lunatik_toruntime(L));
-	request->skcipher = skcipher_request_alloc(tfm, gfp);
-	if (request->skcipher == NULL) {
-		lunatik_free(request->iv);
-		lunatik_enomem(L);
-	}
+	LUACRYPTO_REQUEST_ALLOC(L, request, skcipher, tfm);
 }
 
 static inline void luacrypto_skcipher_setrequest(luacrypto_skcipher_request_t *request, char *buffer)
 {
 	struct skcipher_request *skcipher = request->skcipher;
-	struct scatterlist *sg = &request->sg;
 	size_t data_len = request->data_len;
 
-	memcpy(buffer, request->data, data_len);
+	sg_init_one(&request->src, request->data, data_len);	/* mapped from Lua string */
+	sg_init_one(&request->dst, buffer, data_len);		/* into allocated buffer */
 
-	sg_init_one(sg, buffer, data_len);
-
-	skcipher_request_set_crypt(skcipher, sg, sg, data_len, request->iv);
+	skcipher_request_set_crypt(skcipher, &request->src, &request->dst, data_len, request->iv);
 	skcipher_request_set_callback(skcipher, 0, NULL, NULL);
 }
 
@@ -112,15 +99,13 @@ static int luacrypto_skcipher_crypt(lua_State *L, int (*crypt)(struct skcipher_r
 
 	char *buffer = (char *)lunatik_malloc(L, request.data_len);
 	if (buffer == NULL) {
-		skcipher_request_free(request.skcipher);
-		lunatik_free(request.iv);
+		LUACRYPTO_REQUEST_FREE(&request, skcipher);
 		lunatik_enomem(L);
 	}
 
 	luacrypto_skcipher_setrequest(&request, buffer);
 	int ret = crypt(request.skcipher);
-	skcipher_request_free(request.skcipher);
-	lunatik_free(request.iv);
+	LUACRYPTO_REQUEST_FREE(&request, skcipher);
 	if (ret < 0) {
 		lunatik_free(buffer);
 		lunatik_throw(L, ret);

--- a/tests/crypto/aead.lua
+++ b/tests/crypto/aead.lua
@@ -91,3 +91,25 @@ test("AEAD AES-128-GCM decrypt with authentication failure", function()
 	assert(err == "EBADMSG", "Error code should be 'EBADMSG', got: " .. err)
 end)
 
+-- Round-trip without the optional AAD argument; covers aad_len = 0.
+test("AEAD AES-128-GCM round-trip without AAD", function()
+	local c = aead("gcm(aes)")
+	c:setkey"0123456789abcdef"
+	c:setauthsize(16)
+	local ciphertext = c:encrypt("abcdefghijkl", "plaintext")
+	local plaintext = c:decrypt("abcdefghijkl", ciphertext)
+	assert(plaintext == "plaintext", "Round-trip without AAD failed: got " .. bin2hex(plaintext))
+end)
+
+-- Encrypt produces tag only (crypt_len = 0); decrypt of a tag-only input
+-- yields empty plaintext (output_len = 0).
+test("AEAD AES-128-GCM round-trip empty plaintext with AAD", function()
+	local c = aead("gcm(aes)")
+	c:setkey"0123456789abcdef"
+	c:setauthsize(16)
+	local tag = c:encrypt("abcdefghijkl", "", "0123456789abcdef")
+	assert(#tag == 16, "Empty-plaintext output should be just the tag (16 bytes), got " .. #tag)
+	local plaintext = c:decrypt("abcdefghijkl", tag, "0123456789abcdef")
+	assert(plaintext == "", "Empty-plaintext round-trip failed")
+end)
+


### PR DESCRIPTION
  Map AEAD and SKCIPHER inputs through scatterlists pointing directly at
  the Lua input strings, instead of memcpy-ing them into a contiguous
  buffer used for in-place encrypt/decrypt. Reduces transient memory
  pressure, allowing the operations to succeed under GFP_ATOMIC where
  the previous duplicate of the source data could fail (the scenario
  reported in #567 for aead).

  Common boilerplate (IV checking, request alloc, request free) is
  pulled out to `luacrypto.h` so both submodules stay aligned by
  construction. Two regression tests are added covering the empty-AAD
  and empty-output paths exercised by the refactor.

  Counter-proposal to #567: same motivation, applied to skcipher as
  well and structured around shared helpers.