### PR TITLE
tests/lib: avoid printk-vs-uptime clock skew in dmesg_since

### DIFF
--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -16,12 +16,8 @@ ktap_pass()   { KTAP_COUNT=$((KTAP_COUNT+1)); KTAP_PASS=$((KTAP_PASS+1)); echo "
 ktap_fail()   { KTAP_COUNT=$((KTAP_COUNT+1)); KTAP_FAIL=$((KTAP_FAIL+1)); echo "not ok $KTAP_COUNT $*"; }
 ktap_totals() { echo "# Totals: pass:$KTAP_PASS fail:$KTAP_FAIL skip:0"; }
 
-DMESG_TS=0
-mark_dmesg() { DMESG_TS=$(awk '{print $1}' /proc/uptime); }
-dmesg_since() {
-	dmesg | awk -v ts="$DMESG_TS" \
-		'match($0, /\[[ ]*([0-9]+\.[0-9]+)/, a) && a[1]+0 >= ts+0'
-}
+mark_dmesg() { dmesg -C 2>/dev/null; }
+dmesg_since() { dmesg; }
 check_dmesg() {
 	local errs
 	errs=$(dmesg_since | grep -E "\.lua:[0-9]+:" || true)


### PR DESCRIPTION
mark_dmesg saved $(awk '{print $1}' /proc/uptime) and dmesg_since filtered dmesg lines whose [ts] was >= that value.  This silently breaks on systems that suspended at any point: /proc/uptime includes time spent in suspend, but printk_time does not, so printk timestamps are permanently behind uptime by the cumulative suspend duration. After the offset grows beyond the test wallclock, every recent printk is filtered out and the test fails reporting "missing message" even though the message is in dmesg.

Drop the timestamp comparison: clear the ring at mark_dmesg and read the whole dmesg in dmesg_since.  The tests only ever want what came out since the mark, and dmesg -C makes that trivially true.