### PR TITLE
luaprobe: fix use-after-free panic on kprobes-on-ftrace kernels

### DIFF
--- a/autogen/specs.lua
+++ b/autogen/specs.lua
@@ -57,6 +57,10 @@ return {
 		include = { "DROP", "ACCEPT", "STOLEN", "QUEUE", "REPEAT", "STOP" } },
 	{ header = "asm/unistd.h",                  prefix = "__NR_",      module = "syscall.numbers",
 		desc = "System call numbers (`__NR_*`) for the build arch.",
-		exclude = { "__NR_arch_specific_syscall", "__NR_compat_", "__NR_syscalls" } },
+		-- __NR_x32_*/__NR_ia32_* show up when CONFIG_X86_X32_ABI /
+		-- IA32_EMULATION are set (e.g. Debian kernels); they index
+		-- separate syscall tables, out of bounds for syscall.address().
+		exclude = { "__NR_arch_specific_syscall", "__NR_compat_", "__NR_syscalls",
+			"__NR_x32_", "__NR_ia32_" } },
 }
 

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -92,9 +92,13 @@ static void luaprobe_delete(luaprobe_t *probe)
 	const char *symbol_name = kp->symbol_name;
 
 	if (kp->pre_handler != NULL) {
+		/* handlers must stay untouched while registered: on kprobe-on-ftrace
+		 * kernels the disarm path picks the ftrace_ops from
+		 * `post_handler != NULL` (ipmodify); clearing it first unbalances
+		 * arm/disarm and leaves a freed kprobe armed (use-after-free). */
+		unregister_kprobe(kp);
 		kp->pre_handler = NULL;
 		kp->post_handler = NULL;
-		unregister_kprobe(kp);
 	}
 
 	if (symbol_name != NULL) {

--- a/tests/probe/kprobe_concurrent.sh
+++ b/tests/probe/kprobe_concurrent.sh
@@ -59,15 +59,17 @@ done
 
 sleep $SLEEP
 
-# Stop must complete within 5 s; timeout exit code 124 means a hang.
-timeout 5 lunatik stop "$SCRIPT" 2>/dev/null
+# A hung stop never returns, so any finite bound detects it. Unregistering
+# one kprobe per syscall costs a synchronize_rcu + ftrace update each,
+# which takes ~10 s on a small VM: 30 s leaves headroom without masking hangs.
+timeout 30 lunatik stop "$SCRIPT" 2>/dev/null
 STOP_RET=$?
 
 for pid in "${LOAD_PIDS[@]}"; do kill "$pid" 2>/dev/null; done
 wait "${LOAD_PIDS[@]}" 2>/dev/null
 LOAD_PIDS=()
 
-[ $STOP_RET -eq 124 ] && fail "runtime stop hung (exceeded 5s timeout)"
+[ $STOP_RET -eq 124 ] && fail "runtime stop hung (exceeded 30s timeout)"
 ktap_pass "runtime stop completed within timeout"
 
 check_dmesg || { ktap_totals; exit 1; }


### PR DESCRIPTION
Running the test suite on a Debian 6.12 kernel (built with
CONFIG_KPROBES_ON_FTRACE, as most distro kernels are) surfaced two real
bugs, both fixed here, plus one test-timing adjustment.

## luaprobe: use-after-free ending in a kernel panic

`luaprobe_delete()` cleared `kp->pre_handler`/`kp->post_handler` *before*
calling `unregister_kprobe()`. A kprobe's fields belong to the kprobes
core while it is registered, and on kprobes-on-ftrace kernels the
arm/disarm path selects the ftrace_ops based on `post_handler != NULL`
(ipmodify):

- at registration, `post_handler` is set, so the probe is armed into
  `kprobe_ipmodify_ops`;
- at unregistration with `post_handler` already NULLed, disarm recomputes
  ipmodify as false and tries to remove the address from
  `kprobe_ftrace_ops` instead, failing with
  `Failed to disarm kprobe-ftrace at __x64_sys_...+0x4 (error -2)`.

The address then stays armed in `kprobe_ipmodify_ops` while the kprobe is
removed from the hash table and freed together with the lunatik object.
The next time the probed function executes,
`kprobe_ftrace_handler() → get_kprobe()` dereferences the freed entry:
page-fault Oops cascade in `get_kprobe()`, ending in
`Kernel panic - not syncing: Attempted to kill init!`.

Reproduced deterministically on Debian 6.12 (QEMU): a single
register-all-syscalls/stop cycle (`tests/probe/kprobe_concurrent.sh`)
warns on disarm and the machine panics as soon as syscall traffic hits
the orphaned address — no concurrency needed. Kernels where kprobes
don't land on ftrace sites never take the ipmodify path, which is why
this went unnoticed so far.

Fix: unregister first, then reset the handlers (luaprobe only uses them
as its "registered" flag).

## autogen: x32/ia32 syscall numbers out of bounds

On kernels with CONFIG_X86_X32_ABI / CONFIG_IA32_EMULATION (e.g.
Debian), `<asm/unistd.h>` under `__KERNEL__` also pulls in the generated
`unistd_64_x32.h` and `unistd_32_ia32.h`, so autogen's `__NR_` prefix
scan picks up `__NR_x32_*` (≥ 512) and `__NR_ia32_*`. Those index
separate syscall tables; feeding them to `syscall.address()` trips its
`nr < __NR_syscalls` bounds check, so iterating `syscall.table` errors
out with "bad argument #1 to 'address' (out of bounds)". Both prefixes
are now excluded.

## tests/probe: stop timeout

With the use-after-free fixed, `lunatik stop` of one kprobe per syscall
completes correctly but costs a `synchronize_rcu()` plus an ftrace
filter update per probe: measured ~6.6 s idle and ~10.5 s under the
test's own CPU load on a 2-vCPU QEMU guest. The 5 s hang-detection bound
was calibrated on bare metal; it is raised to 30 s, which still detects
genuine hangs (those never return) without flagging slow-but-correct
teardown on small VMs.

## Verification

Full test suite on Debian trixie (6.12 cloud kernel) in QEMU:
31 pass / 0 fail, no kprobe warnings in dmesg. The previously panicking
register/stop cycle now completes cleanly, idle and under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)