### PR TITLE
luaprobe: fix use-after-free panic on kprobes-on-ftrace kernels (v2)

### DIFF
--- a/autogen/specs.lua
+++ b/autogen/specs.lua
@@ -57,6 +57,7 @@ return {
 		include = { "DROP", "ACCEPT", "STOLEN", "QUEUE", "REPEAT", "STOP" } },
 	{ header = "asm/unistd.h",                  prefix = "__NR_",      module = "syscall.numbers",
 		desc = "System call numbers (`__NR_*`) for the build arch.",
-		exclude = { "__NR_arch_specific_syscall", "__NR_compat_", "__NR_syscalls" } },
+		exclude = { "__NR_arch_specific_syscall", "__NR_compat_", "__NR_syscalls",
+			"__NR_x32_", "__NR_ia32_" } },
 }
 

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -92,9 +92,10 @@ static void luaprobe_delete(luaprobe_t *probe)
 	const char *symbol_name = kp->symbol_name;
 
 	if (kp->pre_handler != NULL) {
+		/* disarm picks the ftrace_ops from post_handler; clear handlers only after unregister */
+		unregister_kprobe(kp);
 		kp->pre_handler = NULL;
 		kp->post_handler = NULL;
-		unregister_kprobe(kp);
 	}
 
 	if (symbol_name != NULL) {

--- a/tests/probe/kprobe_concurrent.sh
+++ b/tests/probe/kprobe_concurrent.sh
@@ -59,15 +59,15 @@ done
 
 sleep $SLEEP
 
-# Stop must complete within 5 s; timeout exit code 124 means a hang.
-timeout 5 lunatik stop "$SCRIPT" 2>/dev/null
+# Stop must complete within 30 s; timeout exit code 124 means a hang.
+timeout 30 lunatik stop "$SCRIPT" 2>/dev/null
 STOP_RET=$?
 
 for pid in "${LOAD_PIDS[@]}"; do kill "$pid" 2>/dev/null; done
 wait "${LOAD_PIDS[@]}" 2>/dev/null
 LOAD_PIDS=()
 
-[ $STOP_RET -eq 124 ] && fail "runtime stop hung (exceeded 5s timeout)"
+[ $STOP_RET -eq 124 ] && fail "runtime stop hung (exceeded 30s timeout)"
 ktap_pass "runtime stop completed within timeout"
 
 check_dmesg || { ktap_totals; exit 1; }


### PR DESCRIPTION
  Running the test suite on a Debian 6.12 kernel (built with
  CONFIG_KPROBES_ON_FTRACE, like most distro kernels) surfaced two bugs,
  fixed here, plus one test-timing adjustment.

  ## luaprobe: use-after-free ending in a kernel panic

  `luaprobe_delete()` cleared `kp->pre_handler`/`kp->post_handler` before
  calling `unregister_kprobe()`. On kprobes-on-ftrace kernels the
  arm/disarm path selects the ftrace_ops from `post_handler != NULL`
  (ipmodify): at registration the probe is armed into `kprobe_ipmodify_ops`,
  but disarming with `post_handler` already NULLed recomputes ipmodify as
  false and tries to remove the address from `kprobe_ftrace_ops` instead,
  failing with "Failed to disarm kprobe-ftrace at ... (error -2)".

  The failed disarm makes unregistration bail out before unhashing the
  kprobe, which is then freed together with the lunatik object while still
  hashed and armed. The next time the probed function runs,
  `get_kprobe()` dereferences the freed entry, cascading into a kernel
  panic. Reproduced deterministically on Debian 6.12 (QEMU) with a single
  register-all-syscalls/stop cycle. Kernels where kprobes do not land on
  ftrace sites never take the ipmodify path, which is why this went
  unnoticed.

  Fix: unregister first, then reset the handlers (luaprobe only uses them
  as its "registered" flag).

  ## autogen: x32/ia32 syscall numbers out of bounds

  On kernels with CONFIG_X86_X32_ABI / CONFIG_IA32_EMULATION (e.g.
  Debian), `<asm/unistd.h>` also pulls in `__NR_x32_*` (>= 512) and
  `__NR_ia32_*`. Those index separate syscall tables, so feeding them to
  `syscall.address()` trips its bounds check and iterating `syscall.table`
  errors with "bad argument #1 to 'address' (out of bounds)". Both
  prefixes are now excluded.

  ## tests/probe: stop timeout

  With the use-after-free fixed, `lunatik stop` of one kprobe per syscall
  completes correctly but costs a `synchronize_rcu()` plus an ftrace
  filter update per probe (~10 s under load on a 2-vCPU QEMU guest). The
  5 s hang-detection bound was calibrated on bare metal; raising it to
  30 s still detects genuine hangs (those never return) without flagging
  slow-but-correct teardown on small VMs.

  ## Verification

  Full test suite on Debian trixie (6.12 cloud kernel) in QEMU:
  31 pass / 0 fail, no kprobe warnings in dmesg.