### PR TITLE
crypto: pre-allocate skcipher/aead request and IV per cipher object (v2)

### DIFF
--- a/lib/luacrypto.h
+++ b/lib/luacrypto.h
@@ -38,6 +38,14 @@ typedef struct luacrypto_ctx_s {
 	u8 *iv;
 } luacrypto_ctx_t;
 
+/* checkctx returns the context; check returns ctx->tfm for tfm-only methods. */
+#define LUACRYPTO_CHECKER(name, T)							\
+LUNATIK_PRIVATECHECKER(luacrypto_##name##_checkctx, luacrypto_ctx_t *)			\
+static inline T *luacrypto_##name##_check(lua_State *L, int idx)				\
+{											\
+	return (T *)luacrypto_##name##_checkctx(L, idx)->tfm;				\
+}
+
 #define LUACRYPTO_NEWCTX(name, T, alloc, class)							\
 int luacrypto_##name##_new(lua_State *L)							\
 {												\

--- a/lib/luacrypto.h
+++ b/lib/luacrypto.h
@@ -46,6 +46,17 @@ static inline T *luacrypto_##name##_check(lua_State *L, int idx)				\
 	return (T *)luacrypto_##name##_checkctx(L, idx)->tfm;				\
 }
 
+/* store the request and allocate the IV (NULL when the cipher has none),
+ * failing if either could not be obtained */
+static inline void luacrypto_initctx(lua_State *L, luacrypto_ctx_t *ctx,
+	void *request, unsigned int ivsize)
+{
+	ctx->request = request;
+	ctx->iv = ivsize != 0 ? (u8 *)lunatik_malloc(L, ivsize) : NULL;
+	if (ctx->request == NULL || (ivsize != 0 && ctx->iv == NULL))
+		lunatik_enomem(L);
+}
+
 #define LUACRYPTO_NEWCTX(name, T, alloc, class)							\
 int luacrypto_##name##_new(lua_State *L)							\
 {												\
@@ -58,11 +69,8 @@ int luacrypto_##name##_new(lua_State *L)							\
 	if (IS_ERR(tfm))									\
 		lunatik_throw(L, PTR_ERR(tfm));							\
 	ctx->tfm = tfm;										\
-	unsigned int ivsize = crypto_##name##_ivsize(tfm);					\
-	ctx->request = name##_request_alloc(tfm, gfp);						\
-	ctx->iv = ivsize != 0 ? (u8 *)lunatik_malloc(L, ivsize) : NULL;				\
-	if (ctx->request == NULL || (ivsize != 0 && ctx->iv == NULL))				\
-		lunatik_enomem(L);								\
+	luacrypto_initctx(L, ctx, name##_request_alloc(tfm, gfp),				\
+		crypto_##name##_ivsize(tfm));							\
 	return 1;										\
 }
 

--- a/lib/luacrypto.h
+++ b/lib/luacrypto.h
@@ -30,33 +30,58 @@ static void luacrypto_##name##_release(void *private)		\
 		obj_free(obj);					\
 }
 
-static inline u8 *luacrypto_checkiv(lua_State *L, int idx, size_t expected)
-{
-	size_t iv_len;
-	const char *iv = luaL_checklstring(L, idx, &iv_len);
-	if (iv_len != expected)
-		lunatik_throw(L, -EINVAL);
+/* Per-tfm fixed-size state (request, IV) allocated once at creation, so
+ * encrypt/decrypt never allocates on the hot path (e.g. softirq). */
+typedef struct luacrypto_ctx_s {
+	void *tfm;
+	void *request;
+	u8 *iv;
+} luacrypto_ctx_t;
 
-	u8 *out = (u8 *)lunatik_checkalloc(L, iv_len);
-	memcpy(out, iv, iv_len);
-	return out;
+#define LUACRYPTO_NEWCTX(name, T, alloc, class)							\
+int luacrypto_##name##_new(lua_State *L)							\
+{												\
+	const char *algname = luaL_checkstring(L, 1);						\
+	gfp_t gfp = lunatik_gfp(lunatik_toruntime(L));						\
+	lunatik_object_t *object = lunatik_newobject(L, &class,				\
+		sizeof(luacrypto_ctx_t), LUNATIK_OPT_NONE);					\
+	luacrypto_ctx_t *ctx = (luacrypto_ctx_t *)object->private;				\
+	T *tfm = alloc(algname, 0, 0);								\
+	if (IS_ERR(tfm))									\
+		lunatik_throw(L, PTR_ERR(tfm));							\
+	ctx->tfm = tfm;										\
+	unsigned int ivsize = crypto_##name##_ivsize(tfm);					\
+	ctx->request = name##_request_alloc(tfm, gfp);						\
+	ctx->iv = ivsize != 0 ? (u8 *)lunatik_malloc(L, ivsize) : NULL;				\
+	if (ctx->request == NULL || (ivsize != 0 && ctx->iv == NULL))				\
+		lunatik_enomem(L);								\
+	return 1;										\
 }
 
-#define LUACRYPTO_REQUEST_ALLOC(L, request, name, tfm)				\
-do {										\
-	gfp_t __gfp = lunatik_gfp(lunatik_toruntime(L));			\
-	(request)->name = name##_request_alloc((tfm), __gfp);			\
-	if ((request)->name == NULL) {						\
-		lunatik_free((request)->iv);					\
-		lunatik_enomem(L);						\
-	}									\
-} while (0)
+#define LUACRYPTO_RELEASERCTX(name, T, tfm_free)		\
+static void luacrypto_##name##_release(void *private)		\
+{								\
+	luacrypto_ctx_t *ctx = (luacrypto_ctx_t *)private;	\
+	if (ctx == NULL)					\
+		return;						\
+	name##_request_free(ctx->request);			\
+	lunatik_free(ctx->iv);					\
+	if (ctx->tfm)						\
+		tfm_free((T *)ctx->tfm);			\
+}
 
-#define LUACRYPTO_REQUEST_FREE(request, name)					\
-do {										\
-	name##_request_free((request)->name);					\
-	lunatik_free((request)->iv);						\
-} while (0)
+static inline u8 *luacrypto_checkiv(lua_State *L, int idx, u8 *iv, size_t expected)
+{
+	size_t iv_len;
+	const char *str = luaL_checklstring(L, idx, &iv_len);
+	if (iv_len != expected)
+		lunatik_throw(L, -EINVAL);
+	if (iv_len == 0)
+		return NULL;
+
+	memcpy(iv, str, iv_len);
+	return iv;
+}
 
 extern const lunatik_class_t luacrypto_shash_class;
 extern const lunatik_class_t luacrypto_skcipher_class;

--- a/lib/luacrypto_aead.c
+++ b/lib/luacrypto_aead.c
@@ -17,9 +17,14 @@
 
 #include "luacrypto.h"
 
-LUNATIK_PRIVATECHECKER(luacrypto_aead_check, struct crypto_aead *);
+LUNATIK_PRIVATECHECKER(luacrypto_aead_checkctx, luacrypto_ctx_t *);
 
-LUACRYPTO_RELEASER(aead, struct crypto_aead, crypto_free_aead);
+static inline struct crypto_aead *luacrypto_aead_check(lua_State *L, int idx)
+{
+	return (struct crypto_aead *)luacrypto_aead_checkctx(L, idx)->tfm;
+}
+
+LUACRYPTO_RELEASERCTX(aead, struct crypto_aead, crypto_free_aead);
 
 /***
 * Sets the cipher key.
@@ -75,8 +80,8 @@ static int luacrypto_aead_authsize(lua_State *L)
 }
 
 typedef struct luacrypto_aead_request_s {
-	struct scatterlist src[2];	/* AAD + data, mapped from Lua strings */
-	struct scatterlist dst[2];	/* AAD prefix + output, in allocated buffer */
+	struct scatterlist src[2];	/* AAD + data */
+	struct scatterlist dst[2];	/* AAD prefix + output */
 	struct aead_request *aead;
 	const char *data;
 	const char *aad;
@@ -89,14 +94,15 @@ typedef struct luacrypto_aead_request_s {
 static inline void luacrypto_aead_newrequest(lua_State *L, luacrypto_aead_request_t *request)
 {
 	memset(request, 0, sizeof(luacrypto_aead_request_t));
-	struct crypto_aead *tfm = luacrypto_aead_check(L, 1);
+	luacrypto_ctx_t *ctx = luacrypto_aead_checkctx(L, 1);
+	struct crypto_aead *tfm = (struct crypto_aead *)ctx->tfm;
 
-	request->iv = luacrypto_checkiv(L, 2, crypto_aead_ivsize(tfm));
+	request->iv = luacrypto_checkiv(L, 2, ctx->iv, crypto_aead_ivsize(tfm));
 	request->data = luaL_checklstring(L, 3, &request->crypt_len);
 	request->aad = luaL_optlstring(L, 4, "", &request->aad_len);
-	request->authsize = crypto_aead_authsize(tfm);
 
-	LUACRYPTO_REQUEST_ALLOC(L, request, aead, tfm);
+	request->authsize = crypto_aead_authsize(tfm);
+	request->aead = (struct aead_request *)ctx->request;
 }
 
 static inline void luacrypto_aead_setrequest(luacrypto_aead_request_t *request, char *buffer, size_t output_len)
@@ -113,7 +119,8 @@ static inline void luacrypto_aead_setrequest(luacrypto_aead_request_t *request, 
 	sg_set_buf(&src[n - 1], request->data, request->crypt_len);
 
 	/* dst mirrors the AAD prefix and reserves room for the output. */
-	memcpy(buffer, request->aad, request->aad_len);
+	if (request->aad_len)
+		memcpy(buffer, request->aad, request->aad_len);
 	sg_init_table(dst, n);
 	if (request->aad_len)
 		sg_set_buf(&dst[0], buffer, request->aad_len);
@@ -124,19 +131,12 @@ static inline void luacrypto_aead_setrequest(luacrypto_aead_request_t *request, 
 	aead_request_set_callback(aead, 0, NULL, NULL);
 }
 
-static inline void luacrypto_aead_request_free(luacrypto_aead_request_t *request)
-{
-	LUACRYPTO_REQUEST_FREE(request, aead);
-}
-
 static inline char *luacrypto_aead_prepare(lua_State *L, luacrypto_aead_request_t *request, size_t output_len)
 {
 	size_t buffer_len = request->aad_len + (output_len ? output_len : 1);
 	char *buffer = (char *)lunatik_malloc(L, buffer_len);
-	if (buffer == NULL) {
-		luacrypto_aead_request_free(request);
+	if (buffer == NULL)
 		lunatik_enomem(L);
-	}
 	luacrypto_aead_setrequest(request, buffer, output_len);
 	return buffer;
 }
@@ -144,7 +144,6 @@ static inline char *luacrypto_aead_prepare(lua_State *L, luacrypto_aead_request_
 static inline int luacrypto_aead_finish(lua_State *L, luacrypto_aead_request_t *request,
 	char *buffer, int ret, size_t output_len)
 {
-	luacrypto_aead_request_free(request);
 	if (ret < 0) {
 		lunatik_free(buffer);
 		lunatik_throw(L, ret);
@@ -188,10 +187,8 @@ static int luacrypto_aead_decrypt(lua_State *L)
 {
 	luacrypto_aead_request_t request;
 	luacrypto_aead_newrequest(L, &request);
-	if (request.crypt_len < request.authsize) {
-		luacrypto_aead_request_free(&request);
+	if (request.crypt_len < request.authsize)
 		lunatik_throw(L, -EBADMSG);
-	}
 	size_t output_len = request.crypt_len - request.authsize;
 	char *buffer = luacrypto_aead_prepare(L, &request, output_len);
 	int ret = crypto_aead_decrypt(request.aead);
@@ -222,7 +219,7 @@ const lunatik_class_t luacrypto_aead_class = {
 	.name = "crypto_aead",
 	.methods = luacrypto_aead_mt,
 	.release = luacrypto_aead_release,
-	.opt = LUNATIK_OPT_MONITOR | LUNATIK_OPT_EXTERNAL,
+	.opt = LUNATIK_OPT_MONITOR,
 };
 
 /***
@@ -235,5 +232,5 @@ const lunatik_class_t luacrypto_aead_class = {
 *   local aead = require("crypto").aead
 *   local cipher = aead("gcm(aes)")
 */
-LUACRYPTO_NEW(aead, struct crypto_aead, crypto_alloc_aead, luacrypto_aead_class);
+LUACRYPTO_NEWCTX(aead, struct crypto_aead, crypto_alloc_aead, luacrypto_aead_class);
 

--- a/lib/luacrypto_aead.c
+++ b/lib/luacrypto_aead.c
@@ -17,12 +17,7 @@
 
 #include "luacrypto.h"
 
-LUNATIK_PRIVATECHECKER(luacrypto_aead_checkctx, luacrypto_ctx_t *);
-
-static inline struct crypto_aead *luacrypto_aead_check(lua_State *L, int idx)
-{
-	return (struct crypto_aead *)luacrypto_aead_checkctx(L, idx)->tfm;
-}
+LUACRYPTO_CHECKER(aead, struct crypto_aead);
 
 LUACRYPTO_RELEASERCTX(aead, struct crypto_aead, crypto_free_aead);
 

--- a/lib/luacrypto_skcipher.c
+++ b/lib/luacrypto_skcipher.c
@@ -17,9 +17,14 @@
 
 #include "luacrypto.h"
 
-LUNATIK_PRIVATECHECKER(luacrypto_skcipher_check, struct crypto_skcipher *);
+LUNATIK_PRIVATECHECKER(luacrypto_skcipher_checkctx, luacrypto_ctx_t *);
 
-LUACRYPTO_RELEASER(skcipher, struct crypto_skcipher, crypto_free_skcipher);
+static inline struct crypto_skcipher *luacrypto_skcipher_check(lua_State *L, int idx)
+{
+	return (struct crypto_skcipher *)luacrypto_skcipher_checkctx(L, idx)->tfm;
+}
+
+LUACRYPTO_RELEASERCTX(skcipher, struct crypto_skcipher, crypto_free_skcipher);
 
 /***
 * Sets the cipher key.
@@ -72,12 +77,12 @@ typedef struct luacrypto_skcipher_request_s {
 static inline void luacrypto_skcipher_newrequest(lua_State *L, luacrypto_skcipher_request_t *request)
 {
 	memset(request, 0, sizeof(luacrypto_skcipher_request_t));
-	struct crypto_skcipher *tfm = luacrypto_skcipher_check(L, 1);
+	luacrypto_ctx_t *ctx = luacrypto_skcipher_checkctx(L, 1);
+	struct crypto_skcipher *tfm = (struct crypto_skcipher *)ctx->tfm;
 
-	request->iv = luacrypto_checkiv(L, 2, crypto_skcipher_ivsize(tfm));
+	request->iv = luacrypto_checkiv(L, 2, ctx->iv, crypto_skcipher_ivsize(tfm));
 	request->data = luaL_checklstring(L, 3, &request->data_len);
-
-	LUACRYPTO_REQUEST_ALLOC(L, request, skcipher, tfm);
+	request->skcipher = (struct skcipher_request *)ctx->request;
 }
 
 static inline void luacrypto_skcipher_setrequest(luacrypto_skcipher_request_t *request, char *buffer)
@@ -97,15 +102,13 @@ static int luacrypto_skcipher_crypt(lua_State *L, int (*crypt)(struct skcipher_r
 	luacrypto_skcipher_request_t request;
 	luacrypto_skcipher_newrequest(L, &request);
 
-	char *buffer = (char *)lunatik_malloc(L, request.data_len);
-	if (buffer == NULL) {
-		LUACRYPTO_REQUEST_FREE(&request, skcipher);
+	/* extra byte for the NUL terminator written by lunatik_pushstring() */
+	char *buffer = (char *)lunatik_malloc(L, request.data_len + 1);
+	if (buffer == NULL)
 		lunatik_enomem(L);
-	}
 
 	luacrypto_skcipher_setrequest(&request, buffer);
 	int ret = crypt(request.skcipher);
-	LUACRYPTO_REQUEST_FREE(&request, skcipher);
 	if (ret < 0) {
 		lunatik_free(buffer);
 		lunatik_throw(L, ret);
@@ -164,7 +167,7 @@ const lunatik_class_t luacrypto_skcipher_class = {
 	.name = "crypto_skcipher",
 	.methods = luacrypto_skcipher_mt,
 	.release = luacrypto_skcipher_release,
-	.opt = LUNATIK_OPT_MONITOR | LUNATIK_OPT_EXTERNAL,
+	.opt = LUNATIK_OPT_MONITOR,
 };
 
 /***
@@ -177,5 +180,5 @@ const lunatik_class_t luacrypto_skcipher_class = {
 *   local skcipher = require("crypto").skcipher
 *   local cipher = skcipher("cbc(aes)")
 */
-LUACRYPTO_NEW(skcipher, struct crypto_skcipher, crypto_alloc_skcipher, luacrypto_skcipher_class);
+LUACRYPTO_NEWCTX(skcipher, struct crypto_skcipher, crypto_alloc_skcipher, luacrypto_skcipher_class);
 

--- a/lib/luacrypto_skcipher.c
+++ b/lib/luacrypto_skcipher.c
@@ -17,12 +17,7 @@
 
 #include "luacrypto.h"
 
-LUNATIK_PRIVATECHECKER(luacrypto_skcipher_checkctx, luacrypto_ctx_t *);
-
-static inline struct crypto_skcipher *luacrypto_skcipher_check(lua_State *L, int idx)
-{
-	return (struct crypto_skcipher *)luacrypto_skcipher_checkctx(L, idx)->tfm;
-}
+LUACRYPTO_CHECKER(skcipher, struct crypto_skcipher);
 
 LUACRYPTO_RELEASERCTX(skcipher, struct crypto_skcipher, crypto_free_skcipher);
 

--- a/tests/crypto/aead.lua
+++ b/tests/crypto/aead.lua
@@ -113,3 +113,18 @@ test("AEAD AES-128-GCM round-trip empty plaintext with AAD", function()
 	assert(plaintext == "", "Empty-plaintext round-trip failed")
 end)
 
+test("AEAD AES-128-GCM stress round-trip", function()
+	local c = aead("gcm(aes)")
+	local iv = "abcdefghijkl"
+	local aad = "0123456789abcdef"
+	local plaintext = "plaintext"
+	c:setkey"0123456789abcdef"
+	c:setauthsize(16)
+
+	for _ = 1, 5000 do
+		local ciphertext = c:encrypt(iv, plaintext, aad)
+		local decrypted = c:decrypt(iv, ciphertext, aad)
+		assert(decrypted == plaintext, "Stress round-trip mismatch")
+	end
+end)
+

--- a/tests/crypto/skcipher.lua
+++ b/tests/crypto/skcipher.lua
@@ -92,3 +92,14 @@ test("SKCIPHER AES-128-CBC stress round-trip", function()
 	end
 end)
 
+test("SKCIPHER AES-128-ECB round-trip without IV", function()
+	local c = skcipher("ecb(aes)")
+	local plaintext = "This is a test!!"
+	c:setkey"0123456789abcdef"
+	assert(c:ivsize() == 0, "ECB should have no IV")
+
+	local ciphertext = c:encrypt("", plaintext)
+	local decrypted = c:decrypt("", ciphertext)
+	assert(decrypted == plaintext, "ECB round-trip mismatch")
+end)
+

--- a/tests/crypto/skcipher.lua
+++ b/tests/crypto/skcipher.lua
@@ -79,3 +79,16 @@ test("SKCIPHER AES-128-CBC decrypt with data not multiple of blocksize", functio
 	assert(err == "EINVAL", "Error code should be 'EINVAL', got: " .. err)
 end)
 
+test("SKCIPHER AES-128-CBC stress round-trip", function()
+	local c = skcipher("cbc(aes)")
+	local iv = "fedcba9876543210"
+	local plaintext = "This is a test!!"
+	c:setkey"0123456789abcdef"
+
+	for _ = 1, 5000 do
+		local ciphertext = c:encrypt(iv, plaintext)
+		local decrypted = c:decrypt(iv, ciphertext)
+		assert(decrypted == plaintext, "Stress round-trip mismatch")
+	end
+end)
+


### PR DESCRIPTION
  skcipher/aead allocated the request and the IV buffer on every
  encrypt/decrypt. Under memory pressure in softirq context this fails
  with ENOMEM (notably `ecb` during QUIC decryption in ipparse).

  Hold the tfm, the request and the IV buffer (all fixed-size for a given
  tfm) in a `luacrypto_ctx_t` allocated once at creation time. The hot
  path no longer performs any fallible allocation besides the output
  buffer. The runtime lock already serializes operations on a cipher
  object, so the request and IV are safe to reuse across calls.

  The skcipher output buffer gains one byte for the NUL terminator written
  by `lunatik_pushstring()`, fixing a one-byte overflow on the previous
  exact-size allocation.

  The shared context lets skcipher and aead generate their `checkctx`/`check`
  accessors from a single `LUACRYPTO_CHECKER` macro instead of repeating the
  boilerplate in each file.

  Adds skcipher/aead stress round-trip tests.
