### PR TITLE
lunatik: publish object before arming __gc in newobject

### DIFF
--- a/lunatik_obj.c
+++ b/lunatik_obj.c
@@ -25,11 +25,10 @@ lunatik_object_t *lunatik_newobject(lua_State *L, const lunatik_class_t *class, 
 	lunatik_checkclass(L, class);
 
 	lunatik_setobject(object, class, opt);
+	*pobject = object; /* before setclass exposes it to __gc */
 	lunatik_setclass(L, class, lunatik_ismonitor(object->opt));
 
 	object->private = lunatik_isexternal(class->opt) ? NULL : lunatik_checkzalloc(L, size);
-
-	*pobject = object;
 	return object;
 }
 EXPORT_SYMBOL(lunatik_newobject);

--- a/tests/README.md
+++ b/tests/README.md
@@ -75,6 +75,10 @@ Regression tests for `lunatik_monitor` (spinlock + GC interaction).
 - **map_sync**: `rcu.map()` remains safe when called while another
   kthread is modifying the table.
 
+- **newobject_oom**: a failed private allocation in `lunatik_newobject()`
+  (forced via an absurd `rcu.table()` bucket count) surfaces as a graceful
+  error without the `__gc` finalizer running on uninitialized memory.
+
 ### runtime
 
 Regression tests for `lunatik_newruntime` and cross-runtime plumbing.

--- a/tests/rcu/newobject_oom.lua
+++ b/tests/rcu/newobject_oom.lua
@@ -1,0 +1,22 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the newobject_oom test (see newobject_oom.sh).
+
+local rcu = require("rcu")
+local test = require("util").test
+
+local HUGE_BUCKETS <const> = 1 << 58
+
+test("rcu.table with huge size fails gracefully", function()
+	assert(not pcall(rcu.table, HUGE_BUCKETS), "huge allocation should have failed")
+	collectgarbage() -- force the failed object's finalizer to run now
+end)
+
+test("runtime usable after failed allocation", function()
+	local t = rcu.table(16)
+	t["n"] = 42
+	assert(t["n"] == 42, "table broken after failed allocation")
+end)
+

--- a/tests/rcu/newobject_oom.sh
+++ b/tests/rcu/newobject_oom.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for a use-after-free in lunatik_newobject(): the object's
+# __gc finalizer used to run on uninitialized userdata memory when the private
+# allocation failed *after* the metatable (and thus __gc) was already set.
+#
+# Requesting an rcu.table with an absurd bucket count forces that allocation to
+# fail; the buggy core then dereferenced a garbage object pointer in
+# lunatik_deleteobject() and oopsed. The fix publishes the object before
+# arming __gc, so the failure must surface as a graceful Lua error and leave
+# the kernel alive.
+#
+# Usage: sudo bash tests/rcu/newobject_oom.sh
+
+DIR="$(dirname "$(readlink -f "$0")")"
+
+source "$DIR/../lib.sh"
+
+cleanup() { lunatik stop tests/rcu/newobject_oom 2>/dev/null; }
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+mark_dmesg
+run_script tests/rcu/newobject_oom
+
+log=$(dmesg_since)
+crash=$(echo "$log" | grep -E "Oops|BUG: unable|general protection|kernel BUG at|unable to handle kernel" || true)
+luaerr=$(echo "$log" | grep -E "\.lua:[0-9]+:" || true)
+if [ -n "$crash" ]; then
+	ktap_fail "rcu/newobject_oom: kernel crashed on failed allocation"
+	echo "# ${crash%%$'\n'*}"
+elif [ -n "$luaerr" ]; then
+	ktap_fail "rcu/newobject_oom: Lua-level failure"
+	echo "# ${luaerr%%$'\n'*}"
+else
+	ktap_pass "rcu/newobject_oom"
+fi
+
+ktap_totals
+[ $KTAP_FAIL -eq 0 ]
+

--- a/tests/rcu/run.sh
+++ b/tests/rcu/run.sh
@@ -39,5 +39,8 @@ RESULT=$?
 
 echo ""
 bash "$DIR/map_sync.sh" || RESULT=1
+
+echo ""
+bash "$DIR/newobject_oom.sh" || RESULT=1
 exit $RESULT
 


### PR DESCRIPTION
lunatik_newobject() set the userdata's metatable (arming the __gc finalizer) before storing the object pointer into the userdata. If the private allocation right after threw (e.g. ENOMEM on a large size), the error unwind ran __gc on the still-uninitialized userdata memory, so lunatik_deleteobject() dereferenced a garbage pointer and oopsed.

Store the object into the userdata right after lunatik_setobject() (which already NULLs private), before lunatik_setclass() arms __gc, so a later throw finalizes a valid, releasable object.

The regression test forces the failure through an absurd rcu.table() bucket count and checks the kernel stays alive.