### PR TITLE
lunatik: free object private with kvfree, not kfree

### DIFF
--- a/lunatik.h
+++ b/lunatik.h
@@ -132,7 +132,7 @@ static inline void *lunatik_realloc(lua_State *L, void *ptr, size_t size)
 }
 
 #define lunatik_malloc(L, s)	lunatik_realloc((L), NULL, (s))
-#define lunatik_free(p)		kfree(p)
+#define lunatik_free(p)		kvfree(p)
 #define lunatik_gfp(runtime)	((runtime)->gfp)
 
 #define lunatik_enomem(L)	luaL_error((L), "not enough memory")

--- a/tests/README.md
+++ b/tests/README.md
@@ -78,6 +78,9 @@ Regression tests for `lunatik_monitor` (spinlock + GC interaction).
 - **newobject_oom**: a failed private allocation in `lunatik_newobject()`
   (forced via an absurd `rcu.table()` bucket count) surfaces as a graceful
   error without the `__gc` finalizer running on uninitialized memory.
+- **bigtable_free**: a large `rcu.table()` whose private exceeds `KMALLOC_MAX`
+  is backed by `vmalloc`; releasing it must free with `kvfree`, not `kfree`,
+  so the teardown leaves the kernel alive.
 
 ### runtime
 

--- a/tests/rcu/bigtable_free.lua
+++ b/tests/rcu/bigtable_free.lua
@@ -1,0 +1,13 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the bigtable_free test (see bigtable_free.sh).
+-- Holds a table whose private is large enough to be vmalloc-backed in a global;
+-- the harness measures it, then frees it by stopping the runtime.
+
+local BIG_BUCKETS <const> = 1 << 22 -- ~32 MiB of buckets, past the kmalloc order
+
+BIGTABLE = require("rcu").table(BIG_BUCKETS)
+BIGTABLE["probe"] = true
+

--- a/tests/rcu/bigtable_free.sh
+++ b/tests/rcu/bigtable_free.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for freeing a large object private. lunatik_newobject()
+# allocates the private through the runtime allocator, which uses kvmalloc for
+# big sizes (vmalloc once past the kmalloc order). lunatik_releaseprivate() then
+# freed it with kfree(), which faults on a vmalloc'd pointer; the fix frees it
+# with kvfree().
+#
+# The kmalloc/vmalloc threshold depends on the kernel's MAX_ORDER, so the test
+# confirms via VmallocUsed that the private is actually vmalloc-backed and skips
+# (never false-passes) when the allocation stayed in kmalloc. When it is
+# vmalloc-backed, freeing it must leave the kernel alive.
+#
+# Usage: sudo bash tests/rcu/bigtable_free.sh
+
+DIR="$(dirname "$(readlink -f "$0")")"
+
+source "$DIR/../lib.sh"
+
+cleanup() { lunatik stop tests/rcu/bigtable_free 2>/dev/null; }
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+vmalloc_kib() { grep VmallocUsed /proc/meminfo | awk '{print $2}'; }
+
+before=$(vmalloc_kib)
+run_script tests/rcu/bigtable_free
+after=$(vmalloc_kib)
+delta_mib=$(( (after - before) / 1024 ))
+
+mark_dmesg
+lunatik stop tests/rcu/bigtable_free 2>/dev/null
+log=$(dmesg_since)
+crash=$(echo "$log" | grep -iE "Oops|BUG: unable|kernel BUG at|unable to handle kernel|mem abort" || true)
+
+if [ -n "$crash" ]; then
+	ktap_fail "rcu/bigtable_free: kernel crashed freeing a vmalloc'd private"
+	echo "# ${crash%%$'\n'*}"
+elif [ "$delta_mib" -lt 16 ]; then
+	ktap_skip "rcu/bigtable_free: private not vmalloc-backed (delta ${delta_mib}MiB), cannot exercise kvfree"
+else
+	ktap_pass "rcu/bigtable_free"
+fi
+
+ktap_totals
+[ $KTAP_FAIL -eq 0 ]
+

--- a/tests/rcu/run.sh
+++ b/tests/rcu/run.sh
@@ -42,5 +42,8 @@ bash "$DIR/map_sync.sh" || RESULT=1
 
 echo ""
 bash "$DIR/newobject_oom.sh" || RESULT=1
+
+echo ""
+bash "$DIR/bigtable_free.sh" || RESULT=1
 exit $RESULT
 


### PR DESCRIPTION
The runtime allocator backs allocations larger than one page with kvmalloc, which falls back to vmalloc past the kmalloc order. lunatik_free was kfree, so releasing an object whose private was that large faulted on the vmalloc'd pointer. Free with kvfree, which handles both kmalloc'd and vmalloc'd pointers.

Add a regression test: a large rcu.table whose bucket array (the object private) exceeds the kmalloc order is vmalloc-backed; the test confirms that via VmallocUsed and skips otherwise, then checks the kernel survives the free.