### PR TITLE
Add ebpf maps binding

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,7 @@ jobs:
         make defconfig
         echo "CONFIG_STACK_VALIDATION=n" >> .config
         echo "CONFIG_WERROR=n" >> .config
+        echo "CONFIG_BPF_SYSCALL=y" >> .config
         if [[ "$SERIES" == "5."* ]]; then
           sed -i 's/-Werror//g' tools/objtool/Makefile
           sed -i 's/-Werror//g' tools/lib/subcmd/Makefile

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CONFIG_LUNATIK_RUN ?= m
 # Order matters: modules are loaded left-to-right and unloaded right-to-left (rmmod).
 # A module must appear AFTER all modules it depends on (e.g. SKB before NETFILTER).
 LUNATIK_MODULES := DEVICE LINUX NOTIFIER SOCKET NETLINK RCU SET THREAD FIB DATA PROBE SYSCALL XDP FIFO SKB NETFILTER \
-	COMPLETION CRYPTO CPU HID SIGNAL BYTEORDER DARKEN
+	COMPLETION CRYPTO CPU HID SIGNAL BYTEORDER DARKEN EBPF_MAP
 
 $(foreach c,$(LUNATIK_MODULES),\
 	$(eval CONFIG_LUNATIK_$(c) ?= m))

--- a/autogen/specs.lua
+++ b/autogen/specs.lua
@@ -36,6 +36,8 @@ return {
 		desc = "Network device notifier event types." },
 	{ header = "uapi/linux/bpf.h",              prefix = "XDP_",       module = "xdp",
 		desc = "XDP verdicts and flags." },
+	{ header = "uapi/linux/bpf.h",              prefix = "BPF_",       module = "bpf",
+		desc = "BPF maps and flags." },
 	{ header = "linux/sched.h",                 prefix = "TASK_",      module = "task",
 		desc = "Task state flags." },
 	{ header = "linux/net.h",                   prefix = "SOCK_",      module = "socket.sock",

--- a/config.ld
+++ b/config.ld
@@ -58,6 +58,7 @@ file = {
 	'./lib/syscall/table.lua',
 	'./lib/luathread.c',
 	'./lib/luaxdp.c',
+	'./lib/luaebpf_map.c',
 }
 
 -- examples = "./examples"

--- a/lib/Kbuild
+++ b/lib/Kbuild
@@ -26,4 +26,5 @@ obj-$(CONFIG_LUNATIK_SIGNAL) += luasignal.o
 obj-$(CONFIG_LUNATIK_BYTEORDER) += luabyteorder.o
 obj-$(CONFIG_LUNATIK_DARKEN) += luadarken.o
 obj-$(CONFIG_LUNATIK_SKB) += luaskb.o
+obj-$(CONFIG_LUNATIK_EBPF_MAP) += luaebpf_map.o
 

--- a/lib/luaebpf_map.c
+++ b/lib/luaebpf_map.c
@@ -1,0 +1,316 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+/***
+* Lua interface for eBPF maps.
+*
+* This module provides generic key-value access to pinned eBPF maps,
+* supporting types that implement standard lookup, update, deletion,
+* and iteration operations, including:
+*   - BPF_MAP_TYPE_HASH
+*   - BPF_MAP_TYPE_ARRAY
+*   - BPF_MAP_TYPE_LRU_HASH
+*
+* Keys and values are exchanged as packed Lua strings whose sizes must
+* match the map's configured key and value sizes.
+*
+* @module ebpf.map
+*/
+
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
+#include <linux/bpf.h>
+#include <linux/namei.h>
+#include <linux/fs.h>
+
+#include <lunatik.h>
+
+LUNATIK_PRIVATECHECKER(luaebpf_map_check, struct bpf_map *,
+	luaL_argcheck(L, private != NULL, ix, "bpf map is not set");
+	/* map->ops should be set on creation; crash if broken */
+	BUG_ON(!private->ops);
+);
+
+#define luaebpf_map_checksize(L, size, expected, ix, arg) \
+	luaL_argcheck((L), (size) == (expected), (ix), "invalid " arg " size")
+
+#define luaebpf_map_checkoptsize(L, size, expected, ix, arg) \
+    luaL_argcheck((L), ((size) == (expected)) || ((size) == 0), (ix), "invalid " arg " size")
+
+#define luaebpf_map_is_valid_update_flag(flags) \
+	((flags) == BPF_ANY || (flags) == BPF_NOEXIST || (flags) == BPF_EXIST)
+
+#define luaebpf_map_push_clean(L, ret, buffer, buffer_size) \
+do { 												\
+	if ((ret) == 0) 								\
+		lua_pushlstring(L, buffer, buffer_size); 	\
+	kfree(buffer); 									\
+	if (ret == -ENOENT) 							\
+		lua_pushnil(L); 							\
+	else if (ret) 									\
+		lunatik_throw(L, ret); 						\
+} while (0)
+
+static int luaebpf_map_pushresult(lua_State *L, long ret)
+{
+	if (ret == -ENOENT) {
+		lua_pushboolean(L, 0);
+		return 1;
+	}
+	if (ret)
+		lunatik_throw(L, ret);
+	lua_pushboolean(L, 1);
+	return 1;
+}
+
+static void luaebpf_map_release(void *private);
+
+static inline struct bpf_map *luaebpf_map_frompath(const struct path *path)
+{
+	struct inode *inode = d_inode(path->dentry);
+	return inode ? inode->i_private : NULL;
+}
+
+static struct bpf_map *luaebpf_map_get(const char *pathname)
+{
+	struct path path;
+
+	if (kern_path(pathname, LOOKUP_FOLLOW, &path))
+		return NULL;
+
+	struct bpf_map *map = luaebpf_map_frompath(&path);
+	if (map)
+		bpf_map_inc(map);
+
+	path_put(&path);
+	return map;
+}
+
+/**
+* Looks up a key from the map.
+* @function lookup
+* @tparam map map
+* @tparam string key Packed key
+* @treturn string value Packed value, or `nil` if the key is not present
+*/
+static int luaebpf_map_lookup(lua_State *L)
+{
+	struct bpf_map *map = luaebpf_map_check(L, 1);
+	size_t key_size;
+	const char *key = luaL_checklstring(L, 2, &key_size);
+	luaebpf_map_checksize(L, key_size, map->key_size, 2, "key");
+
+	void *value = map->ops->map_lookup_elem(map, (void *)key);
+	if (!value) {
+		lua_pushnil(L);
+	} else {
+		lua_pushlstring(L, value, map->value_size);
+	}
+	return 1;
+}
+
+/**
+* Updates a key in the map.
+* @function update
+* @tparam map map
+* @tparam string key Packed key.
+* @tparam string value Packed value.
+* @tparam[opt=BPF_ANY] integer flags Update flags. One of:
+*   - `BPF_ANY` (default): Create a new element or update an existing one.
+*   - `BPF_NOEXIST`: Create a new element only if the key does not exist.
+*   - `BPF_EXIST`: Update an existing element only if the key exists.
+* @treturn boolean success
+* @raise Error if the operation is not permitted by the map.
+*/
+static int luaebpf_map_update(lua_State *L)
+{
+	struct bpf_map *map= luaebpf_map_check(L, 1);
+	size_t key_size;
+	const char *key = luaL_checklstring(L, 2, &key_size);
+	size_t value_size;
+	const char *value = luaL_checklstring(L, 3, &value_size);
+
+	luaebpf_map_checksize(L, key_size, map->key_size, 2, "key");
+	luaebpf_map_checksize(L, value_size, map->value_size, 3, "value");
+	u64 flags = luaL_optinteger(L, 4, BPF_ANY);
+
+	if (!luaebpf_map_is_valid_update_flag(flags))
+		luaL_argerror(L, 4, "invalid update flag");
+
+	long ret = map->ops->map_update_elem(map, (void *)key, (void *)value, flags);
+	return luaebpf_map_pushresult(L, ret);
+}
+
+/**
+* Deletes a key from the map.
+* @function delete
+* @tparam map map
+* @tparam string key Packed key.
+* @treturn boolean success
+* @raise Error if the operation is not permitted by the map.
+*/
+static int luaebpf_map_delete(lua_State *L)
+{
+	struct bpf_map *map = luaebpf_map_check(L, 1);
+	size_t key_size;
+	const char *key = luaL_checklstring(L, 2, &key_size);
+
+	luaebpf_map_checksize(L, key_size, map->key_size, 2, "key");
+
+	long ret = map->ops->map_delete_elem(map, (void *)key);
+	return luaebpf_map_pushresult(L, ret);
+}
+
+/**
+* Looks up and deletes a key from the map.
+* @function remove
+* @tparam map map
+* @tparam string key Packed key.
+* @treturn string value Packed value, or `nil` if the key is not present.
+* @raise Error if the operation is not permitted by the map or memory allocation fails.
+*/
+static int luaebpf_map_remove(lua_State *L)
+{
+	struct bpf_map *map = luaebpf_map_check(L, 1);
+	size_t key_size;
+	const char *key = luaL_checklstring(L, 2, &key_size);
+
+	luaebpf_map_checksize(L, key_size, map->key_size, 2, "key");
+
+	char *value = lunatik_checkalloc(L, map->value_size);
+	int ret = map->ops->map_lookup_and_delete_elem(map, (void *)key, (void *)value, 0);
+
+	luaebpf_map_push_clean(L, ret, value, map->value_size);
+
+	return 1;
+}
+
+/**
+* Returns the next key in the map.
+* @function next
+* @tparam map map
+* @tparam[opt] string key Packed key, returns the first key if nothing is passed.
+* @treturn string next_key Packed next key, or `nil` if there are no more keys.
+* @raise Error if the operation is not permitted by the map or memory allocation fails.
+* @usage
+*   local map = require("ebpf.map")
+*   local flow = map.open("/sys/fs/bpf/flow_cache")
+*   local key = flow:next()
+*   while key do
+*   	print(key)
+*   	key = flow:next(key)
+*   end
+*   flow:close()
+*/
+static int luaebpf_map_get_next_key(lua_State *L)
+{
+	struct bpf_map *map = luaebpf_map_check(L, 1);
+	size_t key_size;
+	const char *key = luaL_optlstring(L, 2, NULL, &key_size);
+
+	luaebpf_map_checkoptsize(L, key_size, map->key_size, 2, "key");
+	void *next_key = lunatik_checkalloc(L, map->key_size);
+	long ret = map->ops->map_get_next_key(map, (void *)key, next_key);
+
+	luaebpf_map_push_clean(L, ret, next_key, map->key_size);
+
+	return 1;
+}
+
+/**
+* Releases the map reference.
+* @function close
+*/
+static int luaebpf_map_close(lua_State *L)
+{
+	lunatik_object_t *obj = lunatik_checkobject(L, 1);
+	struct bpf_map *map = obj->private;
+	if (map) {
+		obj->private = NULL;
+		bpf_map_put(map);
+	}
+	return 0;
+}
+
+static const luaL_Reg luaebpf_map_mt[] = {
+	{"lookup", luaebpf_map_lookup},
+	{"update", luaebpf_map_update},
+	{"delete", luaebpf_map_delete},
+	{"remove", luaebpf_map_remove},
+	{"next",   luaebpf_map_get_next_key},
+	{"close",  luaebpf_map_close},
+	{"__gc",   lunatik_deleteobject},
+	{NULL, NULL}
+};
+
+LUNATIK_OPENER(ebpf_map);
+static const lunatik_class_t luaebpf_map_class = {
+	.name = "ebpf_map",
+	.methods = luaebpf_map_mt,
+	.release = luaebpf_map_release,
+	.opener = luaopen_ebpf_map,
+	.opt = LUNATIK_OPT_EXTERNAL,
+};
+
+/**
+* Opens a map from pinned bpffs path.
+*
+* @function open
+* @tparam string path Path to a pinned eBPF map.
+* @treturn map map Opened map handle.
+* @usage
+*   local map = require("ebpf.map")
+*   local bpf = require("linux.bpf")
+*   local counter = map.open("/sys/fs/bpf/counters")
+*   -- 32-bit key/value encoded as packed strings.
+*   local key = string.pack("I4", 1)
+*   local value = string.pack("I4", 42)
+*   assert(counter:update(key, value, bpf.ANY))
+*   local result = counter:lookup(key)
+*   if result then
+*       print(string.unpack("I4", result))
+*   end
+*   counter:delete(key)
+*   counter:close()
+*/
+static int luaebpf_map_open(lua_State *L)
+{
+	const char *pathname = luaL_checkstring(L, 1);
+	struct bpf_map *map = luaebpf_map_get(pathname);
+	luaL_argcheck(L, map != NULL, 1, "failed to open bpf map");
+	lunatik_object_t *object = lunatik_newobject(L, &luaebpf_map_class, 0, LUNATIK_OPT_NONE);
+	object->private = map;
+	return 1;
+}
+
+static const luaL_Reg luaebpf_map_lib[] = {
+	{"open", luaebpf_map_open},
+	{NULL, NULL},
+};
+
+static void luaebpf_map_release(void *private)
+{
+	struct bpf_map *map = (struct bpf_map *)private;
+	if (map)
+		bpf_map_put(map);
+}
+
+LUNATIK_CLASSES(ebpf_map, &luaebpf_map_class);
+LUNATIK_NEWLIB(ebpf_map, luaebpf_map_lib, luaebpf_map_classes);
+
+static int __init luaebpf_map_init(void)
+{
+	return 0;
+}
+
+static void __exit luaebpf_map_exit(void)
+{
+}
+
+module_init(luaebpf_map_init);
+module_exit(luaebpf_map_exit);
+MODULE_LICENSE("Dual MIT/GPL");
+MODULE_AUTHOR("Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>");
+

--- a/lib/luaebpf_map.c
+++ b/lib/luaebpf_map.c
@@ -252,7 +252,7 @@ static const lunatik_class_t luaebpf_map_class = {
 	.methods = luaebpf_map_mt,
 	.release = luaebpf_map_release,
 	.opener = luaopen_ebpf_map,
-	.opt = LUNATIK_OPT_EXTERNAL | LUNATIK_OPT_IRQ,
+	.opt = LUNATIK_OPT_EXTERNAL | LUNATIK_OPT_HARDIRQ,
 };
 
 /**

--- a/lib/luaebpf_map.c
+++ b/lib/luaebpf_map.c
@@ -235,13 +235,14 @@ static int luaebpf_map_close(lua_State *L)
 }
 
 static const luaL_Reg luaebpf_map_mt[] = {
-	{"lookup", luaebpf_map_lookup},
-	{"update", luaebpf_map_update},
-	{"delete", luaebpf_map_delete},
-	{"remove", luaebpf_map_remove},
-	{"next",   luaebpf_map_get_next_key},
-	{"close",  luaebpf_map_close},
-	{"__gc",   lunatik_deleteobject},
+	{"lookup",  luaebpf_map_lookup},
+	{"update",  luaebpf_map_update},
+	{"delete",  luaebpf_map_delete},
+	{"remove",  luaebpf_map_remove},
+	{"next",    luaebpf_map_get_next_key},
+	{"close",   luaebpf_map_close},
+	{"__close", lunatik_deleteobject},
+	{"__gc",    lunatik_deleteobject},
 	{NULL, NULL}
 };
 
@@ -251,7 +252,7 @@ static const lunatik_class_t luaebpf_map_class = {
 	.methods = luaebpf_map_mt,
 	.release = luaebpf_map_release,
 	.opener = luaopen_ebpf_map,
-	.opt = LUNATIK_OPT_EXTERNAL,
+	.opt = LUNATIK_OPT_EXTERNAL | LUNATIK_OPT_IRQ,
 };
 
 /**

--- a/tests/ebpf/map_values.lua
+++ b/tests/ebpf/map_values.lua
@@ -1,0 +1,80 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+local map = require "ebpf.map"
+local bpf = require "linux.bpf"
+local test = require("util").test
+
+test("ebpf.map lookup returns inserted value", function()
+	local test = map.open("/sys/fs/bpf/test_map")
+	local value = test:lookup("foo")
+	assert(value == "bar", "expected 'bar', got: " .. tostring(value))
+	test:close()
+end)
+
+test("ebpf.map update inserts value", function()
+	local test = map.open("/sys/fs/bpf/test_map")
+	assert(test:update("abc", "xyz", bpf.ANY))
+	local value = test:lookup("abc")
+	assert(value == "xyz", "expected 'xyz', got: " .. tostring(value))
+	test:close()
+end)
+
+test("ebpf.map delete removes value", function()
+	local test = map.open("/sys/fs/bpf/test_map")
+	assert(test:update("tmp", "val", bpf.ANY))
+	assert(test:delete("tmp"))
+	local value = test:lookup("tmp")
+	assert(value == nil, "expected nil after delete")
+	test:close()
+end)
+
+test("ebpf.map lookup missing key returns nil", function()
+	local test = map.open("/sys/fs/bpf/test_map")
+	local value = test:lookup("zzz")
+	assert(value == nil, "expected nil")
+	test:close()
+end)
+
+test("ebpf.map remove extracts and removes value", function()
+    local test = map.open("/sys/fs/bpf/test_map")
+    assert(test:update("del", "pop", bpf.ANY))
+    local value = test:remove("del")
+    assert(value == "pop", "expected 'pop', got: " .. tostring(value))
+    local missing = test:lookup("del")
+    assert(missing == nil, "expected nil lookup after remove")
+    test:close()
+end)
+
+test("ebpf.map remove missing key returns nil", function()
+    local test = map.open("/sys/fs/bpf/test_map")
+    local value = test:remove("zzz")
+    assert(value == nil, "expected nil for non-existent key extraction")
+    test:close()
+end)
+
+test("ebpf.map next fetches first key when passed nil", function()
+    local test = map.open("/sys/fs/bpf/test_map")
+    assert(test:update("k11", "v11", bpf.ANY))
+    local first_key = test:next()
+    assert(first_key ~= nil, "expected a key string, got nil")
+    test:close()
+end)
+
+test("ebpf.map next can iterate through elements", function()
+    local test = map.open("/sys/fs/bpf/test_map")
+    assert(test:update("k21", "v21", bpf.ANY))
+    assert(test:update("k22", "v22", bpf.ANY))
+    local key = test:next()
+    local count = 0
+    while key do
+        count = count + 1
+        key = test:next(key)
+        if count > 100 then break end
+    end
+    assert(count >= 2, "expected to iterate through at least 2 elements, counted: " .. count)
+    test:close()
+end)
+

--- a/tests/ebpf/run.sh
+++ b/tests/ebpf/run.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Runs all ebpf tests and reports aggregated KTAP results.
+#
+# Usage: sudo bash tests/ebpf/run.sh
+
+DIR="$(dirname "$(readlink -f "$0")")"
+
+source "$DIR/../lib.sh"
+
+BPF_FS=/sys/fs/bpf
+MAP=$BPF_FS/test_map
+
+cleanup()
+{
+	rm -f "$MAP"
+}
+
+trap cleanup EXIT
+
+cleanup
+
+if ! mountpoint -q "$BPF_FS"; then
+    mount -t bpf bpf "$BPF_FS"
+fi
+
+bpftool map create \
+	"$MAP" \
+	type hash \
+	key 3 \
+	value 3 \
+	entries 128 \
+	name test_map >/dev/null
+
+bpftool map update \
+	pinned "$MAP" \
+	key hex 66 6f 6f \
+	value hex 62 61 72
+
+TESTS="map_values"
+TOTAL=$(echo $TESTS | wc -w)
+
+ktap_header
+ktap_plan $TOTAL
+
+for t in $TESTS; do
+	mark_dmesg
+
+	if ! lunatik run "tests/ebpf/$t" 2>/dev/null; then
+		ktap_fail "ebpf/$t: script execution failed"
+		continue
+	fi
+
+	errs=$(dmesg_since | grep -iE "^[^:]+: FAIL	|\.lua:[0-9]+:" || true)
+
+	if [ -z "$errs" ]; then
+		ktap_pass "ebpf/$t"
+	else
+		ktap_fail "ebpf/$t"
+		while IFS= read -r line; do
+			echo "# $line"
+		done <<< "$errs"
+	fi
+done
+
+ktap_totals
+exit $?
+


### PR DESCRIPTION
Draft of the ebpf maps support

1. Create the map using bpftool and pin it to bpffs
```sh
$ bpftool map create /sys/fs/bpf/flow_cache type hash key 3 value 3 entries 128 \
name flow_cache
```

2. Verify the map
```sh
$ bpftool map show pinned /sys/fs/bpf/flow_cache
```

3. Update the map and add a key
```sh
$ bpftool map update \
    pinned /sys/fs/bpf/flow_cache \
    key hex 66 6f 6f \
    value hex 62 61 72
```

4. Lookup for this key to verify update
```sh
$ bpftool map lookup \
    pinned /sys/fs/bpf/flow_cache \
    key hex 66 6f 6f
```

5. Now we can use the map via bpffs path
```lua
local map = require("ebpf.map")

local flow = map.open("/sys/fs/bpf/flow_cache")

local val = flow:lookup("foo")

if val then
    print(val)
end

-- flow:update(key, val)
-- flow:delete(key)
```