### PR TITLE
netlink: shared message (de)serialization module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ scripts_install:
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/lunatik
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/socket
+	${MKDIR} ${SCRIPTS_INSTALL_PATH}/netlink
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/syscall
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/crypto
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/linux
@@ -91,6 +92,7 @@ scripts_install:
 	${INSTALL} -m 0644 lib/lighten.lua ${SCRIPTS_INSTALL_PATH}/
 	${INSTALL} -m 0644 lib/lunatik/*.lua ${SCRIPTS_INSTALL_PATH}/lunatik
 	${INSTALL} -m 0644 lib/socket/*.lua ${SCRIPTS_INSTALL_PATH}/socket
+	${INSTALL} -m 0644 lib/netlink/*.lua ${SCRIPTS_INSTALL_PATH}/netlink
 	${INSTALL} -m 0644 lib/syscall/*.lua ${SCRIPTS_INSTALL_PATH}/syscall
 	${INSTALL} -m 0644 lib/crypto/*.lua ${SCRIPTS_INSTALL_PATH}/crypto
 	# NOTE: `lib/linux/` exists only as LDoc stubs (see doc-stubs); never install it.
@@ -107,6 +109,7 @@ scripts_uninstall:
 	${RM} ${SCRIPTS_INSTALL_PATH}/lighten.lua
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/lunatik
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/socket
+	${RM} -r ${SCRIPTS_INSTALL_PATH}/netlink
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/syscall
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/crypto
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/linux

--- a/lib/netlink/message.lua
+++ b/lib/netlink/message.lua
@@ -1,0 +1,144 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+---
+-- Netlink message (de)serialization helpers shared by `netlink.rt` and
+-- `netlink.genl`. Builds `nlmsghdr`/`nlattr` structures with `string.pack` and
+-- parses received buffers into Lua tables.
+-- @module netlink.message
+--
+
+local nl = require("linux.netlink")
+
+local message = {}
+
+-- struct nlmsghdr: len(u32) type(u16) flags(u16) seq(u32) pid(u32)
+local NLMSG_HDR    = "<I4I2I2I4I4"
+local NLMSG_HDRLEN = 16
+-- struct nlattr: len(u16) type(u16)
+local NLA_HDR    = "<I2I2"
+local NLA_HDRLEN = 4
+
+message.BUFSIZE = 65536
+
+local function align(len)
+	return (len + 3) & ~3
+end
+
+---
+-- Builds a netlink attribute (`nlattr` plus padded value).
+-- @tparam integer atype attribute type.
+-- @tparam string value attribute payload.
+-- @treturn string the serialized attribute.
+function message.attr(atype, value)
+	local len = NLA_HDRLEN + #value
+	return string.pack(NLA_HDR, len, atype) .. value .. string.rep("\0", align(len) - len)
+end
+
+---
+-- Builds a `u32` netlink attribute.
+-- @tparam integer atype attribute type.
+-- @tparam integer value attribute value.
+-- @treturn string the serialized attribute.
+function message.attr_u32(atype, value)
+	return message.attr(atype, string.pack("<I4", value))
+end
+
+---
+-- Builds a complete netlink message.
+-- @tparam integer mtype message type.
+-- @tparam integer flags NLM_F_* flags.
+-- @tparam integer seq sequence number.
+-- @tparam string payload family header and/or attributes.
+-- @treturn string the serialized message.
+function message.encode(mtype, flags, seq, payload)
+	return string.pack(NLMSG_HDR, NLMSG_HDRLEN + #payload, mtype, flags, seq, 0) .. payload
+end
+
+---
+-- Parses a buffer into a list of `{type, flags, body}` messages, where `body`
+-- holds the bytes after the `nlmsghdr` (family header and attributes).
+-- @tparam string buf received buffer.
+-- @treturn table list of messages.
+function message.parse(buf)
+	local messages = {}
+	local pos = 1
+	while pos + NLMSG_HDRLEN - 1 <= #buf do
+		local len, mtype, flags = string.unpack(NLMSG_HDR, buf, pos)
+		if len < NLMSG_HDRLEN then break end
+		table.insert(messages, {type = mtype, flags = flags,
+			body = buf:sub(pos + NLMSG_HDRLEN, pos + len - 1)})
+		pos = pos + align(len)
+	end
+	return messages
+end
+
+---
+-- Parses the attributes in `body` starting at `offset` into a
+-- `{[type] = value}` table.
+-- @tparam string body message body.
+-- @tparam integer offset first byte of the attribute area.
+-- @treturn table attributes keyed by type.
+function message.attrs(body, offset)
+	local attrs = {}
+	local pos = offset
+	while pos + NLA_HDRLEN - 1 <= #body do
+		local len, atype = string.unpack(NLA_HDR, body, pos)
+		if len < NLA_HDRLEN then break end
+		attrs[atype] = body:sub(pos + NLA_HDRLEN, pos + len - 1)
+		pos = pos + align(len)
+	end
+	return attrs
+end
+
+local sequence = 0
+
+---
+-- Returns a fresh, monotonically increasing sequence number.
+-- @treturn integer the sequence number.
+function message.seq()
+	sequence = sequence + 1
+	return sequence
+end
+
+---
+-- Receives a full multipart response, concatenating chunks until `NLMSG_DONE`
+-- or a non-multipart message is seen.
+-- @tparam netlink sock open netlink socket.
+-- @treturn string the concatenated response buffer.
+function message.recv_all(sock)
+	local parts = {}
+	local done
+	repeat
+		local chunk = sock:recv(message.BUFSIZE)
+		table.insert(parts, chunk)
+		for _, msg in ipairs(message.parse(chunk)) do
+			if msg.type == nl.type.DONE or (msg.flags & nl.flag.MULTI) == 0 then
+				done = true
+				break
+			end
+		end
+	until done
+	return table.concat(parts)
+end
+
+---
+-- Raises an error if any message in `buf` is an `NLMSG_ERROR` with a non-zero
+-- error code.
+-- @tparam string buf response buffer.
+-- @raise on a netlink error.
+function message.check_error(buf)
+	for _, msg in ipairs(message.parse(buf)) do
+		if msg.type == nl.type.ERROR then
+			local err = string.unpack("<i4", msg.body)
+			if err ~= 0 then
+				error("netlink error " .. -err)
+			end
+		end
+	end
+end
+
+return message
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -57,6 +57,8 @@ Tests for the `netlink` socket and its higher-level Lua modules.
 
 - **socket**: opens a `NETLINK_ROUTE` socket and asserts a hand-built
   `RTM_GETLINK` dump request gets a reply (raw `new`/`send`/`recv`/`close`).
+- **message**: builds a message with attributes and parses it back, asserting
+  the round-trip preserves the type and attribute values.
 
 ### notifier
 

--- a/tests/netlink/message.lua
+++ b/tests/netlink/message.lua
@@ -1,0 +1,20 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the netlink message test (see message.sh).
+-- Pure round-trip: build a message with attributes and parse it back.
+
+local message = require("netlink.message")
+
+local payload = message.attr_u32(4, 0x01020304) .. message.attr(3, "eth0\0")
+local buf = message.encode(16, 5, message.seq(), payload)
+
+local msgs = message.parse(buf)
+assert(#msgs == 1 and msgs[1].type == 16, "message header round-trip failed")
+
+local attrs = message.attrs(msgs[1].body, 1)
+assert(string.unpack("<I4", attrs[4]) == 0x01020304, "u32 attribute round-trip failed")
+assert(string.unpack("z", attrs[3]) == "eth0", "string attribute round-trip failed")
+print("netlink message: round-trip ok")
+

--- a/tests/netlink/message.sh
+++ b/tests/netlink/message.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Tests netlink.message: builds a message with attributes and parses it back,
+# asserting the round-trip preserves the message type and attribute values.
+#
+# Usage: sudo bash tests/netlink/message.sh
+
+SCRIPT="tests/netlink/message"
+MODULE="luanetlink"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+ktap_header
+ktap_plan 1
+
+cat /sys/module/$MODULE/refcnt > /dev/null 2>&1 || {
+	echo "# SKIP: $MODULE not loaded"
+	ktap_totals
+	exit 0
+}
+
+mark_dmesg
+run_script "$SCRIPT"
+check_dmesg || { ktap_totals; exit 1; }
+
+dmesg | grep -q "netlink message: round-trip ok" || fail "message round-trip failed"
+ktap_pass "message: nlmsghdr/nlattr build and parse round-trip"
+
+ktap_totals
+

--- a/tests/netlink/run.sh
+++ b/tests/netlink/run.sh
@@ -11,7 +11,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
 SEP=$'\n'
-for t in "$DIR"/socket.sh; do
+for t in "$DIR"/socket.sh "$DIR"/message.sh; do
 	echo "${SEP}# --- $(basename "$t") ---"
 	bash "$t" || FAILED=$((FAILED+1))
 done


### PR DESCRIPTION
Part of the #589 split. **Based on the socket-core PR.**

Adds `netlink.message`: the shared `nlmsghdr`/`nlattr` building and parsing (attribute builders, message encoder, parsing into Lua tables, sequence counter, multipart receive, error checking). Includes a pure build/parse round-trip test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)