### PR TITLE
netlink: kernel-to-userspace multicast (netlink.channel)

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -53,6 +53,13 @@ config LUNATIK_SOCKET
 	help
 	  Networking socket support for Lua scripts.
 
+config LUNATIK_NETLINK
+	tristate "Lunatik Netlink Support"
+	default m
+	help
+	  Generic netlink channel (netlink.channel) for softirq-safe
+	  kernel-to-userspace delivery (broadcast and unicast) from Lua scripts.
+
 config LUNATIK_RCU
 	tristate "Lunatik RCU Support"
 	default m

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ CONFIG_LUNATIK_RUN ?= m
 
 # Order matters: modules are loaded left-to-right and unloaded right-to-left (rmmod).
 # A module must appear AFTER all modules it depends on (e.g. SKB before NETFILTER).
-LUNATIK_MODULES := DEVICE LINUX NOTIFIER SOCKET RCU SET THREAD FIB DATA PROBE SYSCALL XDP FIFO SKB NETFILTER \
+LUNATIK_MODULES := DEVICE LINUX NOTIFIER SOCKET NETLINK RCU SET THREAD FIB DATA PROBE SYSCALL XDP FIFO SKB NETFILTER \
 	COMPLETION CRYPTO CPU HID SIGNAL BYTEORDER DARKEN
 
 $(foreach c,$(LUNATIK_MODULES),\
@@ -156,6 +156,7 @@ tests_install:
 		${INSTALL} -m 0755 tests/$$d/*.sh ${LUNATIK_TESTS_INSTALL_PATH}/$$d; \
 		${INSTALL} -m 0644 tests/$$d/*.lua ${SCRIPTS_INSTALL_PATH}/tests/$$d; \
 	done
+	${INSTALL} -m 0644 tests/netlink/channel_subscriber.c ${LUNATIK_TESTS_INSTALL_PATH}/netlink
 	${MKDIR} ${LUNATIK_TESTS_INSTALL_PATH}/socket/unix ${SCRIPTS_INSTALL_PATH}/tests/socket/unix
 	${INSTALL} -m 0755 tests/socket/run.sh ${LUNATIK_TESTS_INSTALL_PATH}/socket
 	${INSTALL} -m 0755 tests/socket/unix/*.sh ${LUNATIK_TESTS_INSTALL_PATH}/socket/unix

--- a/config.ld
+++ b/config.ld
@@ -41,6 +41,7 @@ file = {
 	'./lib/netlink/message.lua',
 	'./lib/netlink/session.lua',
 	'./lib/luanetfilter.c',
+	'./lib/luanetlink.c',
 	'./lib/luaskb.c',
 	'./lib/luanotifier.c',
 	'./lib/luaprobe.c',

--- a/lib/Kbuild
+++ b/lib/Kbuild
@@ -5,6 +5,7 @@ obj-$(CONFIG_LUNATIK_DEVICE) += luadevice.o
 obj-$(CONFIG_LUNATIK_LINUX) += lualinux.o
 obj-$(CONFIG_LUNATIK_NOTIFIER) += luanotifier.o
 obj-$(CONFIG_LUNATIK_SOCKET) += luasocket.o
+obj-$(CONFIG_LUNATIK_NETLINK) += luanetlink.o
 obj-$(CONFIG_LUNATIK_RCU) += luarcu.o
 obj-$(CONFIG_LUNATIK_SET) += luaset.o
 obj-$(CONFIG_LUNATIK_THREAD) += luathread.o

--- a/lib/luanetlink.c
+++ b/lib/luanetlink.c
@@ -1,0 +1,194 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+/***
+* Generic netlink channel.
+* Exposes `netlink.channel`, a generic netlink family with one multicast group
+* whose `broadcast`/`unicast` are safe from softirq (netfilter hooks, XDP), for
+* kernel-to-userspace delivery. The message body is built in Lua (e.g. with
+* `netlink.message`) and sent as-is; request/response netlink is otherwise done
+* in Lua over the `socket` module. Only this softirq-capable send path needs a
+* dedicated kernel object.
+*
+* @module netlink
+*/
+
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+#include <linux/skbuff.h>
+#include <net/netlink.h>
+#include <net/genetlink.h>
+
+#include <lunatik.h>
+
+/* the family's sole multicast group; genl requires a non-empty group name */
+#define LUANETLINK_MCGRP	"lunatik"
+
+typedef struct luanetlink_channel_s {
+	struct genl_family          family;
+	struct genl_multicast_group mcgrp;
+	bool                        registered;
+} luanetlink_channel_t;
+
+LUNATIK_PRIVATECHECKER(luanetlink_channel_check, luanetlink_channel_t *);
+
+static void luanetlink_channel_release(void *private)
+{
+	luanetlink_channel_t *channel = (luanetlink_channel_t *)private;
+
+	if (channel->registered)
+		genl_unregister_family(&channel->family);
+}
+
+/***
+* A generic netlink channel.
+* Returned by `netlink.channel()`. Backed by a generic netlink family with one
+* multicast group; `broadcast` and `unicast` are safe from softirq (netfilter
+* hooks, XDP) and deliver to userspace subscribers of the family.
+* @type netlink.channel
+*/
+
+/* Builds a genl message: a `cmd` header plus the caller's `payload`, trusted
+ * to be well-formed attributes framed in Lua. Raises on an allocation error. */
+static struct sk_buff *luanetlink_message(lua_State *L, struct genl_family *family,
+	int cmd, const char *payload, size_t len, gfp_t gfp)
+{
+	struct sk_buff *skb = genlmsg_new(len, gfp);
+	if (skb == NULL)
+		lunatik_enomem(L);
+
+	void *hdr = genlmsg_put(skb, 0, 0, family, 0, cmd);
+	if (hdr == NULL) {
+		nlmsg_free(skb);
+		lunatik_throw(L, -EMSGSIZE);
+	}
+	if (len != 0)
+		skb_put_data(skb, payload, len);
+	genlmsg_end(skb, hdr);
+	return skb;
+}
+
+/***
+* Broadcasts a message to every subscriber of the channel's group.
+* Safe to call from softirq.
+* @function broadcast
+* @tparam integer cmd Generic netlink command.
+* @tparam[opt] string payload Message body (e.g. from `netlink.message`).
+* @treturn boolean whether it reached at least one subscriber.
+* @raise on an allocation error.
+*/
+static int luanetlink_broadcast(lua_State *L)
+{
+	luanetlink_channel_t *channel = luanetlink_channel_check(L, 1);
+	int cmd = (int)luaL_checkinteger(L, 2);
+	size_t len;
+	const char *payload = luaL_optlstring(L, 3, "", &len);
+	gfp_t gfp = lunatik_gfp(lunatik_toruntime(L));
+	struct sk_buff *skb = luanetlink_message(L, &channel->family, cmd, payload, len, gfp);
+
+	lua_pushboolean(L, genlmsg_multicast(&channel->family, skb, 0, 0, gfp) >= 0);
+	return 1;
+}
+
+/***
+* Unicasts a message to a single userspace subscriber by port id.
+* Safe to call from softirq.
+* @function unicast
+* @tparam integer portid Destination netlink port id.
+* @tparam integer cmd Generic netlink command.
+* @tparam[opt] string payload Message body (e.g. from `netlink.message`).
+* @treturn boolean whether it was queued to the port id (`false` if the port
+*   id is gone or its receive buffer is full).
+* @raise if `portid` is 0, or on an allocation error.
+*/
+static int luanetlink_unicast(lua_State *L)
+{
+	luanetlink_channel_t *channel = luanetlink_channel_check(L, 1);
+	u32 portid = (u32)luaL_checkinteger(L, 2);
+	int cmd = (int)luaL_checkinteger(L, 3);
+	size_t len;
+	const char *payload = luaL_optlstring(L, 4, "", &len);
+	gfp_t gfp = lunatik_gfp(lunatik_toruntime(L));
+
+	luaL_argcheck(L, portid != 0, 2, "invalid port id");
+	struct sk_buff *skb = luanetlink_message(L, &channel->family, cmd, payload, len, gfp);
+
+	lua_pushboolean(L, genlmsg_unicast(&init_net, skb, portid) >= 0);
+	return 1;
+}
+
+static const luaL_Reg luanetlink_channel_mt[] = {
+	{"__gc",      lunatik_deleteobject},
+	{"broadcast", luanetlink_broadcast},
+	{"unicast",   luanetlink_unicast},
+	{NULL, NULL}
+};
+
+LUNATIK_OPENER(netlink);
+
+static const lunatik_class_t luanetlink_channel_class = {
+	.name    = "netlink.channel",
+	.methods = luanetlink_channel_mt,
+	.release = luanetlink_channel_release,
+	.opener  = luaopen_netlink,
+	.opt     = LUNATIK_OPT_SOFTIRQ | LUNATIK_OPT_SINGLE,
+};
+
+/***
+* Creates a generic netlink channel.
+* Registers a generic netlink family `name` with a single multicast group;
+* userspace resolves the family by name (e.g. via `netlink.genl`) to learn the
+* group it must join. Like a netfilter hook, it must be created at script load
+* (process context); the returned channel lives for the runtime and its
+* `broadcast`/`unicast` may then be called from softirq.
+* @function channel
+* @tparam string name Generic netlink family name (up to `GENL_NAMSIZ-1` bytes).
+* @treturn netlink.channel A new channel object.
+* @raise if the name is empty or too long, or family registration fails.
+*/
+static int luanetlink_channel_new(lua_State *L)
+{
+	size_t len;
+	const char *name = luaL_checklstring(L, 1, &len);
+	luaL_argcheck(L, len > 0 && len < GENL_NAMSIZ, 1, "invalid family name length");
+	lunatik_object_t *object = lunatik_newobject(L, &luanetlink_channel_class,
+		sizeof(luanetlink_channel_t), LUNATIK_OPT_NONE);
+	luanetlink_channel_t *channel = (luanetlink_channel_t *)object->private;
+
+	memcpy(channel->family.name, name, len + 1);
+	memcpy(channel->mcgrp.name, LUANETLINK_MCGRP, sizeof(LUANETLINK_MCGRP));
+	channel->family.version  = 1;
+	channel->family.module   = THIS_MODULE;
+	channel->family.mcgrps   = &channel->mcgrp;
+	channel->family.n_mcgrps = 1;
+
+	lunatik_try(L, genl_register_family, &channel->family);
+	channel->registered = true;
+
+	lunatik_register(L, -1, object); /* pin: release sleeps, must run at teardown */
+	return 1; /* object */
+}
+
+static const luaL_Reg luanetlink_lib[] = {
+	{"channel", luanetlink_channel_new},
+	{NULL, NULL}
+};
+
+LUNATIK_CLASSES(netlink, &luanetlink_channel_class);
+LUNATIK_NEWLIB(netlink, luanetlink_lib, luanetlink_classes);
+
+static int __init luanetlink_init(void)
+{
+	return 0;
+}
+
+static void __exit luanetlink_exit(void)
+{
+}
+
+module_init(luanetlink_init);
+module_exit(luanetlink_exit);
+MODULE_LICENSE("Dual MIT/GPL");
+MODULE_AUTHOR("Lourival Vieira Neto <lourival.neto@ringzero.com.br>");
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -72,6 +72,13 @@ higher-level `netlink.*` modules built on top of it.
   `call()` round-trip (regression for the orphaned-ACK desync), a `GETFAMILY`
   `dump()` that lists every family (with `nlctrl` among them), and an unknown
   family raising.
+- **channel**: a softirq runtime registers a generic netlink family, unicasts
+  to an absent port id (which returns `false`), and installs a `PRE_ROUTING`
+  netfilter hook that, on received traffic (NET_RX softirq), both broadcasts to
+  the group and unicasts to a fixed port id; a userspace subscriber bound to
+  that port id and joined to the group receives both, proving kernel-to-
+  userspace broadcast and unicast delivery from softirq (skips without
+  `gcc`/`genl`).
 
 ### notifier
 

--- a/tests/netlink/channel.lua
+++ b/tests/netlink/channel.lua
@@ -1,0 +1,38 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the netlink channel test (see channel.sh).
+
+local netlink   = require("netlink")
+local message   = require("netlink.message")
+local netfilter = require("netfilter")
+local nf        = require("linux.nf")
+
+local CMD, PAYLOAD = 1, 1        -- arbitrary genl command and attribute type
+local UNICAST_PORT = 0x4c554e41  -- fixed port id the subscriber binds to
+local ABSENT_PORT  = 0x7fffffff  -- unbound port id: a unicast to it must drop
+
+local channel = netlink.channel("lunatiktest")
+local bcast = message.attrs{[PAYLOAD] = "channel broadcast ok"}
+local ucast = message.attrs{[PAYLOAD] = "channel unicast ok"}
+
+-- a header-only unicast to an absent port id is a dropped frame: false, no raise
+assert(channel:unicast(ABSENT_PORT, CMD) == false)
+print("netlink channel: unicast to absent peer returns false")
+
+local function channel_hook(skb)
+	channel:broadcast(CMD, bcast)
+	channel:unicast(UNICAST_PORT, CMD, ucast)
+	return nf.action.ACCEPT
+end
+
+-- PRE_ROUTING on received (loopback) traffic runs in NET_RX softirq, so both
+-- the broadcast and the unicast are genuinely exercised from softirq context.
+netfilter.register{
+	hook     = channel_hook,
+	pf       = nf.proto.INET,
+	hooknum  = nf.inet.PRE_ROUTING,
+	priority = nf.ip.pri.FILTER,
+}
+

--- a/tests/netlink/channel.sh
+++ b/tests/netlink/channel.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Tests netlink.channel end to end FROM SOFTIRQ: a softirq runtime registers a
+# generic netlink family ("lunatiktest"), unicasts to an absent port id (which
+# must return false), and installs a PRE_ROUTING netfilter hook that, on
+# received traffic (NET_RX softirq), both broadcasts to the group and unicasts
+# to a fixed port id. A userspace subscriber (built with gcc) binds to that port
+# id and joins the group, and receives both messages, proving kernel-to-
+# userspace broadcast and unicast delivery from softirq.
+#
+# Usage: sudo bash tests/netlink/channel.sh
+
+SCRIPT="tests/netlink/channel"
+MODULE="luanetlink"
+FAMILY="lunatiktest"
+DIR="$(dirname "$(readlink -f "$0")")"
+
+source "$DIR/../lib.sh"
+
+SUB_BIN="$(mktemp)"
+SUB_OUT="$(mktemp)"
+SUB_ERR="$(mktemp)"
+cleanup() {
+	kill "$SUB_PID" 2>/dev/null
+	lunatik stop "$SCRIPT" 2>/dev/null
+	rm -f "$SUB_BIN" "$SUB_OUT" "$SUB_ERR"
+}
+trap cleanup EXIT
+
+ktap_header
+ktap_plan 3
+
+cat /sys/module/$MODULE/refcnt > /dev/null 2>&1 || {
+	echo "# SKIP: $MODULE not loaded"
+	ktap_totals
+	exit 0
+}
+skip() { ktap_skip "$1"; ktap_totals; exit 0; }
+command -v gcc  > /dev/null 2>&1 || skip "channel: gcc unavailable"
+command -v genl > /dev/null 2>&1 || skip "channel: genl tool unavailable"
+
+gcc -O2 -o "$SUB_BIN" "$DIR/channel_subscriber.c" 2>/dev/null || skip "channel: subscriber failed to build"
+
+mark_dmesg
+run_script "$SCRIPT" softirq
+check_dmesg || { ktap_totals; exit 1; }
+
+dmesg_since | grep -q "netlink channel: unicast to absent peer returns false" || fail "unicast did not return false"
+ktap_pass "channel: unicast to an absent port id returns false"
+
+# the family is now registered; resolve its multicast group id (the group line
+# is the only one with an "ID-0x" token; the family id prints as "ID: 0x")
+GRP=$(genl ctrl get name "$FAMILY" 2>/dev/null \
+	| grep -oiE 'ID-0x[0-9a-fA-F]+' | head -1 | sed 's/^[Ii][Dd]-//')
+[ -n "$GRP" ] || fail "could not resolve multicast group for family $FAMILY"
+
+"$SUB_BIN" "$GRP" > "$SUB_OUT" 2> "$SUB_ERR" &
+SUB_PID=$!
+ready=""
+for _ in $(seq 1 50); do grep -q READY "$SUB_ERR" 2>/dev/null && { ready=1; break; }; sleep 0.1; done
+[ -n "$ready" ] || fail "subscriber not ready: $(cat "$SUB_ERR")"
+
+# generate loopback traffic; the received packet fires PRE_ROUTING in NET_RX softirq
+for _ in $(seq 1 5); do echo x > /dev/udp/127.0.0.1/9999 2>/dev/null; sleep 0.1; done
+
+wait "$SUB_PID" 2>/dev/null
+check_dmesg || { ktap_totals; exit 1; }
+
+grep -q "channel broadcast ok" "$SUB_OUT" || fail "subscriber did not receive the softirq broadcast"
+ktap_pass "channel: userspace received a broadcast sent from a softirq hook"
+
+grep -q "channel unicast ok" "$SUB_OUT" || fail "subscriber did not receive the softirq unicast"
+ktap_pass "channel: userspace received a unicast sent from a softirq hook"
+
+ktap_totals
+

--- a/tests/netlink/channel_subscriber.c
+++ b/tests/netlink/channel_subscriber.c
@@ -1,0 +1,116 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+/*
+* Userspace subscriber for the netlink channel test (see channel.sh): binds to
+* a fixed port id (so the kernel can unicast to it) and joins the given generic
+* netlink multicast group, then reads until it has seen both the broadcast and
+* the unicast message (or a recv times out).
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <linux/netlink.h>
+#include <linux/genetlink.h>
+
+#ifndef SOL_NETLINK
+#define SOL_NETLINK 270
+#endif
+#ifndef NLA_TYPE_MASK
+#define NLA_TYPE_MASK (~(int)0xC000)
+#endif
+
+#define PAYLOAD      1
+#define UNICAST_PORT 0x4c554e41 /* must match channel.lua */
+
+/* message classification, accumulated into a bitmask until BOTH are seen */
+enum {
+	NONE      = 0,
+	BROADCAST = 1,
+	UNICAST   = 2,
+	BOTH      = BROADCAST | UNICAST,
+};
+
+/* binds a NETLINK_GENERIC socket to UNICAST_PORT, joins multicast group `grp`,
+ * and bounds every recv with a timeout; returns the fd, or -1 on failure */
+static int subscribe(int grp)
+{
+	struct sockaddr_nl addr = { .nl_family = AF_NETLINK, .nl_pid = UNICAST_PORT };
+	struct timeval tv = { .tv_sec = 5 };
+	int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_GENERIC);
+
+	if (fd < 0 ||
+	    bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0 ||
+	    setsockopt(fd, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP, &grp, sizeof(grp)) < 0 ||
+	    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+		perror("subscribe");
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+/* prints the channel's PAYLOAD attribute (the single attribute right after the
+ * genl header) and returns which message it was; bounds the read by `n` */
+static int report(char *buf, ssize_t n)
+{
+	struct nlmsghdr *nlh = (struct nlmsghdr *)buf;
+	struct nlattr *na = (struct nlattr *)((char *)NLMSG_DATA(nlh) + GENL_HDRLEN);
+	int len = (int)n - (int)NLMSG_LENGTH(GENL_HDRLEN);
+
+	if (len < (int)NLA_HDRLEN || na->nla_len < NLA_HDRLEN ||
+	    (na->nla_type & NLA_TYPE_MASK) != PAYLOAD)
+		return NONE;
+
+	int plen = (int)(na->nla_len - NLA_HDRLEN);
+	char msg[256];
+
+	plen = MIN(plen, len - (int)NLA_HDRLEN);
+	plen = MIN(plen, (int)sizeof(msg) - 1);
+	memcpy(msg, (char *)na + NLA_HDRLEN, plen);
+	msg[plen] = '\0';
+	printf("%s\n", msg);
+	fflush(stdout);
+
+	if (strstr(msg, "broadcast"))
+		return BROADCAST;
+	if (strstr(msg, "unicast"))
+		return UNICAST;
+	return NONE;
+}
+
+int main(int argc, char **argv)
+{
+	if (argc < 2) {
+		fprintf(stderr, "usage: %s <group-id>\n", argv[0]);
+		return 1;
+	}
+
+	int fd = subscribe((int)strtol(argv[1], NULL, 0));
+	if (fd < 0)
+		return 1;
+
+	/* the group is joined; the harness waits for this before sending traffic */
+	fprintf(stderr, "READY\n");
+	fflush(stderr);
+
+	char buf[4096];
+	int seen = NONE;
+	while (seen != BOTH) {
+		ssize_t n = recv(fd, buf, sizeof(buf), 0);
+		if (n <= 0)
+			break;
+		seen |= report(buf, n);
+	}
+
+	return seen == BOTH ? 0 : 1;
+}
+

--- a/tests/netlink/run.sh
+++ b/tests/netlink/run.sh
@@ -11,7 +11,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
 SEP=$'\n'
-for t in "$DIR"/socket.sh "$DIR"/message.sh "$DIR"/session.sh "$DIR"/genl_family.sh; do
+for t in "$DIR"/socket.sh "$DIR"/message.sh "$DIR"/session.sh "$DIR"/genl_family.sh "$DIR"/channel.sh; do
 	echo "${SEP}# --- $(basename "$t") ---"
 	bash "$t" || FAILED=$((FAILED+1))
 done


### PR DESCRIPTION
Stacked on the message PR (for the shared test harness; the channel code itself is independent). `netlink.channel`: a generic netlink multicast family whose broadcast is softirq-safe (netfilter/XDP). This is the only netlink kernel module. Test broadcasts from a LOCAL_OUT netfilter hook (softirq) and receives it in userspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)