### PR TITLE
socket: add @type block grouping the socket methods

### DIFF
--- a/lib/luasocket.c
+++ b/lib/luasocket.c
@@ -109,6 +109,11 @@ LUNATIK_PRIVATECHECKER(luasocket_check, struct socket *);
 #define luasocket_setmsg(m)		memset(&(m), 0, sizeof(m))
 
 /***
+* A kernel socket, returned by `socket.new()`.
+* @type socket
+*/
+
+/***
 * Sends a message through the socket.
 *
 * For connection-oriented sockets (`SOCK_STREAM`), `addr` and `port` are usually omitted


### PR DESCRIPTION
Documentation only. luasocket registers the socket object but lacked the LDoc `@type` block that groups its methods in the generated docs (as every other object-registering module has). Base of the netlink stack: #595 sits on top of it so its diff stays scoped to the AF_NETLINK change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)