### PR TITLE
class: add a minimal OOP class helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ scripts_install:
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/linux
 	${MKDIR} ${LUA_PATH}/lunatik
 	${INSTALL} -m 0644 driver.lua ${SCRIPTS_INSTALL_PATH}/
+	${INSTALL} -m 0644 lib/class.lua ${SCRIPTS_INSTALL_PATH}/
 	${INSTALL} -m 0644 lib/mailbox.lua ${SCRIPTS_INSTALL_PATH}/
 	${INSTALL} -m 0644 lib/net.lua ${SCRIPTS_INSTALL_PATH}/
 	${INSTALL} -m 0644 lib/util.lua ${SCRIPTS_INSTALL_PATH}/
@@ -101,6 +102,7 @@ scripts_install:
 
 scripts_uninstall:
 	${RM} ${SCRIPTS_INSTALL_PATH}/driver.lua
+	${RM} ${SCRIPTS_INSTALL_PATH}/class.lua
 	${RM} ${SCRIPTS_INSTALL_PATH}/mailbox.lua
 	${RM} ${SCRIPTS_INSTALL_PATH}/net.lua
 	${RM} ${SCRIPTS_INSTALL_PATH}/util.lua

--- a/config.ld
+++ b/config.ld
@@ -16,6 +16,7 @@ file = {
 	'./lib/luabyteorder.c',
 	'./lib/luacompletion.c',
 	'./lib/luacpu.c',
+	'./lib/class.lua',
 	'./lib/crypto/hkdf.lua',
 	'./lib/luacrypto_aead.c',
 	'./lib/luacrypto_comp.c',

--- a/lib/class.lua
+++ b/lib/class.lua
@@ -1,0 +1,37 @@
+--
+-- SPDX-FileCopyrightText: (c) 2023-2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+---
+-- Minimal class helper for the OOP-style modules (e.g. `socket.inet`,
+-- `socket.unix`). Calling the module on a table makes it an instantiable class:
+-- it gains a `:new` constructor that wires `__index`/`__close` and sets the
+-- class as the metatable of new objects, serving both to build instances and to
+-- derive specializations (subclasses that inherit the methods).
+-- @module class
+-- @usage
+-- local class = require("class")
+--
+-- local Point = class{}
+-- function Point:sum() return self.x + self.y end
+--
+-- local point <close> = Point:new{x = 1, y = 2}   -- point:sum() == 3
+
+local function new(self, o)
+	o = o or {}
+	self.__index = self
+	self.__close = self.close
+	return setmetatable(o, self)
+end
+
+---
+-- Makes `class` an instantiable class by attaching the shared `:new`.
+-- @tparam[opt] table class the class table (defaults to a fresh table).
+-- @treturn table the same table, ready to receive methods and be instantiated.
+return function(class)
+	class = class or {}
+	class.new = new
+	return class
+end
+

--- a/lib/socket/inet.lua
+++ b/lib/socket/inet.lua
@@ -16,27 +16,24 @@
 --
 
 local socket = require("socket")
-local net = require("net")
+local net    = require("net")
+local class  = require("class")
 
 ---
 -- Base class for socket types.
 -- @type inet
 -- @field localhost (string) The loopback address '127.0.0.1'.
-local inet = {localhost = '127.0.0.1'}
 
 ---
--- Constructor for inet socket objects.
--- Initializes a new socket object, setting up its metatable for OOP-like behavior.
--- @param o (table) [optional] An initial table to be used as the object.
--- @return (table) The new inet socket object.
-function inet:new(o)
-	local o = o or {}
-	self.__index = self
-	self.__close = self.close
-	return setmetatable(o, self)
-end
+-- Creates a new inet socket object.
+-- @function inet:new
+-- @tparam[opt] table o an initial object table.
+-- @treturn inet the new socket object.
+-- @see class
+local inet = class{localhost = '127.0.0.1'}
 
 local af = require("linux.socket").af
+
 ---
 -- Metamethod to create a new socket instance when `inet()` or `inet.tcp()` or `inet.udp()` is called.
 -- This is the primary way to create new socket instances (e.g., `local sock = inet.tcp()`).

--- a/lib/socket/unix.lua
+++ b/lib/socket/unix.lua
@@ -17,6 +17,7 @@
 -- @see socket.inet
 --
 local socket = require("socket")
+local class  = require("class")
 
 local af   = require("linux.socket").af
 local sock = require("linux.socket").sock
@@ -24,19 +25,14 @@ local sock = require("linux.socket").sock
 ---
 -- Base class for UNIX domain socket objects.
 -- @type unix
-local unix = {}
 
 ---
--- Constructor for unix socket objects.
--- Initializes a new socket object and sets up its metatable.
--- @param o (table) [optional] An initial table to use as the object.
--- @return (table) The new unix socket object.
-function unix:new(o)
-	local o = o or {}
-	self.__index = self
-	self.__close = self.close
-	return setmetatable(o, self)
-end
+-- Creates a new unix socket object.
+-- @function unix:new
+-- @tparam[opt] table o an initial object table.
+-- @treturn unix the new socket object.
+-- @see class
+local unix = class{}
 
 ---
 -- Creates a new UNIX domain socket instance.


### PR DESCRIPTION
Factors the `:new` constructor duplicated verbatim across the OOP-style modules (`socket.inet`, `socket.unix`, and the upcoming `netlink.rt`/`netlink.genl`) into a shared `class` helper. `class(t)` attaches the `:new` that wires `__index`/`__close` and sets the metatable, serving both to build instances and to derive specializations. Adopted in `socket.inet` and `socket.unix`; the netlink stack depends on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)