### PR TITLE
socket: add setsockopt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,8 @@ tests_install:
 	done
 	${INSTALL} -m 0644 tests/netlink/channel_subscriber.c ${LUNATIK_TESTS_INSTALL_PATH}/netlink
 	${MKDIR} ${LUNATIK_TESTS_INSTALL_PATH}/socket/unix ${SCRIPTS_INSTALL_PATH}/tests/socket/unix
-	${INSTALL} -m 0755 tests/socket/run.sh ${LUNATIK_TESTS_INSTALL_PATH}/socket
+	${INSTALL} -m 0755 tests/socket/*.sh ${LUNATIK_TESTS_INSTALL_PATH}/socket
+	${INSTALL} -m 0644 tests/socket/*.lua ${SCRIPTS_INSTALL_PATH}/tests/socket
 	${INSTALL} -m 0755 tests/socket/unix/*.sh ${LUNATIK_TESTS_INSTALL_PATH}/socket/unix
 	${INSTALL} -m 0644 tests/socket/unix/*.lua ${SCRIPTS_INSTALL_PATH}/tests/socket/unix
 

--- a/autogen.lua
+++ b/autogen.lua
@@ -207,7 +207,7 @@ local extract = {}
 -- struct's total size, so extract.parse can reconstruct its layout. Returns
 -- the C source for one struct spec.
 local function struct_probes(spec)
-	local out = { ('\tCOMMENT("struct %s %s");\n'):format(spec.module, spec.struct) }
+	local out = { ('\tCOMMENT("struct %s %s %s");\n'):format(spec.module, spec.struct, spec.as or spec.struct) }
 	for _, f in ipairs(spec.fields) do
 		table.insert(out, ('\tDEFINE(%s_%s_off, offsetof(struct %s, %s));\n'):format(spec.struct, f, spec.struct, f))
 		table.insert(out, ('\tDEFINE(%s_%s_sz, sizeof(((struct %s *)0)->%s));\n'):format(spec.struct, f, spec.struct, f))
@@ -306,8 +306,8 @@ end
 local function flush_struct(modules, order, struct)
 	if not struct then return end
 	table.insert(get_module(modules, order, struct.module).entries, {
-		key = struct.name,
-		value = struct_facts(struct.name, struct.fields, struct.total),
+		key = struct.key,
+		value = struct_facts(struct.key, struct.fields, struct.total),
 	})
 end
 
@@ -326,7 +326,7 @@ function extract.parse()
 		local ascii = line:match('%.ascii%s*"(.-)"')
 		if ascii then
 			local mname, mprefix = ascii:match('^%-%>#module%s+(%S+)%s+(%S+)$')
-			local smod, sname = ascii:match('^%-%>#struct%s+(%S+)%s+(%S+)$')
+			local smod, sname, skey = ascii:match('^%-%>#struct%s+(%S+)%s+(%S+)%s+(%S+)$')
 			if mname then
 				flush_struct(modules, order, struct)
 				struct = nil
@@ -335,7 +335,7 @@ function extract.parse()
 			elseif smod then
 				flush_struct(modules, order, struct)
 				current = nil
-				struct = { module = smod, name = sname, fields = {}, total = 0 }
+				struct = { module = smod, name = sname, key = skey, fields = {}, total = 0 }
 			else
 				local sym, val = ascii:match('^%-%>(%S+)%s+%$?(%-?%d+)%s+.+$')
 				if sym and val and struct then

--- a/autogen/specs.lua
+++ b/autogen/specs.lua
@@ -14,6 +14,7 @@
 -- @field desc   short LDoc description used by autogen/ldoc.lua
 -- @field prefix constant prefix (constant specs)
 -- @field struct kernel struct name (struct specs)
+-- @field as     Lua key for the layout (struct specs); defaults to `struct`
 -- @field fields the struct's scalar fields (struct specs); order is free
 --   (sorted by offset), but list them all, as gaps become padding and
 --   non-scalar fields fail the build
@@ -45,6 +46,14 @@ return {
 		desc = "Message flags for send/recv." },
 	{ header = "uapi/linux/in.h",               prefix = "IPPROTO_",   module = "socket.ipproto",
 		desc = "IP-layer protocol numbers." },
+	{ header = "linux/socket.h",                prefix = "SOL_",       module = "socket.sol",
+		desc = "Socket option levels (SOL_*)." },
+	{ header = "uapi/asm-generic/socket.h",     prefix = "SO_",        module = "socket.so",
+		desc = "Socket-level option names (SO_*)." },
+	{ header = "uapi/linux/time_types.h",       module = "socket.layout",    struct = "__kernel_sock_timeval",
+		desc = "Socket option payload layouts.",
+		as = "timeval",
+		fields = { "tv_sec", "tv_usec" } },
 	{ header = "uapi/linux/netfilter.h",        prefix = "NFPROTO_",   module = "nf.proto",
 		desc = "Netfilter protocol families." },
 	{ header = "uapi/linux/netfilter.h",        prefix = "NF_INET_",   module = "nf.inet",

--- a/lib/luasocket.c
+++ b/lib/luasocket.c
@@ -34,6 +34,10 @@
 
 #include <lunatik.h>
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0)
+typedef int (*luasocket_setter_t)(struct socket *, int, int, sockptr_t, unsigned int);
+#endif
+
 #define luasocket_msgaddr(msg, addr, size)	\
 do {						\
 	msg.msg_namelen = size;			\
@@ -379,6 +383,49 @@ LUASOCKET_NEWGETTER(sockname);
 LUASOCKET_NEWGETTER(peername);
 
 /***
+* Sets a socket option.
+* `SOL_SOCKET` options are handled by the network core; any other level is
+* passed to the socket's protocol handler, mirroring the `setsockopt(2)`
+* routing.
+*
+* @function setsockopt
+* @tparam integer level option level (e.g., `linux.socket.sol.SOCKET`).
+* @tparam integer optname option name (e.g., `linux.socket.so.RCVTIMEO_NEW`).
+* @tparam integer|string value option value: an integer for the common `int`
+*   payload, or a string carrying the option's packed binary payload.
+* @raise Error if the operation fails.
+* @usage
+*   -- bound blocking receives to 500 ms (a `struct __kernel_sock_timeval`)
+*   sock:setsockopt(sol.SOCKET, so.RCVTIMEO_NEW, timeval:pack(0, 500000))
+*/
+static int luasocket_setsockopt(lua_State *L)
+{
+	struct socket *socket = luasocket_check(L, 1);
+	int level = (int)luaL_checkinteger(L, 2);
+	int optname = (int)luaL_checkinteger(L, 3);
+	int value;
+	size_t len;
+	const char *optval;
+
+	if (lua_type(L, 4) == LUA_TSTRING)
+		optval = lua_tolstring(L, 4, &len);
+	else {
+		value = (int)luaL_checkinteger(L, 4);
+		optval = (const char *)&value;
+		len = sizeof(value);
+	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
+	lunatik_try(L, do_sock_setsockopt, socket, false, level, optname,
+		KERNEL_SOCKPTR((void *)optval), (int)len);
+#else
+	luasocket_setter_t setter = level == SOL_SOCKET ? sock_setsockopt : socket->ops->setsockopt;
+	luaL_argcheck(L, setter != NULL, 2, "unsupported option level");
+	lunatik_try(L, setter, socket, level, optname, KERNEL_SOCKPTR((void *)optval), (unsigned int)len);
+#endif
+	return 0;
+}
+
+/***
 * Closes the socket.
 * This shuts down the socket for both reading and writing and releases
 * associated kernel resources.
@@ -410,6 +457,7 @@ static const luaL_Reg luasocket_mt[] = {
 	{"listen", luasocket_listen},
 	{"accept", luasocket_accept},
 	{"connect", luasocket_connect},
+	{"setsockopt", luasocket_setsockopt},
 	{"getsockname", luasocket_getsockname},
 	{"getpeername", luasocket_getpeername},
 	{NULL, NULL}

--- a/tests/README.md
+++ b/tests/README.md
@@ -175,6 +175,11 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
 
 ### socket
 
+- **setsockopt**: `socket:setsockopt()` sets an integer option (`SO_RCVBUF`)
+  and a packed struct option (`SO_RCVTIMEO_NEW` built with the `timeval`
+  layout codec); with the receive timeout set, a receive with no data returns
+  (raises) instead of blocking forever.
+
 - **unix/stream**: `socket.unix` STREAM server (bind/listen/accept) and
   client (connect/send/receive), both using the path stored at
   construction.

--- a/tests/socket/run.sh
+++ b/tests/socket/run.sh
@@ -11,8 +11,9 @@ DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
 SEP=""
-for t in "$DIR"/unix/run.sh; do
-	echo "${SEP}# --- unix ---"
+for t in "$DIR"/setsockopt.sh "$DIR"/unix/run.sh; do
+	name="${t#"$DIR"/}"; name="${name%/run.sh}"; name="${name%.sh}"
+	echo "${SEP}# --- $name ---"
 	SEP=$'\n'
 	bash "$t" || FAILED=$((FAILED+1))
 done

--- a/tests/socket/setsockopt.lua
+++ b/tests/socket/setsockopt.lua
@@ -1,0 +1,28 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the socket setsockopt test (see setsockopt.sh).
+
+local socket = require("socket")
+local struct = require("struct")
+local sk     = require("linux.socket")
+
+local timeval    = struct(sk.layout.timeval)
+local TIMEOUT_MS = 100
+local RCVBUF     = 32768
+
+local sock = socket.new(sk.af.NETLINK, sk.sock.RAW, 0)
+
+-- integer value: the common int payload
+sock:setsockopt(sk.sol.SOCKET, sk.so.RCVBUF, RCVBUF)
+print("socket setsockopt: integer option set")
+
+-- string value: a packed struct payload; no data ever arrives, so a bounded
+-- receive must return (raise), not hang
+sock:setsockopt(sk.sol.SOCKET, sk.so.RCVTIMEO_NEW, timeval:pack(0, TIMEOUT_MS * 1000))
+local ok = pcall(sock.receive, sock, 16)
+sock:close()
+assert(not ok, "receive should have timed out")
+print("socket setsockopt: bounded receive returned")
+

--- a/tests/socket/setsockopt.sh
+++ b/tests/socket/setsockopt.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Tests socket:setsockopt(): sets an integer option (SO_RCVBUF) and a packed
+# struct option (SO_RCVTIMEO_NEW as a struct __kernel_sock_timeval built with
+# the timeval layout codec); with the receive timeout set, a receive with no
+# data must return (raise) instead of blocking forever.
+#
+# Usage: sudo bash tests/socket/setsockopt.sh
+
+SCRIPT="tests/socket/setsockopt"
+MODULE="luasocket"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+ktap_header
+ktap_plan 2
+
+cat /sys/module/$MODULE/refcnt > /dev/null 2>&1 || {
+	echo "# SKIP: $MODULE not loaded"
+	ktap_totals
+	exit 0
+}
+
+mark_dmesg
+run_script "$SCRIPT"
+check_dmesg || { ktap_totals; exit 1; }
+
+dmesg_since | grep -q "socket setsockopt: integer option set" || fail "integer option failed"
+ktap_pass "setsockopt: integer value sets an int option (SO_RCVBUF)"
+
+dmesg_since | grep -q "socket setsockopt: bounded receive returned" || fail "receive did not time out"
+ktap_pass "setsockopt: packed struct value bounds a blocking receive (SO_RCVTIMEO)"
+
+ktap_totals
+


### PR DESCRIPTION
Resolves #603.

`sock:setsockopt(level, optname, value)` sets a socket option: an integer value is passed as the common `int` payload, and a string carries the option's packed binary payload — e.g. a `struct __kernel_sock_timeval` for `SO_RCVTIMEO_NEW`, bounding a blocking receive so it can be made interruptible (a `spawn`ed kthread polling `thread.shouldstop()`) and defending against a no-reply peer:

```lua
local timeval = struct(sk.layout.timeval)
sock:setsockopt(sk.sol.SOCKET, sk.so.RCVTIMEO_NEW, timeval:pack(0, 500 * 1000))
```

### Design notes
- **Routing mirrors `setsockopt(2)`**: `SOL_SOCKET` goes through the network core (`sock_setsockopt`) and any other level through the protocol handler (`sock->ops->setsockopt`). The distinction matters: netlink's handler rejects non-`SOL_NETLINK` levels with `-ENOPROTOOPT`, so a protocol-handler-only implementation cannot set `SO_RCVTIMEO` on a netlink socket.
- **Constants and layout from autogen**: `linux.socket.sol` (`SOL_*`), `linux.socket.so` (`SO_*`) and the `timeval` payload layout (`struct __kernel_sock_timeval`, the y2038-safe variant) are extracted from the kernel headers; a small autogen `as` field names the layout's Lua key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)