### PR TITLE
netlink: test session dump draining a MULTI reply to EOF

### DIFF
--- a/tests/netlink/session.lua
+++ b/tests/netlink/session.lua
@@ -18,7 +18,7 @@ local function sock_send() end
 
 local function sock_receive(self)
 	self.i = self.i + 1
-	return self.chunks[self.i]
+	return self.chunks[self.i] or ""
 end
 
 local function fakesession(chunks)
@@ -32,6 +32,11 @@ end
 -- dump must terminate (not hang) on an empty read
 assert(#fakesession{""}:dump(MTYPE, "") == 0, "dump on empty read should return no messages")
 print("netlink session: dump empty-read ok")
+
+-- dump must drain a MULTI reply that never sends DONE down to the empty read
+local drained = fakesession{message.encode(MTYPE, nl.flag.MULTI, 1, "data")}:dump(MTYPE, "")
+assert(#drained == 1 and drained[1].type == MTYPE, "dump should drain a MULTI reply to the empty read")
+print("netlink session: dump drains a MULTI reply ok")
 
 -- talk drains the reply up to the ack and passes a zero error code; a data
 -- message in the same datagram is kept, in order

--- a/tests/netlink/session.sh
+++ b/tests/netlink/session.sh
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: MIT OR GPL-2.0-only
 #
 # Tests netlink.session over a fake socket: dump() terminates (does not hang)
-# on an empty read; talk() drains the reply up to the kernel acknowledgment,
+# on an empty read; dump() drains a MULTI reply that never sends DONE down to
+# the empty read; talk() drains the reply up to the kernel acknowledgment,
 # keeping a data reply and passing a zero error code; and talk() raises the
 # bare symbolic error name on a kernel error reply.
 #
@@ -16,7 +17,7 @@ MODULE="luasocket"
 source "$(dirname "$(readlink -f "$0")")/../lib.sh"
 
 ktap_header
-ktap_plan 3
+ktap_plan 4
 
 cat /sys/module/$MODULE/refcnt > /dev/null 2>&1 || {
 	echo "# SKIP: $MODULE not loaded"
@@ -30,6 +31,9 @@ check_dmesg || { ktap_totals; exit 1; }
 
 dmesg | grep -q "netlink session: dump empty-read ok" || fail "dump did not terminate on empty read"
 ktap_pass "session: dump terminates on empty read"
+
+dmesg | grep -q "netlink session: dump drains a MULTI reply ok" || fail "dump did not drain a MULTI reply"
+ktap_pass "session: dump drains a MULTI reply to the empty read"
 
 dmesg | grep -q "netlink session: talk drains the ack" || fail "talk did not drain the ack"
 ktap_pass "session: talk drains the trailing ack"


### PR DESCRIPTION
The `netlink.session` test's fake socket returned `nil` once its chunk list was exhausted, which does not model `socket:receive`: the real method never returns `nil` (it raises on error and pushes a string, empty on a zero-byte read). No existing test path reached exhaustion, so it never fired, but a `dump` of a `MULTI` reply that never sends `DONE` does reach it, and against the old fake it would hit `attempt to get length of a nil value` in `replies()` rather than draining cleanly.

The fake now returns `""` past its last chunk, faithful to the real contract, and a new test exercises exactly that path: a `MULTI` reply with no `DONE` must drain down to the empty read and keep its message. Verified the new test fails (nil length) against the old fake and passes against the fixed one; the full netlink session suite is 4/4.

This is a test-fidelity fix, not a library bug: `netlink.session` itself is correct, since the real `socket:receive` never yields `nil`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)