### PR TITLE
netlink: fix LDoc rendering (channel constructor, rt @type)

### DIFF
--- a/lib/luanetlink.c
+++ b/lib/luanetlink.c
@@ -146,6 +146,7 @@ static const lunatik_class_t luanetlink_channel_class = {
 * @tparam string name Generic netlink family name (up to `GENL_NAMSIZ-1` bytes).
 * @treturn netlink.channel A new channel object.
 * @raise if the name is empty or too long, or family registration fails.
+* @within netlink
 */
 static int luanetlink_channel_new(lua_State *L)
 {

--- a/lib/netlink/rt.lua
+++ b/lib/netlink/rt.lua
@@ -54,6 +54,9 @@ local function str(value)
 end
 
 ---
+-- @type rt
+
+---
 -- Creates a new rt object.
 -- @function rt:new
 -- @tparam[opt] table o an initial object table.


### PR DESCRIPTION
Two LDoc rendering fixes in the netlink modules, found by regenerating the docs and comparing against the working class modules (rcu, session, genl, socket.inet):

1. **channel constructor** — `netlink.channel(name)` rendered as `netlink.channel:channel` (a method of the type), because its docblock follows the `@type netlink.channel` block. `@within netlink` places it back under the module, as `rcu.table` does with `@within rcu`.

2. **rt methods** — `rt.lua` had no `@type` block, so its methods rendered as loose module functions (`route_add`, `new`, ...) instead of `rt:route_add` etc. Added `@type rt`, mirroring `netlink.session`/`netlink.genl`.

Regenerated docs locally to verify both: the channel constructor is now the module function `netlink.channel (name)`, and rt's methods group under `Class rt` (`rt:route_add`, ...). `Build docs` CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)