### PR TITLE
examples: add netfailover (reactive policy routing)

### DIFF
--- a/examples/netfailover/README.md
+++ b/examples/netfailover/README.md
@@ -1,0 +1,48 @@
+# netfailover — reactive policy routing from the kernel
+
+Reprograms routing in reaction to a link going down, entirely in-kernel, in Lua,
+hot-loaded. No userspace routing daemon, no recompile.
+
+When the watched interface (`dummy0` by default) goes **down**, a backup route is
+installed in table `200`; when it comes back **up**, the route is removed. The
+decision and the rtnetlink write both happen inside the kernel.
+
+## Why two runtimes
+
+A netdevice notifier callback runs holding `rtnl_lock`. Issuing rtnetlink from it
+would re-enter `rtnl_lock` and **self-deadlock**, so the work is split:
+
+- `control.lua` (process runtime) registers the `notifier.netdevice` callback,
+  which only records the link state into a shared `rcu.table`. Fast, lock-safe.
+- `reactor.lua` (spawned kthread, sleepable) polls that state and reprograms
+  routing with `netlink.rt.route` — `rtnl_lock` is not held here — and broadcasts each
+  action on a `netlink.channel` for a userspace dashboard.
+
+The two live in separate runtimes on purpose: sharing one would let the reactor
+hold the runtime lock while waiting on `rtnl_lock` as the notifier holds
+`rtnl_lock` waiting on the runtime lock — a classic ABBA deadlock.
+
+## Run
+
+```sh
+sudo ip link add dummy0 type dummy && sudo ip link set dummy0 up
+
+sudo lunatik run   examples/netfailover/control
+sudo lunatik spawn examples/netfailover/reactor
+
+# watch the reactions
+sudo dmesg -w | grep netfailover &
+
+sudo ip link set dummy0 down   # -> backup route installed in table 200
+ip route show table 200
+sudo ip link set dummy0 up     # -> backup route removed
+```
+
+## Stop
+
+```sh
+sudo lunatik stop examples/netfailover/reactor
+sudo lunatik stop examples/netfailover/control
+sudo ip link del dummy0
+```
+

--- a/examples/netfailover/control.lua
+++ b/examples/netfailover/control.lua
@@ -1,0 +1,34 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+local lunatik  = require("lunatik")
+local notifier = require("notifier")
+local rcu      = require("rcu")
+local netdev   = require("linux.netdev")
+local notify   = require("linux.notify")
+
+local events = rcu.table()   -- ifname -> "down" (nil = up)
+
+lunatik._ENV["netfailover"] = events
+
+-- the netdevice callback runs holding rtnl_lock, so it must not issue rtnetlink
+-- itself (that self-deadlocks); it only records the link state, which the
+-- separately spawned reactor reprograms routing from without the lock held
+local sentinel = setmetatable({}, {__gc = function()
+	lunatik._ENV["netfailover"] = nil
+end})
+
+local function callback(event, name)
+	local _ = sentinel   -- keep the sentinel reachable from the notifier
+	if event == netdev.DOWN then
+		events[name] = true
+	elseif event == netdev.UP then
+		events[name] = nil
+	end
+	return notify.OK
+end
+
+notifier.netdevice(callback)
+

--- a/examples/netfailover/reactor.lua
+++ b/examples/netfailover/reactor.lua
@@ -1,0 +1,45 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+local lunatik = require("lunatik")
+local netlink = require("netlink")
+local thread  = require("thread")
+local linux   = require("linux")
+local af      = require("linux.socket").af
+local scope   = require("linux.rtnetlink").scope
+
+local WATCHED <const> = "dummy0"                  -- primary uplink to watch
+local BACKUP  <const> = 200                       -- backup routing table id
+local DST     <const> = string.char(192, 0, 2, 1) -- 192.0.2.1
+local DST_LEN <const> = 32
+local LO      <const> = 1                         -- loopback ifindex
+local CMD     <const> = 1                         -- channel genl command
+local POLL_MS <const> = 200
+
+local function attacher()
+	local route <close> = netlink.rt.route()
+	local channel       = netlink.channel("netfailover")
+	local active        = false
+	while not thread.shouldstop() do
+		local events = lunatik._ENV["netfailover"]
+		local down = events and events[WATCHED]
+		if down and not active then
+			route:add{family = af.INET, dst = DST, dst_len = DST_LEN,
+				oif = LO, table = BACKUP, scope = scope.LINK}
+			channel:multicast(CMD, WATCHED .. " down: failover route installed")
+			print("netfailover: " .. WATCHED .. " down -> backup route installed")
+			active = true
+		elseif not down and active then
+			route:del{family = af.INET, dst = DST, dst_len = DST_LEN,
+				oif = LO, table = BACKUP}
+			channel:multicast(CMD, WATCHED .. " up: failover route removed")
+			print("netfailover: " .. WATCHED .. " up -> backup route removed")
+			active = false
+		end
+		linux.schedule(POLL_MS)
+	end
+end
+return attacher
+


### PR DESCRIPTION
A demoable use case for the netlink support: reactive policy routing driven by a link event, entirely in-kernel, in Lua, hot-loaded — no userspace routing daemon, no recompile.

When the watched interface goes **down**, `reactor.lua` installs a backup route via `netlink.rt` (visible in `ip route show table 200`) and broadcasts the action on a `netlink.channel`; it removes the route when the link is back **up**.

## The design point (worth a slide)

A `notifier.netdevice` callback runs holding `rtnl_lock`. Issuing rtnetlink from it would re-enter `rtnl_lock` and self-deadlock, so the work is split across two runtimes:

- `control.lua` (process runtime) — the callback only records the link state into a shared `rcu.table`. Lock-safe, non-blocking.
- `reactor.lua` (spawned kthread, sleepable) — polls the state and reprograms routing with `netlink.rt`, `rtnl_lock` not held, then broadcasts on `netlink.channel`.

They are deliberately separate runtimes: one shared runtime would deadlock ABBA (reactor holds the runtime lock waiting on `rtnl_lock`; the notifier holds `rtnl_lock` waiting on the runtime lock).

Validated end-to-end against a `dummy0` interface: toggling it down/up installs and removes the backup route in table 200, confirmed in `ip route` and dmesg. Run steps in the README.

Second of three use-case PRs toward the Netdev talk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)