### PR TITLE
examples: add floodguard (adaptive in-kernel blackholing)

### DIFF
--- a/examples/floodguard/README.md
+++ b/examples/floodguard/README.md
@@ -1,0 +1,47 @@
+# floodguard — adaptive in-kernel blackholing
+
+Detects flooding sources and blackholes them in the dataplane, in Lua, in
+softirq, and streams each mitigation to userspace over a netlink channel. No
+userspace agent sits in the packet path.
+
+A `PRE_ROUTING` netfilter hook counts packets per source address in an
+`rcu.table`; once a source crosses `THRESHOLD` packets it is dropped (`DROP`) and
+a `blackholed <ip>` event is multicast on the `floodguard` netlink channel. This
+is a minimal illustration: counts are not aged, so a source stays blackholed for
+the life of the runtime.
+
+## Run
+
+```sh
+sudo lunatik run examples/floodguard/filter softirq   # softirq: hook + channel
+
+sudo dmesg -w | grep floodguard &                     # watch mitigations
+```
+
+The channel is a generic netlink family named `floodguard` with one multicast
+group; a userspace dashboard can subscribe to it and print the live feed —
+`tests/netlink/channel_subscriber.c` is a minimal subscriber to build on.
+
+## Demo
+
+Drive traffic from a distinct source (e.g. a network namespace) past the
+threshold and watch it get blackholed:
+
+```sh
+sudo ip netns add attacker
+sudo ip link add veth-h type veth peer name veth-a
+sudo ip link set veth-a netns attacker
+sudo ip addr add 10.99.0.1/24 dev veth-h && sudo ip link set veth-h up
+sudo ip netns exec attacker ip addr add 10.99.0.2/24 dev veth-a
+sudo ip netns exec attacker ip link set veth-a up
+
+sudo ip netns exec attacker ping -c 150 -i 0.01 10.99.0.1   # ~100 get through, rest dropped
+```
+
+## Stop
+
+```sh
+sudo lunatik stop examples/floodguard/filter
+sudo ip netns del attacker && sudo ip link del veth-h
+```
+

--- a/examples/floodguard/filter.lua
+++ b/examples/floodguard/filter.lua
@@ -1,0 +1,54 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+local netfilter = require("netfilter")
+local netlink   = require("netlink")
+local rcu       = require("rcu")
+local nf        = require("linux.nf")
+
+local family   = nf.proto
+local action   = nf.action
+local hooks    = nf.inet
+local priority = nf.ip.pri
+
+local THRESHOLD <const> = 100  -- packets from a source before it is blackholed
+local CMD       <const> = 1    -- channel genl command
+local IP_VIHL   <const> = 0    -- version/IHL byte offset
+local IP_SADDR  <const> = 12   -- IPv4 source address offset
+
+local counts  = rcu.table()    -- source address (string key) -> packet count
+local channel = netlink.channel("floodguard")
+
+local function ipv4(addr)
+	return string.format("%d.%d.%d.%d",
+		addr & 0xff, addr >> 8 & 0xff, addr >> 16 & 0xff, addr >> 24 & 0xff)
+end
+
+local function verdict(skb)
+	local pkt = skb:data()
+	if pkt:getuint8(IP_VIHL) >> 4 ~= 4 then
+		return action.ACCEPT
+	end
+	local src = pkt:getuint32(IP_SADDR)
+	local key = tostring(src)
+	local n = (counts[key] or 0) + 1
+	counts[key] = n
+	if n == THRESHOLD then
+		channel:multicast(CMD, "blackholed " .. ipv4(src))
+		print("floodguard: " .. ipv4(src) .. " exceeded threshold, blackholing")
+	end
+	if n >= THRESHOLD then
+		return action.DROP
+	end
+	return action.ACCEPT
+end
+
+netfilter.register{
+	hook     = verdict,
+	pf       = family.INET,
+	hooknum  = hooks.PRE_ROUTING,
+	priority = priority.RAW,
+}
+


### PR DESCRIPTION
A demoable dataplane use case for the netlink support: adaptive blackholing that detects flooding sources and mitigates them entirely in the kernel, in Lua, in softirq, streaming each action to userspace over a netlink channel.

A `PRE_ROUTING` netfilter hook counts packets per source address in an `rcu.table`; once a source crosses `THRESHOLD` packets it is dropped and a `blackholed <ip>` event is broadcast on the `floodguard` `netlink.channel`. Detection, mitigation and telemetry all run in one softirq runtime, hot-loaded, with no userspace agent in the packet path. The channel is a genl multicast family a userspace dashboard subscribes to (template: `tests/netlink/channel_subscriber.c`).

Validated end-to-end against a network namespace source: 150 pings from `10.99.0.2` past a threshold of 100 → ~99 get through, the rest are dropped, and dmesg shows the blackhole event with the correct source address. Run steps in the README.

## Scope note

This showcases the softirq `netlink.channel` (kernel-to-userspace telemetry) with dataplane mitigation. The control-plane variant — a sleepable reactor installing a blackhole FIB rule via `netlink.rt` — is a natural follow-up once rule support (#616) and an `FRA_SRC` selector land; it is deliberately not stacked here so this PR stays self-contained on `master`.

Third of three use-case PRs toward the Netdev talk (nl80211 #617, netfailover #618, floodguard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)