### PR TITLE
netlink: rename channel:broadcast to multicast

### DIFF
--- a/lib/luanetlink.c
+++ b/lib/luanetlink.c
@@ -6,7 +6,7 @@
 /***
 * Generic netlink channel.
 * Exposes `netlink.channel`, a generic netlink family with one multicast group
-* whose `broadcast`/`unicast` are safe from softirq (netfilter hooks, XDP), for
+* whose `multicast`/`unicast` are safe from softirq (netfilter hooks, XDP), for
 * kernel-to-userspace delivery. The message body is built in Lua (e.g. with
 * `netlink.message`) and sent as-is; request/response netlink is otherwise done
 * in Lua over the `socket` module. Only this softirq-capable send path needs a
@@ -44,7 +44,7 @@ static void luanetlink_channel_release(void *private)
 /***
 * A generic netlink channel.
 * Returned by `netlink.channel()`. Backed by a generic netlink family with one
-* multicast group; `broadcast` and `unicast` are safe from softirq (netfilter
+* multicast group; `multicast` and `unicast` are safe from softirq (netfilter
 * hooks, XDP) and deliver to userspace subscribers of the family.
 * @type netlink.channel
 */
@@ -70,15 +70,15 @@ static struct sk_buff *luanetlink_message(lua_State *L, struct genl_family *fami
 }
 
 /***
-* Broadcasts a message to every subscriber of the channel's group.
+* Multicasts a message to every subscriber of the channel's group.
 * Safe to call from softirq.
-* @function broadcast
+* @function multicast
 * @tparam integer cmd Generic netlink command.
 * @tparam[opt] string payload Message body (e.g. from `netlink.message`).
 * @treturn boolean whether it reached at least one subscriber.
 * @raise on an allocation error.
 */
-static int luanetlink_broadcast(lua_State *L)
+static int luanetlink_multicast(lua_State *L)
 {
 	luanetlink_channel_t *channel = luanetlink_channel_check(L, 1);
 	int cmd = (int)luaL_checkinteger(L, 2);
@@ -120,7 +120,7 @@ static int luanetlink_unicast(lua_State *L)
 
 static const luaL_Reg luanetlink_channel_mt[] = {
 	{"__gc",      lunatik_deleteobject},
-	{"broadcast", luanetlink_broadcast},
+	{"multicast", luanetlink_multicast},
 	{"unicast",   luanetlink_unicast},
 	{NULL, NULL}
 };
@@ -141,7 +141,7 @@ static const lunatik_class_t luanetlink_channel_class = {
 * userspace resolves the family by name (e.g. via `netlink.genl`) to learn the
 * group it must join. Like a netfilter hook, it must be created at script load
 * (process context); the returned channel lives for the runtime and its
-* `broadcast`/`unicast` may then be called from softirq.
+* `multicast`/`unicast` may then be called from softirq.
 * @function channel
 * @tparam string name Generic netlink family name (up to `GENL_NAMSIZ-1` bytes).
 * @treturn netlink.channel A new channel object.

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,10 +84,10 @@ higher-level `netlink.*` modules built on top of it.
   (`NLM_F_EXCL`), then `rt.route_del()` removes it.
 - **channel**: a softirq runtime registers a generic netlink family, unicasts
   to an absent port id (which returns `false`), and installs a `PRE_ROUTING`
-  netfilter hook that, on received traffic (NET_RX softirq), both broadcasts to
+  netfilter hook that, on received traffic (NET_RX softirq), both multicasts to
   the group and unicasts to a fixed port id; a userspace subscriber bound to
   that port id and joined to the group receives both, proving kernel-to-
-  userspace broadcast and unicast delivery from softirq (skips without
+  userspace multicast and unicast delivery from softirq (skips without
   `gcc`/`genl`).
 
 ### notifier

--- a/tests/netlink/channel.lua
+++ b/tests/netlink/channel.lua
@@ -14,7 +14,7 @@ local UNICAST_PORT = 0x4c554e41  -- fixed port id the subscriber binds to
 local ABSENT_PORT  = 0x7fffffff  -- unbound port id: a unicast to it must drop
 
 local channel = netlink.channel("lunatiktest")
-local bcast = message.attrs{[PAYLOAD] = "channel broadcast ok"}
+local mcast = message.attrs{[PAYLOAD] = "channel multicast ok"}
 local ucast = message.attrs{[PAYLOAD] = "channel unicast ok"}
 
 -- a header-only unicast to an absent port id is a dropped frame: false, no raise
@@ -22,13 +22,13 @@ assert(channel:unicast(ABSENT_PORT, CMD) == false)
 print("netlink channel: unicast to absent peer returns false")
 
 local function channel_hook(skb)
-	channel:broadcast(CMD, bcast)
+	channel:multicast(CMD, mcast)
 	channel:unicast(UNICAST_PORT, CMD, ucast)
 	return nf.action.ACCEPT
 end
 
 -- PRE_ROUTING on received (loopback) traffic runs in NET_RX softirq, so both
--- the broadcast and the unicast are genuinely exercised from softirq context.
+-- the multicast and the unicast are genuinely exercised from softirq context.
 netfilter.register{
 	hook     = channel_hook,
 	pf       = nf.proto.INET,

--- a/tests/netlink/channel.sh
+++ b/tests/netlink/channel.sh
@@ -6,10 +6,10 @@
 # Tests netlink.channel end to end FROM SOFTIRQ: a softirq runtime registers a
 # generic netlink family ("lunatiktest"), unicasts to an absent port id (which
 # must return false), and installs a PRE_ROUTING netfilter hook that, on
-# received traffic (NET_RX softirq), both broadcasts to the group and unicasts
+# received traffic (NET_RX softirq), both multicasts to the group and unicasts
 # to a fixed port id. A userspace subscriber (built with gcc) binds to that port
 # id and joins the group, and receives both messages, proving kernel-to-
-# userspace broadcast and unicast delivery from softirq.
+# userspace multicast and unicast delivery from softirq.
 #
 # Usage: sudo bash tests/netlink/channel.sh
 
@@ -69,8 +69,8 @@ for _ in $(seq 1 5); do echo x > /dev/udp/127.0.0.1/9999 2>/dev/null; sleep 0.1;
 wait "$SUB_PID" 2>/dev/null
 check_dmesg || { ktap_totals; exit 1; }
 
-grep -q "channel broadcast ok" "$SUB_OUT" || fail "subscriber did not receive the softirq broadcast"
-ktap_pass "channel: userspace received a broadcast sent from a softirq hook"
+grep -q "channel multicast ok" "$SUB_OUT" || fail "subscriber did not receive the softirq multicast"
+ktap_pass "channel: userspace received a multicast sent from a softirq hook"
 
 grep -q "channel unicast ok" "$SUB_OUT" || fail "subscriber did not receive the softirq unicast"
 ktap_pass "channel: userspace received a unicast sent from a softirq hook"

--- a/tests/netlink/channel_subscriber.c
+++ b/tests/netlink/channel_subscriber.c
@@ -6,7 +6,7 @@
 /*
 * Userspace subscriber for the netlink channel test (see channel.sh): binds to
 * a fixed port id (so the kernel can unicast to it) and joins the given generic
-* netlink multicast group, then reads until it has seen both the broadcast and
+* netlink multicast group, then reads until it has seen both the multicast and
 * the unicast message (or a recv times out).
 */
 
@@ -33,9 +33,9 @@
 /* message classification, accumulated into a bitmask until BOTH are seen */
 enum {
 	NONE      = 0,
-	BROADCAST = 1,
+	MULTICAST = 1,
 	UNICAST   = 2,
-	BOTH      = BROADCAST | UNICAST,
+	BOTH      = MULTICAST | UNICAST,
 };
 
 /* binds a NETLINK_GENERIC socket to UNICAST_PORT, joins multicast group `grp`,
@@ -80,8 +80,8 @@ static int report(char *buf, ssize_t n)
 	printf("%s\n", msg);
 	fflush(stdout);
 
-	if (strstr(msg, "broadcast"))
-		return BROADCAST;
+	if (strstr(msg, "multicast"))
+		return MULTICAST;
 	if (strstr(msg, "unicast"))
 		return UNICAST;
 	return NONE;


### PR DESCRIPTION
`netlink.channel`'s send method uses `genlmsg_multicast`, delivering only to the sockets that **joined the family's multicast group**. That is multicast, not broadcast, and `netlink_broadcast` is a distinct, lower-level netlink primitive, so the name conflated two different kernel operations.

Rename `channel:broadcast` to `channel:multicast` for precision and a symmetric `multicast`/`unicast` pair. The API is recent (#599) so the churn is contained. C method, tests, subscriber and docs updated; channel test passes 3/3 with the new name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)