### PR TITLE
examples: add linkflap (link-flap detection in the kernel)

### DIFF
--- a/examples/linkflap/subscriber.c
+++ b/examples/linkflap/subscriber.c
@@ -1,0 +1,116 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+/*
+* Userspace consumer for the linkflap example (examples/linkflap/watch.lua):
+* joins the "linkflap" generic netlink multicast group and prints each flapping
+* event, decoding the interface name and transition count from the attributes.
+*
+* Build and run:
+*   cc -O2 examples/linkflap/subscriber.c -o linkflap-sub
+*   GRP=$(genl ctrl get name linkflap | grep -oiE 'ID-0x[0-9a-f]+' | sed 's/^ID-//i')
+*   ./linkflap-sub "$GRP"
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <linux/netlink.h>
+#include <linux/genetlink.h>
+
+#ifndef SOL_NETLINK
+#define SOL_NETLINK 270
+#endif
+#ifndef NLA_TYPE_MASK
+#define NLA_TYPE_MASK (~(int)0xC000)
+#endif
+
+/* event attribute types; must match examples/linkflap/watch.lua */
+#define LINKFLAP_IFNAME 1
+#define LINKFLAP_COUNT  2
+
+/* joins the generic netlink multicast group `grp`; returns the fd, or -1 */
+static int subscribe(int grp)
+{
+	struct sockaddr_nl addr = { .nl_family = AF_NETLINK };
+	int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_GENERIC);
+
+	if (fd < 0 ||
+	    bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0 ||
+	    setsockopt(fd, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP, &grp, sizeof(grp)) < 0) {
+		perror("subscribe");
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+/* decodes one flapping event from the attributes that follow the genl header,
+ * bounding every read by the received length `n`, and prints it */
+static void report(const char *buf, ssize_t n)
+{
+	const struct nlmsghdr *nlh = (const struct nlmsghdr *)buf;
+	const char *attr = (const char *)NLMSG_DATA(nlh) + GENL_HDRLEN;
+	int len = (int)n - (int)NLMSG_LENGTH(GENL_HDRLEN);
+	char ifname[64] = "?";
+	unsigned int count = 0;
+
+	while (len >= (int)NLA_HDRLEN) {
+		const struct nlattr *na = (const struct nlattr *)attr;
+		int alen = na->nla_len;
+		if (alen < (int)NLA_HDRLEN || alen > len)
+			break;
+
+		const char *data = attr + NLA_HDRLEN;
+		int plen = alen - (int)NLA_HDRLEN;
+
+		switch (na->nla_type & NLA_TYPE_MASK) {
+		case LINKFLAP_IFNAME:
+			plen = MIN(plen, (int)sizeof(ifname) - 1);
+			memcpy(ifname, data, plen);
+			ifname[plen] = '\0';
+			break;
+		case LINKFLAP_COUNT:
+			if (plen >= (int)sizeof(count))
+				memcpy(&count, data, sizeof(count));
+			break;
+		}
+
+		int step = NLA_ALIGN(alen);
+		len  -= step;
+		attr += step;
+	}
+
+	printf("linkflap: %s flapping (%u transitions)\n", ifname, count);
+	fflush(stdout);
+}
+
+int main(int argc, char **argv)
+{
+	if (argc < 2) {
+		fprintf(stderr, "usage: %s <group-id>\n", argv[0]);
+		return 1;
+	}
+
+	int fd = subscribe((int)strtol(argv[1], NULL, 0));
+	if (fd < 0)
+		return 1;
+
+	char buf[4096];
+	for (;;) {
+		ssize_t n = recv(fd, buf, sizeof(buf), 0);
+		if (n < (ssize_t)NLMSG_LENGTH(GENL_HDRLEN))
+			break;
+		report(buf, n);
+	}
+
+	close(fd);
+	return 0;
+}
+

--- a/examples/linkflap/watch.lua
+++ b/examples/linkflap/watch.lua
@@ -1,0 +1,53 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+-- Detects link flapping inside the kernel. A notifier.netdevice callback keeps a
+-- per-interface sliding window of UP/DOWN transitions and, once one interface
+-- crosses the threshold within the window, multicasts a structured flapping
+-- event (interface name and transition count) over the "linkflap" generic
+-- netlink family. Consume it in userspace with examples/linkflap/subscriber.c.
+
+local linux    = require("linux")
+local notifier = require("notifier")
+local netlink  = require("netlink")
+local message  = require("netlink.message")
+local netdev   = require("linux.netdev")
+local notify   = require("linux.notify")
+
+local insert = table.insert
+local remove = table.remove
+
+local WINDOW <const> = 10 * 1000000000  -- 10s in nanoseconds
+local LIMIT  <const> = 5                -- transitions within WINDOW to flag flapping
+local FLAP   <const> = 1                -- channel genl command
+local IFNAME <const> = 1                -- event attribute types
+local COUNT  <const> = 2
+
+local channel  = netlink.channel("linkflap")
+local history  = {}  -- ifname -> { transition timestamps }
+local flapping = {}  -- ifname -> true while in a flap episode
+
+local function callback(event, name)
+	if event ~= netdev.UP and event ~= netdev.DOWN then
+		return notify.OK
+	end
+	local now = linux.time()
+	local seen = history[name] or {}
+	insert(seen, now)
+	while seen[1] and now - seen[1] > WINDOW do
+		remove(seen, 1)
+	end
+	history[name] = seen
+	if #seen >= LIMIT and not flapping[name] then
+		flapping[name] = true
+		channel:multicast(FLAP, message.attrs{[IFNAME] = name, [COUNT] = #seen})
+	elseif #seen < LIMIT then
+		flapping[name] = nil
+	end
+	return notify.OK
+end
+
+notifier.netdevice(callback)
+


### PR DESCRIPTION
A `notifier.netdevice` callback keeps a per-interface sliding window of UP/DOWN transitions and, once an interface crosses the threshold within the window, **multicasts a structured flapping event** (interface name and transition count) over the `linkflap` generic netlink family. `subscriber.c` consumes the events in userspace, decoding the attributes and printing e.g. `linkflap: dummy0 flapping (5 transitions)`.

It hooks the kernel's **netdevice notifier chain**, and the value is the **stateful** per-interface window in the handler (plain event forwarding cannot do that). The callback runs holding `rtnl_lock`, so it must not issue rtnetlink itself, but emitting a multicast is safe (it does not take the lock), so this is a single runtime.

Also the first **`netlink.channel` example** in the tree (it had only test coverage).

Validated end to end in the kernel: running `watch.lua` and bouncing a dummy interface past the threshold, `subscriber.c` (joined to the family's multicast group) receives and decodes the event. No `printk` involved; the point is the netlink path.

Rebased onto master now that #620 (multicast rename) is merged.