### PR TITLE
class: named constructor .new instead of callable class

### DIFF
--- a/examples/cpuexporter.lua
+++ b/examples/cpuexporter.lua
@@ -13,7 +13,7 @@ local socket  = require("socket")
 local shouldstop = thread.shouldstop
 local NONBLOCK   = require("linux.socket").sock.NONBLOCK
 
-local server = unix.stream("/tmp/cpuexporter.sock")
+local server = unix.stream.new("/tmp/cpuexporter.sock")
 server:bind()
 server:listen()
 

--- a/examples/echod/daemon.lua
+++ b/examples/echod/daemon.lua
@@ -17,7 +17,7 @@ local sock = require("linux.socket").sock
 local control = data.new(2)
 control:setbyte(1, 1) -- alive
 
-local server = inet.tcp()
+local server = inet.tcp.new()
 server:bind(inet.localhost, 1337)
 server:listen()
 

--- a/examples/shared.lua
+++ b/examples/shared.lua
@@ -30,7 +30,7 @@ local linux  = require("linux")
 
 local shared = rcu.table()
 
-local server = inet.tcp()
+local server = inet.tcp.new()
 server:bind(inet.localhost, 90)
 server:listen()
 

--- a/lib/class.lua
+++ b/lib/class.lua
@@ -5,33 +5,44 @@
 
 ---
 -- Minimal class helper for the OOP-style modules (e.g. `socket.inet`,
--- `socket.unix`). Calling the module on a table makes it an instantiable class:
--- it gains a `:new` constructor that wires `__index`/`__close` and sets the
--- class as the metatable of new objects, serving both to build instances and to
--- derive specializations (subclasses that inherit the methods).
+-- `socket.unix`, `netlink.rt`). `class{}` returns a class table; `:extend{}`
+-- derives a specialization that inherits its methods; `.new(...)` builds an
+-- instance, running the class's `:init(...)` if it defines one; and `close`, if
+-- present, is wired as the to-be-closed handler.
 -- @module class
 -- @usage
 -- local class = require("class")
 --
 -- local Point = class{}
+-- function Point:init(x, y) self.x, self.y = x, y end
 -- function Point:sum() return self.x + self.y end
 --
--- local point <close> = Point:new{x = 1, y = 2}   -- point:sum() == 3
+-- local p = Point.new(1, 2)   -- p:sum() == 3
 
-local function new(self, o)
-	o = o or {}
-	self.__index = self
-	self.__close = self.close
-	return setmetatable(o, self)
+local function closer(o)
+	return o:close()
+end
+
+local function construct(class, ...)
+	local o = setmetatable({}, class)
+	if o.init then o:init(...) end
+	return o
+end
+
+local function extend(parent, def)
+	def = def or {}
+	def.__index = def
+	def.__close = closer
+	def.new     = function(...) return construct(def, ...) end
+	def.extend  = extend
+	return setmetatable(def, {__index = parent})
 end
 
 ---
--- Makes `class` an instantiable class by attaching the shared `:new`.
--- @tparam[opt] table class the class table (defaults to a fresh table).
--- @treturn table the same table, ready to receive methods and be instantiated.
+-- Creates a class.
+-- @tparam[opt] table class initial class table (shared fields and defaults).
+-- @treturn table the class, ready to receive methods, be extended and instantiated.
 return function(class)
-	class = class or {}
-	class.new = new
-	return class
+	return extend(nil, class)
 end
 

--- a/lib/netlink/genl.lua
+++ b/lib/netlink/genl.lua
@@ -5,7 +5,7 @@
 
 ---
 -- Generic netlink (`NETLINK_GENERIC`) interface. A `netlink.session`
--- specialization: create an instance with `genl()`, resolve a family name to
+-- specialization: create an instance with `genl.new()`, resolve a family name to
 -- its id, then dispatch commands; close it when done. All methods block and
 -- require a sleepable runtime.
 --
@@ -36,12 +36,11 @@ local NOOP, ERROR, DONE, OVERRUN = nl.type.NOOP, nl.type.ERROR, nl.type.DONE, nl
 -- @type genl
 
 ---
--- Creates a new genl object.
--- @function genl:new
--- @tparam[opt] table o an initial object table.
+-- Creates a new genl session over `NETLINK_GENERIC`.
+-- @function genl.new
 -- @treturn genl the new genl object.
 -- @see class
-local genl = session:new{proto = nl.proto.GENERIC}
+local genl = session:extend{proto = nl.proto.GENERIC}
 
 local function command(cmd, payload)
 	return genlmsghdr:pack(cmd, GENL_VERSION, 0) .. (payload or "")

--- a/lib/netlink/rt.lua
+++ b/lib/netlink/rt.lua
@@ -6,7 +6,7 @@
 ---
 -- rtnetlink interface for routes, links and addresses. A `netlink.session`
 -- specialization over the `NETLINK_ROUTE` protocol: create an instance with
--- `rt()` and call its methods; the underlying socket is closed by `close()`
+-- `rt.new()` and call its methods; the underlying socket is closed by `close()`
 -- (or the to-be-closed `__close`). All methods block and require a sleepable
 -- runtime.
 --
@@ -57,12 +57,11 @@ end
 -- @type rt
 
 ---
--- Creates a new rt object.
--- @function rt:new
--- @tparam[opt] table o an initial object table.
+-- Creates a new rt session over `NETLINK_ROUTE`.
+-- @function rt.new
 -- @treturn rt the new rt object.
 -- @see class
-local rt = session:new{proto = nl.proto.ROUTE}
+local rt = session:extend{proto = nl.proto.ROUTE}
 
 ---
 -- Lists all routes from the kernel routing tables.

--- a/lib/netlink/session.lua
+++ b/lib/netlink/session.lua
@@ -92,13 +92,10 @@ local function transact(session, mtype, flags, payload, last)
 end
 
 ---
--- Creates a session backed by an `AF_NETLINK` socket of the class's `proto`.
--- @treturn session a new session object.
-function session:__call()
-	local o = self:new()
-	o.socket = socket.new(sk.af.NETLINK, sk.sock.RAW, self.proto)
-	o.sequence = 0
-	return o
+-- Sets up the session's `AF_NETLINK` socket for the class's `proto`; run by `new`.
+function session:init()
+	self.socket = socket.new(sk.af.NETLINK, sk.sock.RAW, self.proto)
+	self.sequence = 0
 end
 
 ---

--- a/lib/socket/inet.lua
+++ b/lib/socket/inet.lua
@@ -35,17 +35,14 @@ local inet = class{localhost = '127.0.0.1'}
 local af = require("linux.socket").af
 
 ---
--- Metamethod to create a new socket instance when `inet()` or `inet.tcp()` or `inet.udp()` is called.
--- This is the primary way to create new socket instances (e.g., `local sock = inet.tcp()`).
--- @return (table) A new socket object (e.g., a TCP or UDP socket object).
+-- Sets up the underlying `AF_INET` socket for the class's type and protocol;
+-- run by `new` (e.g. `inet.tcp.new()` or `inet.udp.new()`).
 -- @see socket.new
 -- @usage
--- local tcp_socket = inet.tcp()
--- local udp_socket = inet.udp()
-function inet:__call()
-	local o = self:new()
-	o.socket = socket.new(af.INET, self.type, self.proto)
-	return o
+-- local tcp_socket = inet.tcp.new()
+-- local udp_socket = inet.udp.new()
+function inet:init()
+	self.socket = socket.new(af.INET, self.type, self.proto)
 end
 
 ---
@@ -144,11 +141,11 @@ local ipproto = require("linux.socket").ipproto
 ---
 -- TCP socket specialization.
 -- Provides methods specific to TCP sockets (e.g., `listen`, `accept`).
--- Create TCP sockets using `inet.tcp()`.
+-- Create TCP sockets using `inet.tcp.new()`.
 -- @table inet.tcp
 -- @field type The socket type (e.g., `linux.socket.sock.STREAM`).
 -- @field proto The protocol (e.g., `linux.socket.ipproto.TCP`).
-inet.tcp = inet:new{type = sock.STREAM, proto = ipproto.TCP}
+inet.tcp = inet:extend{type = sock.STREAM, proto = ipproto.TCP}
 
 ---
 -- Listens for incoming connections on a TCP socket.
@@ -171,11 +168,11 @@ end
 ---
 -- UDP socket specialization.
 -- Provides methods specific to UDP sockets (e.g., `receivefrom`, `sendto`).
--- Create UDP sockets using `inet.udp()`.
+-- Create UDP sockets using `inet.udp.new()`.
 -- @table inet.udp
 -- @field type The socket type (e.g., `linux.socket.sock.DGRAM`).
 -- @field proto The protocol (e.g., `linux.socket.ipproto.UDP`).
-inet.udp = inet:new{type = sock.DGRAM, proto = ipproto.UDP}
+inet.udp = inet:extend{type = sock.DGRAM, proto = ipproto.UDP}
 
 ---
 -- Receives data from a UDP socket, along with the sender's address.

--- a/lib/socket/unix.lua
+++ b/lib/socket/unix.lua
@@ -35,17 +35,15 @@ local sock = require("linux.socket").sock
 local unix = class{}
 
 ---
--- Creates a new UNIX domain socket instance.
--- This is the primary way to create instances (e.g. `local s = unix.stream(path)`).
+-- Sets up the underlying `AF_UNIX` socket and stores the optional default path;
+-- run by `new` (e.g. `unix.stream.new(path)`).
 -- @param path (string) [optional] Default UNIX socket path stored in the object.
 --   Reused automatically by `bind`, `connect`, `send`, `sendto`, and `receivefrom`
 --   when no explicit path is given.
--- @return (table) A new unix socket object.
 -- @see socket.new
-function unix:__call(path)
-	local o = self:new{path = path}
-	o.socket = socket.new(af.UNIX, self.type, 0)
-	return o
+function unix:init(path)
+	self.path = path
+	self.socket = socket.new(af.UNIX, self.type, 0)
 end
 
 ---
@@ -113,10 +111,10 @@ end
 
 ---
 -- STREAM socket specialization (connection-oriented).
--- Create instances with `unix.stream([path])`.
+-- Create instances with `unix.stream.new([path])`.
 -- @table unix.stream
 -- @field type The socket type (`linux.socket.sock.STREAM`).
-unix.stream = unix:new{type = sock.STREAM}
+unix.stream = unix:extend{type = sock.STREAM}
 
 ---
 -- Listens for incoming connections on a STREAM socket.
@@ -137,11 +135,11 @@ end
 
 ---
 -- DGRAM socket specialization (connectionless).
--- Create instances with `unix.dgram([path])`.
+-- Create instances with `unix.dgram.new([path])`.
 -- The optional path is stored as the default destination for `sendto`.
 -- @table unix.dgram
 -- @field type The socket type (`linux.socket.sock.DGRAM`).
-unix.dgram = unix:new{type = sock.DGRAM}
+unix.dgram = unix:extend{type = sock.DGRAM}
 
 ---
 -- Receives data from a DGRAM socket along with the sender's path.

--- a/tests/netlink/addr_list.lua
+++ b/tests/netlink/addr_list.lua
@@ -13,7 +13,7 @@ local function is_loopback(addr)
 	return b1 == 127 and b2 == 0 and b3 == 0 and b4 == 1
 end
 
-local r <close> = rt()
+local r <close> = rt.new()
 for _, addr in ipairs(r:addr_list(af.INET)) do
 	if is_loopback(addr.address) then
 		print("netlink addr_list: 127.0.0.1 found")

--- a/tests/netlink/genl_family.lua
+++ b/tests/netlink/genl_family.lua
@@ -8,7 +8,7 @@ local genl    = require("netlink.genl")
 local message = require("netlink.message")
 local ctrl    = require("linux.genl")
 
-local g <close> = genl()
+local g <close> = genl.new()
 local id = g:family("nlctrl")
 assert(id == ctrl.id.CTRL, "expected nlctrl id == " .. ctrl.id.CTRL .. ", got " .. tostring(id))
 print("netlink genl_family: nlctrl resolved")

--- a/tests/netlink/link_list.lua
+++ b/tests/netlink/link_list.lua
@@ -6,7 +6,7 @@
 
 local rt = require("netlink.rt")
 
-local r <close> = rt()
+local r <close> = rt.new()
 for _, link in ipairs(r:link_list()) do
 	if link.name == "lo" then
 		assert(link.ifindex == 1, "expected lo ifindex == 1, got " .. tostring(link.ifindex))

--- a/tests/netlink/route_adddel.lua
+++ b/tests/netlink/route_adddel.lua
@@ -13,7 +13,7 @@ local DST     = string.char(192, 0, 2, 0) -- 192.0.2.0 (TEST-NET-1), network byt
 local DST_LEN = 24
 local LO      = 1                          -- loopback ifindex
 
-local r <close> = rt()
+local r <close> = rt.new()
 
 local function present()
 	for _, route in ipairs(r:route_list(af.INET)) do

--- a/tests/netlink/route_list.lua
+++ b/tests/netlink/route_list.lua
@@ -6,7 +6,7 @@
 
 local rt = require("netlink.rt")
 
-local r <close> = rt()
+local r <close> = rt.new()
 local routes = r:route_list()
 
 if #routes > 0 then

--- a/tests/socket/unix/dgram_client.lua
+++ b/tests/socket/unix/dgram_client.lua
@@ -9,7 +9,7 @@
 local unix = require("socket.unix")
 
 local SERVER_PATH = "/tmp/lunatik_unix_dgram.sock"
-local client      = unix.dgram(SERVER_PATH)
+local client      = unix.dgram.new(SERVER_PATH)
 
 client:sendto("hello dgram")   -- uses stored SERVER_PATH, no explicit path
 client:close()

--- a/tests/socket/unix/dgram_server.lua
+++ b/tests/socket/unix/dgram_server.lua
@@ -14,7 +14,7 @@ local linux  = require("linux")
 local DONTWAIT = require("linux.socket").msg.DONTWAIT
 local PATH     = "/tmp/lunatik_unix_dgram.sock"
 
-local server = unix.dgram(PATH)
+local server = unix.dgram.new(PATH)
 server:bind()
 
 return function()

--- a/tests/socket/unix/stream_client.lua
+++ b/tests/socket/unix/stream_client.lua
@@ -9,7 +9,7 @@
 local unix = require("socket.unix")
 
 local PATH   = "/tmp/lunatik_unix_stream.sock"
-local client = unix.stream(PATH)
+local client = unix.stream.new(PATH)
 
 client:connect()         -- uses stored PATH
 client:send("ping")

--- a/tests/socket/unix/stream_server.lua
+++ b/tests/socket/unix/stream_server.lua
@@ -14,7 +14,7 @@ local linux  = require("linux")
 local NONBLOCK = require("linux.socket").sock.NONBLOCK
 local PATH     = "/tmp/lunatik_unix_stream.sock"
 
-local server = unix.stream(PATH)
+local server = unix.stream.new(PATH)
 server:bind()
 server:listen(1)
 


### PR DESCRIPTION
The OOP-style modules (`socket.inet`/`unix`, `netlink.rt`/`genl`) were **callable classes**: `require` returned a class you invoked to construct, e.g. `require("netlink.rt")()` / `inet.tcp()`. Two problems:

- **Inconsistent with the rest of lunatik**, where you require a table and call a *named* constructor (`socket.new`, `rcu.table`, `data.new`). The callable form reads as an anonymous call, and calling a method on the class by mistake fails cryptically (on an internal `sequence` field) instead of clearly.
- **`__call` only works one subclass deep.** A grandchild class (e.g. an `nl80211` built on `genl`) is not callable, because `__call` is looked up on the metatable by rawget and is not inherited. That forced a hand-rolled `setmetatable` in the grandchild.

## New shape

`class{}` returns a table; `:extend{}` derives a specialization; `.new(...)` builds an instance, running the class's `:init(...)`; `close` is wired as the to-be-closed handler. Constructors move from `:__call` to `:init`.

```lua
local rt = require("netlink.rt")
local session = rt.new()          -- was rt()
local s = inet.tcp.new()          -- was inet.tcp()
local u = unix.stream.new(path)   -- was unix.stream(path)
```

No `__call`, so subclassing works at **any depth** — this dissolves the grandchild problem (the `nl80211` `setmetatable` hack goes away when that branch adopts this).

Validated in the kernel (without a module reload): `rt.new()`/`genl.new()` drive the netlink dumps, and `unix.stream.new(path)`/`inet.tcp.new()` construct working sockets. The full socket and netlink suites should be run on merge.

Open branches that construct these (`nl80211` #617, `netfailover` #618, `floodguard` #619) rebase onto this and adopt `.new`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)