### PR TITLE
netlink: group rt, genl and channel under a netlink namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ scripts_install:
 	${INSTALL} -m 0644 lib/mailbox.lua ${SCRIPTS_INSTALL_PATH}/
 	${INSTALL} -m 0644 lib/net.lua ${SCRIPTS_INSTALL_PATH}/
 	${INSTALL} -m 0644 lib/struct.lua ${SCRIPTS_INSTALL_PATH}/
+	${INSTALL} -m 0644 lib/netlink.lua ${SCRIPTS_INSTALL_PATH}/
 	${INSTALL} -m 0644 lib/util.lua ${SCRIPTS_INSTALL_PATH}/
 	${INSTALL} -m 0644 lib/lighten.lua ${SCRIPTS_INSTALL_PATH}/
 	${INSTALL} -m 0644 lib/lunatik/*.lua ${SCRIPTS_INSTALL_PATH}/lunatik
@@ -109,6 +110,7 @@ scripts_uninstall:
 	${RM} ${SCRIPTS_INSTALL_PATH}/mailbox.lua
 	${RM} ${SCRIPTS_INSTALL_PATH}/net.lua
 	${RM} ${SCRIPTS_INSTALL_PATH}/struct.lua
+	${RM} ${SCRIPTS_INSTALL_PATH}/netlink.lua
 	${RM} ${SCRIPTS_INSTALL_PATH}/util.lua
 	${RM} ${SCRIPTS_INSTALL_PATH}/lighten.lua
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/lunatik

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The table below lists the available kernel Lua modules:
 | `linux` | Kernel utilities: `schedule`, `time`, `random`, `stat` flags |
 | `thread` | Kernel threads: spawn, stop, `shouldstop` |
 | `socket` | Kernel sockets: TCP, UDP, AF\_PACKET, AF\_UNIX |
-| `netlink` | AF\_NETLINK sockets with rtnetlink and generic-netlink helpers |
+| `netlink` | Netlink namespace: rtnetlink and generic-netlink sessions, softirq-safe channel |
 | `data` | Raw memory buffer for binary data read/write |
 | `device` | Character device drivers |
 | `rcu` | RCU-protected shared hash table |

--- a/config.ld
+++ b/config.ld
@@ -37,6 +37,7 @@ file = {
 	'./lib/linux',
 	'./lib/mailbox.lua',
 	'./lib/net.lua',
+	'./lib/netlink.lua',
 	'./lib/netlink/genl.lua',
 	'./lib/netlink/message.lua',
 	'./lib/netlink/rt.lua',

--- a/lib/luanetlink.c
+++ b/lib/luanetlink.c
@@ -4,15 +4,14 @@
 */
 
 /***
-* Generic netlink channel.
-* Exposes `netlink.channel`, a generic netlink family with one multicast group
+* Generic netlink channel: a generic netlink family with one multicast group
 * whose `multicast`/`unicast` are safe from softirq (netfilter hooks, XDP), for
 * kernel-to-userspace delivery. The message body is built in Lua (e.g. with
 * `netlink.message`) and sent as-is; request/response netlink is otherwise done
 * in Lua over the `socket` module. Only this softirq-capable send path needs a
 * dedicated kernel object.
 *
-* @module netlink
+* @module netlink.channel
 */
 
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
@@ -125,13 +124,13 @@ static const luaL_Reg luanetlink_channel_mt[] = {
 	{NULL, NULL}
 };
 
-LUNATIK_OPENER(netlink);
+LUNATIK_OPENER(netlink_channel);
 
 static const lunatik_class_t luanetlink_channel_class = {
 	.name    = "netlink.channel",
 	.methods = luanetlink_channel_mt,
 	.release = luanetlink_channel_release,
-	.opener  = luaopen_netlink,
+	.opener  = luaopen_netlink_channel,
 	.opt     = LUNATIK_OPT_SOFTIRQ | LUNATIK_OPT_SINGLE,
 };
 
@@ -142,11 +141,11 @@ static const lunatik_class_t luanetlink_channel_class = {
 * group it must join. Like a netfilter hook, it must be created at script load
 * (process context); the returned channel lives for the runtime and its
 * `multicast`/`unicast` may then be called from softirq.
-* @function channel
+* @function new
 * @tparam string name Generic netlink family name (up to `GENL_NAMSIZ-1` bytes).
 * @treturn netlink.channel A new channel object.
 * @raise if the name is empty or too long, or family registration fails.
-* @within netlink
+* @within netlink.channel
 */
 static int luanetlink_channel_new(lua_State *L)
 {
@@ -172,12 +171,12 @@ static int luanetlink_channel_new(lua_State *L)
 }
 
 static const luaL_Reg luanetlink_lib[] = {
-	{"channel", luanetlink_channel_new},
+	{"new", luanetlink_channel_new},
 	{NULL, NULL}
 };
 
-LUNATIK_CLASSES(netlink, &luanetlink_channel_class);
-LUNATIK_NEWLIB(netlink, luanetlink_lib, luanetlink_classes);
+LUNATIK_CLASSES(netlink_channel, &luanetlink_channel_class);
+LUNATIK_NEWLIB(netlink_channel, luanetlink_lib, luanetlink_channel_classes);
 
 static int __init luanetlink_init(void)
 {

--- a/lib/netlink.lua
+++ b/lib/netlink.lua
@@ -1,0 +1,40 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+---
+-- The netlink namespace. Groups the netlink factories.
+-- @module netlink
+
+local channel = require("netlink.channel")
+local rt      = require("netlink.rt")
+local genl    = require("netlink.genl")
+
+local netlink = {}
+
+---
+-- Registers a generic netlink family with one multicast group; the returned
+-- channel's `multicast`/`unicast` are softirq-safe.
+-- @function netlink.channel
+-- @tparam string name Generic netlink family name (up to `GENL_NAMSIZ-1` bytes).
+-- @treturn netlink.channel A new channel object.
+-- @see netlink.channel
+netlink.channel = channel.new
+
+---
+-- rtnetlink session specialization for routes, links and addresses.
+-- Open sessions (sleepable) using `netlink.rt()`.
+-- @table netlink.rt
+-- @see netlink.rt
+netlink.rt = rt
+
+---
+-- Generic netlink session specialization.
+-- Open sessions (sleepable) using `netlink.genl()`.
+-- @table netlink.genl
+-- @see netlink.genl
+netlink.genl = genl
+
+return netlink
+

--- a/lib/netlink/genl.lua
+++ b/lib/netlink/genl.lua
@@ -5,7 +5,7 @@
 
 ---
 -- Generic netlink (`NETLINK_GENERIC`) interface. A `netlink.session`
--- specialization: create an instance with `genl()`, resolve a family name to
+-- specialization: create an instance with `netlink.genl()`, resolve a family name to
 -- its id, then dispatch commands; close it when done. All methods block and
 -- require a sleepable runtime.
 --

--- a/lib/netlink/rt.lua
+++ b/lib/netlink/rt.lua
@@ -6,7 +6,7 @@
 ---
 -- rtnetlink interface for routes, links and addresses. A `netlink.session`
 -- specialization over the `NETLINK_ROUTE` protocol: create an instance with
--- `rt()` and call its methods; the underlying socket is closed by `close()`
+-- `netlink.rt()` and call its methods; the underlying socket is closed by `close()`
 -- (or the to-be-closed `__close`). All methods block and require a sleepable
 -- runtime.
 --

--- a/tests/netlink/addr_list.lua
+++ b/tests/netlink/addr_list.lua
@@ -4,7 +4,7 @@
 --
 -- Kernel-side script for the netlink addr_list test (see addr_list.sh).
 
-local rt = require("netlink.rt")
+local netlink = require("netlink")
 local af = require("linux.socket").af
 
 local function is_loopback(addr)
@@ -13,8 +13,8 @@ local function is_loopback(addr)
 	return b1 == 127 and b2 == 0 and b3 == 0 and b4 == 1
 end
 
-local r <close> = rt()
-for _, addr in ipairs(r:addr_list(af.INET)) do
+local rt <close> = netlink.rt()
+for _, addr in ipairs(rt:addr_list(af.INET)) do
 	if is_loopback(addr.address) then
 		print("netlink addr_list: 127.0.0.1 found")
 		if addr.prefix_len == 8 then

--- a/tests/netlink/genl_family.lua
+++ b/tests/netlink/genl_family.lua
@@ -4,18 +4,18 @@
 --
 -- Kernel-side script for the netlink genl_family test (see genl_family.sh).
 
-local genl    = require("netlink.genl")
+local netlink = require("netlink")
 local message = require("netlink.message")
 local ctrl    = require("linux.genl")
 
-local g <close> = genl()
-local id = g:family("nlctrl")
+local genl <close> = netlink.genl()
+local id = genl:family("nlctrl")
 assert(id == ctrl.id.CTRL, "expected nlctrl id == " .. ctrl.id.CTRL .. ", got " .. tostring(id))
 print("netlink genl_family: nlctrl resolved")
 
 -- a second operation on the SAME instance must work: family() and call() must
 -- drain the NLM_F_ACK so the socket stays in sync (regression for orphaned ACK)
-local msgs = g:call(ctrl.id.CTRL, ctrl.cmd.GETFAMILY, 0,
+local msgs = genl:call(ctrl.id.CTRL, ctrl.cmd.GETFAMILY, 0,
 	message.attrs{[ctrl.attr.FAMILY_NAME] = string.pack("z", "nlctrl")})
 local fid
 for _, m in ipairs(msgs) do fid = fid or m.attrs[ctrl.attr.FAMILY_ID] end
@@ -24,7 +24,7 @@ print("netlink genl_family: call round-trip ok")
 
 -- dump: a GETFAMILY with no family name lists every registered family; nlctrl
 -- must be among them, and each entry carries its decoded attributes
-local families = g:dump(ctrl.id.CTRL, ctrl.cmd.GETFAMILY)
+local families = genl:dump(ctrl.id.CTRL, ctrl.cmd.GETFAMILY)
 assert(#families > 0, "dump returned no families")
 local found
 for _, m in ipairs(families) do
@@ -35,6 +35,6 @@ assert(found, "dump did not list the nlctrl family")
 print("netlink genl_family: dump lists families")
 
 -- an unknown family raises
-assert(not pcall(g.family, g, "nosuchfamily_xyz"), "expected error resolving a missing family")
+assert(not pcall(genl.family, genl, "nosuchfamily_xyz"), "expected error resolving a missing family")
 print("netlink genl_family: missing family errors")
 

--- a/tests/netlink/link_list.lua
+++ b/tests/netlink/link_list.lua
@@ -4,10 +4,10 @@
 --
 -- Kernel-side script for the netlink link_list test (see link_list.sh).
 
-local rt = require("netlink.rt")
+local netlink = require("netlink")
 
-local r <close> = rt()
-for _, link in ipairs(r:link_list()) do
+local rt <close> = netlink.rt()
+for _, link in ipairs(rt:link_list()) do
 	if link.name == "lo" then
 		assert(link.ifindex == 1, "expected lo ifindex == 1, got " .. tostring(link.ifindex))
 		print("netlink link_list: lo found")

--- a/tests/netlink/route_adddel.lua
+++ b/tests/netlink/route_adddel.lua
@@ -4,7 +4,7 @@
 --
 -- Kernel-side script for the netlink route_adddel test (see route_adddel.sh).
 
-local rt = require("netlink.rt")
+local netlink = require("netlink")
 local af = require("linux.socket").af
 local scope = require("linux.rtnetlink").scope
 
@@ -13,10 +13,10 @@ local DST     = string.char(192, 0, 2, 0) -- 192.0.2.0 (TEST-NET-1), network byt
 local DST_LEN = 24
 local LO      = 1                          -- loopback ifindex
 
-local r <close> = rt()
+local rt <close> = netlink.rt()
 
 local function present()
-	for _, route in ipairs(r:route_list(af.INET)) do
+	for _, route in ipairs(rt:route_list(af.INET)) do
 		if route.table == TABLE and route.dst == DST and route.dst_len == DST_LEN then
 			return true
 		end
@@ -24,18 +24,18 @@ local function present()
 	return false
 end
 
-r:route_add{family = af.INET, dst = DST, dst_len = DST_LEN, oif = LO,
+rt:route_add{family = af.INET, dst = DST, dst_len = DST_LEN, oif = LO,
 	table = TABLE, scope = scope.LINK}
 assert(present(), "route not found after add")
 print("netlink route_adddel: added")
 
 -- route_add sends NLM_F_EXCL, so adding the same route again must raise
 -- (EEXIST), surfaced by check_error from the kernel acknowledgment
-assert(not pcall(r.route_add, r, {family = af.INET, dst = DST, dst_len = DST_LEN,
+assert(not pcall(rt.route_add, rt, {family = af.INET, dst = DST, dst_len = DST_LEN,
 	oif = LO, table = TABLE, scope = scope.LINK}), "duplicate add should raise")
 print("netlink route_adddel: duplicate add raises")
 
-r:route_del{family = af.INET, dst = DST, dst_len = DST_LEN, oif = LO, table = TABLE}
+rt:route_del{family = af.INET, dst = DST, dst_len = DST_LEN, oif = LO, table = TABLE}
 assert(not present(), "route still present after del")
 print("netlink route_adddel: deleted")
 

--- a/tests/netlink/route_list.lua
+++ b/tests/netlink/route_list.lua
@@ -4,10 +4,10 @@
 --
 -- Kernel-side script for the netlink route_list test (see route_list.sh).
 
-local rt = require("netlink.rt")
+local netlink = require("netlink")
 
-local r <close> = rt()
-local routes = r:route_list()
+local rt <close> = netlink.rt()
+local routes = rt:route_list()
 
 if #routes > 0 then
 	print("netlink route_list: routes found")


### PR DESCRIPTION
Constructing a netlink session read as an anonymous call on the required class — `require("netlink.rt")()` — inconsistent with `socket.inet`'s `inet.tcp()`. This makes **netlink a namespace like `socket.inet`**:

```lua
local netlink = require("netlink")
local session = netlink.rt()          -- was require("netlink.rt")()
local g       = netlink.genl()
local ch      = netlink.channel(name) -- unchanged
local sock    = inet.tcp()            -- socket family: unchanged
```

`require("netlink")` now returns a table whose `netlink.rt()`, `netlink.genl()` and `netlink.channel(name)` are the factories, mirroring `inet.tcp()`/`inet.udp()`. The aggregator requires the three members eagerly; loading `rt`/`genl` only defines the classes (constructing a session is what needs a sleepable runtime), so a softirq runtime that only wants `netlink.channel` requires `netlink` all the same — the channel test exercises exactly that.

## How

- The channel C module registers as **`netlink.channel`** (`luaopen_netlink_channel`); verified in-kernel that the dotted C module name resolves. The source stays `lib/luanetlink.c` and the kernel module stays `luanetlink.ko`.
- A small Lua aggregator (`lib/netlink.lua`) re-exports `channel`, `rt`, `genl`.

Channel callers (`require("netlink").channel(name)`) are unchanged. Full socket and netlink suites pass; LDoc builds clean.

Supersedes #622 (the `.new` approach): keeps everything callable and consistent with `inet.tcp()`, which is what the redesign was after.

Open branches (`nl80211` #617, `netfailover` #618, `floodguard` #619) rebase onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)