### PR TITLE
bin: surface unload failures instead of ignoring them

### DIFF
--- a/bin/lunatik
+++ b/bin/lunatik
@@ -43,6 +43,13 @@ local function load_modules()
 	if result ~= "" then error(result) end
 end
 
+local function rmmod(module)
+	local loaded <close> = io.open("/sys/module/" .. module .. "/initstate")
+	if loaded and not os.execute("rmmod " .. module) then
+		error("couldn't unload " .. module)
+	end
+end
+
 local function unload_modules()
 	if probe() then
 		local result = dostring[[
@@ -53,7 +60,7 @@ local function unload_modules()
 		if result ~= "" then error(result) end
 	end
 	for i = #modules, 1, -1 do
-		sh("rmmod $MODULE", modules[i], true)
+		rmmod(modules[i])
 	end
 end
 

--- a/bin/lunatik
+++ b/bin/lunatik
@@ -45,7 +45,12 @@ end
 
 local function unload_modules()
 	if probe() then
-		dostring("lunatik.runner.shutdown()")
+		local result = dostring[[
+			lunatik = lunatik or require("lunatik")
+			lunatik.runner = lunatik.runner or require("lunatik.runner")
+			lunatik.runner.shutdown()
+		]]
+		if result ~= "" then error(result) end
 	end
 	for i = #modules, 1, -1 do
 		sh("rmmod $MODULE", modules[i], true)

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -95,7 +95,9 @@ end
 
 --- Shuts down all running scripts and their threads.
 -- Iterates over `env.runtimes` and calls `runner.stop` for each script.
+-- A no-op if `startup` was never called.
 function runner.shutdown()
+	if not env.runtimes then return end
 	rcu.map(env.runtimes, function (script)
 		runner.stop(script)
 	end)


### PR DESCRIPTION
## Root cause

In the kernel, `require()` resolves `luaopen_*` via `__symbol_get()` (`lunatik_conf.h`), which takes a reference on the module that exports it. The reference is only dropped by `symbol_put_addr()` when the runtime's `lua_close()` collects the CLIBS library strings — i.e. **every live runtime pins the modules it required**. The driver runtime pins `luadevice` and `luathread` until `rmmod lunatik_run` (first in unload order) closes it.

After a clean `runner.shutdown()`, everything lunatik owns is torn down synchronously. From that point the only things that can make `rmmod` fail are external: a process still holding a lunatik chardev open (pins `luadevice` via `fops.owner` until the fd closes) or a wrong module ordering in a downstream build. `delete_module(2)` never blocks waiting for references — verified on v5.4 and v6.8: it returns `-EWOULDBLOCK` immediately — so there is nothing to wait on; the failure has to be reported.

`unload_modules()` did the opposite: it discarded the `runner.shutdown()` result and ignored every `rmmod` status, producing a silent partial unload (exit 0) where `lsmod` shows lunatik still loaded with fewer users — the symptom reported in #624. Reproduced exactly by holding `/dev/lunatik` open during `lunatik unload`.

## Fix

- `runner.shutdown()` becomes a no-op before `startup()`, mirroring the `startup()` guard, so it is safe to call from any state;
- `unload` loads the runner idempotently (as `ensure_loaded` does) and fails if `shutdown()` errors — a runtime left running means pinned modules;
- each `rmmod` is checked and the unload aborts naming the first module that can't be removed (`couldn't unload luadevice`), with nonzero exit status; absent modules are skipped by checking `/sys/module/<name>/initstate`, so unload also recovers a partially loaded state.

This replaces the retry loop proposed in #624: the kernel refuses to remove a referenced module no matter how many times it is asked, and that proposal's refcount pre-check skipped pinned modules silently, turning a loud failure into a silent one. If a deployment needs to absorb the window where its own client is still closing the device, that wait belongs in the caller that knows the holder is transient, not in every unload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
