### PR TITLE
Simplify task ownership inside luasched

### DIFF
--- a/examples/workload/workload.lua
+++ b/examples/workload/workload.lua
@@ -24,13 +24,13 @@ local function workload(ctx)
 	for _, rule in ipairs(policy) do
 		if task:comm():match(rule.pattern) then
 			ctx:dsq(rule.dsq)
-			ctx:slice_ns(rule.slice)
+			ctx:slice(rule.slice)
 			log(task:comm(), rule.dsq, rule.slice)
 			return
 		end
 	end
 	ctx:dsq(DEFAULT)
-	ctx:slice_ns(scx.SLICE_DFL)
+	ctx:slice(scx.SLICE_DFL)
 end
 
 sched.attach(workload)

--- a/lib/luasched.c
+++ b/lib/luasched.c
@@ -39,8 +39,7 @@ static lunatik_object_t *luasched_runtimes = NULL;
 typedef struct luasched_ctx_s {
 	struct task_struct *task;
 	int                *dsq;
-	int                *slice_ns;
-	lunatik_object_t   *task_obj;
+	u64                *slice_ns;
 	int                callback_ref;
 } luasched_ctx_t;
 
@@ -56,7 +55,8 @@ LUNATIK_PRIVATECHECKER(luasched_ctx_check, luasched_ctx_t *,
 static int luasched_task(lua_State *L)
 {
 	luasched_ctx_t *ctx = luasched_ctx_check(L, 1);
-	lunatik_getregistry(L, ctx->task_obj);
+	lunatik_object_t *task = luatask_new(L, ctx->task);
+	lunatik_pushobject(L, task);
 	return 1;
 }
 
@@ -99,7 +99,6 @@ static void luasched_release(void *private)
 		put_task_struct(lctx->task);
 		lctx->task = NULL;
 	}
-	lctx->task_obj = NULL;
 }
 
 LUNATIK_OPENER(sched);
@@ -108,14 +107,13 @@ static const lunatik_class_t luasched_class = {
 	.methods = luasched_mt,
 	.release = luasched_release,
 	.opener  = luaopen_sched,
-	.opt     = LUNATIK_OPT_HARDIRQ | LUNATIK_OPT_SINGLE,
+	.opt     = LUNATIK_OPT_HARDIRQ,
 };
 
 static void luasched_handler_cleanup(luasched_ctx_t *lctx)
 {
 	put_task_struct(lctx->task);
 	lctx->task = NULL;
-	lctx->task_obj->private = NULL;
 	lctx->dsq = NULL;
 	lctx->slice_ns = NULL;
 }
@@ -129,7 +127,6 @@ static int luasched_handler(lua_State *L, luasched_ctx_t *ctx)
 	lctx->task = ctx->task;
 	lctx->dsq      = ctx->dsq;
 	lctx->slice_ns = ctx->slice_ns;
-	lctx->task_obj->private = ctx->task;
 
 	lua_rawgeti(L, LUA_REGISTRYINDEX, lctx->callback_ref);
 	if (!lua_isfunction(L, -1)) {
@@ -159,7 +156,7 @@ struct task_class {
 __bpf_kfunc int bpf_luasched_run(char *key, size_t key__sz, struct task_struct *task, struct task_class *cls)
 {
 	int dsq = -1;
-	int slice_ns = -1;
+	u64 slice_ns = -1;
 
 	if (!cls)
 		return -EINVAL;
@@ -258,11 +255,6 @@ static int luasched_attach(lua_State *L)
 
 	lunatik_object_t *object = lunatik_newobject(L, &luasched_class, sizeof(luasched_ctx_t), LUNATIK_OPT_NONE);
 	luasched_ctx_t *ctx = (luasched_ctx_t *)object->private;
-
-	ctx->task_obj = luatask_new(L, NULL);
-	lunatik_pushobject(L, ctx->task_obj);
-	lunatik_register(L, -1, ctx->task_obj);
-	lua_pop(L, 1);
 
 	lua_pushvalue(L, 1);
 	ctx->callback_ref = luaL_ref(L, LUA_REGISTRYINDEX);

--- a/lib/luasched.c
+++ b/lib/luasched.c
@@ -85,10 +85,10 @@ static int luasched_slice_ns(lua_State *L)
 }
 
 static const luaL_Reg luasched_mt[] = {
-	{"__gc",		lunatik_deleteobject},
-	{"task",		luasched_task},
-	{"dsq",			luasched_dsq},
-	{"slice_ns",	luasched_slice_ns},
+	{"__gc",	lunatik_deleteobject},
+	{"task",	luasched_task},
+	{"dsq",		luasched_dsq},
+	{"slice",	luasched_slice_ns},
 	{NULL, NULL}
 };
 
@@ -236,7 +236,7 @@ static int luasched_detach(lua_State *L)
 *     local task = ctx:task()
 *     if task:comm() == "bash" then
 *       ctx:dsq(sched_ext.LOCAL)
-*       ctx:slice_ns(sched_ext.BYPASS)
+*       ctx:slice(sched_ext.BYPASS)
 *     end
 *     return nil
 *   end

--- a/lib/luatask.c
+++ b/lib/luatask.c
@@ -142,10 +142,10 @@ static const lunatik_class_t luatask_class = {
 lunatik_object_t *luatask_new(lua_State *L, struct task_struct *task)
 {
 	lunatik_require(L, &luatask_class);
+	if (!task)
+		return NULL;
 	lunatik_object_t *object = lunatik_newobject(L, &luatask_class, sizeof(struct task_struct *), LUNATIK_OPT_NONE);
-	if (task != NULL) {
-		get_task_struct(task);
-	}
+	get_task_struct(task);
 	object->private = task;
 	lunatik_getobject(object);
 	lua_pop(L, 1);


### PR DESCRIPTION
Allocate a new task whenever `bpf_luasched_run` is invoked