### PR TITLE
Kconfig: say multicast, matching the channel method rename

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -58,7 +58,7 @@ config LUNATIK_NETLINK
 	default m
 	help
 	  Generic netlink channel (netlink.channel) for softirq-safe
-	  kernel-to-userspace delivery (broadcast and unicast) from Lua scripts.
+	  kernel-to-userspace delivery (multicast and unicast) from Lua scripts.
 
 config LUNATIK_RCU
 	tristate "Lunatik RCU Support"


### PR DESCRIPTION
Leftover from #620: the LUNATIK_NETLINK help text still said broadcast, but the channel methods are `multicast`/`unicast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)