### PR TITLE
netlink: move the u32 and str attribute decoders into message

### DIFF
--- a/lib/netlink/message.lua
+++ b/lib/netlink/message.lua
@@ -14,7 +14,7 @@ local nl     = require("linux.netlink")
 local struct = require("struct")
 
 local insert, concat = table.insert, table.concat
-local pack, rep      = string.pack, string.rep
+local pack, unpack, rep = string.pack, string.unpack, string.rep
 
 local message = {}
 
@@ -102,6 +102,22 @@ end
 -- @treturn string|table the serialized attributes, or the parsed table.
 function message.attrs(attrs, pos)
 	return type(attrs) == "string" and parse_attrs(attrs, pos) or encode_attrs(attrs)
+end
+
+---
+-- Decodes a `u32` attribute value.
+-- @tparam[opt] string value raw attribute payload; `nil` is passed through.
+-- @treturn integer|nil the decoded integer.
+function message.u32(value)
+	return value and unpack(U32, value)
+end
+
+---
+-- Decodes a NUL-terminated string attribute value.
+-- @tparam[opt] string value raw attribute payload; `nil` is passed through.
+-- @treturn string|nil the decoded string.
+function message.str(value)
+	return value and unpack("z", value)
 end
 
 return message

--- a/lib/netlink/rt.lua
+++ b/lib/netlink/rt.lua
@@ -23,7 +23,7 @@ local rtnl = require("linux.rtnetlink")
 local sk   = require("linux.socket")
 
 local insert = table.insert
-local unpack = string.unpack
+local u32, str = message.u32, message.str
 
 local rtmsg     = struct(rtnl.layout.rtmsg)
 local RTMSG_LEN = rtmsg.size
@@ -42,16 +42,6 @@ end
 local RTM_TABLE_MAX = (1 << 8 * fieldsize(rtnl.layout.rtmsg, "rtm_table")) - 1
 
 local NEWROUTE, NEWLINK, NEWADDR = rtnl.rtm.NEWROUTE, rtnl.rtm.NEWLINK, rtnl.rtm.NEWADDR
-
-local U32 = "=I4"
-
-local function u32(value)
-	return value and unpack(U32, value)
-end
-
-local function str(value)
-	return value and unpack("z", value)
-end
 
 ---
 -- @type rt


### PR DESCRIPTION
`rt` and the incoming `nl80211` (#617) each define the same nil-passing `u32`/`str` attribute decoders (19 call sites between them). `message` is the wire codec, so decoding attribute values belongs there: `message.u32(value)` / `message.str(value)`, nil passed through. `rt` adopts them via local aliases — zero call-site churn. #617 stacks on this and drops its copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)