### PR TITLE
feat: add pull request template to project repository

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Description
+
+<!-- What does this PR change and why? -->
+
+## Related issue
+
+<!-- e.g. "Fixes #123" or "Related to #123"; leave blank if none -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature (e.g. new Lua API, kernel binding, or module)
+- [ ] Breaking change (existing API/behavior changes in an incompatible way)
+- [ ] Documentation (README, LDoc, `doc/`)
+- [ ] Build / CI (Makefile, Kconfig, Kbuild, `.github/workflows`)
+- [ ] Refactor / cleanup (no functional change)
+
+## Affected component(s)
+
+<!-- e.g. lib/netlink, lib/socket, autogen, tests/, C API (lunatik.h), driver.lua, bin/lunatik -->
+
+## Kernel version(s) tested against
+
+<!-- e.g. 5.15, 6.12 -->
+
+## Testing
+
+<!-- What did you run, and what was the result? Paste relevant KTAP output if useful. -->
+
+## Checklist
+
+- [ ] Tested this patch (e.g. `sudo lunatik test` or the relevant suite under `tests/`)
+- [ ] Checked the code style (tabs for indentation, per `.editorconfig`, matching the Linux kernel style used in this codebase)
+- [ ] Updated documentation (LDoc comments, `README.md`, `doc/capi.md`) where relevant
+- [ ] Said if AI was used to write this patch, and checked the code by hand


### PR DESCRIPTION
Fix: #448 
Adds .github/PULL_REQUEST_TEMPLATE.md so GitHub auto-fills new PR descriptions with a consistent structure.
No functional/code changes — repo config only.

@lneto please check