### PR TITLE
bpf: add bpf.map, a high-level layer over maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ scripts_install:
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/netlink/nl80211
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/syscall
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/crypto
+	${MKDIR} ${SCRIPTS_INSTALL_PATH}/bpf
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/linux
 	${MKDIR} ${LUA_PATH}/lunatik
 	${INSTALL} -m 0644 driver.lua ${SCRIPTS_INSTALL_PATH}/
@@ -102,6 +103,7 @@ scripts_install:
 	${INSTALL} -m 0644 lib/netlink/nl80211/*.lua ${SCRIPTS_INSTALL_PATH}/netlink/nl80211
 	${INSTALL} -m 0644 lib/syscall/*.lua ${SCRIPTS_INSTALL_PATH}/syscall
 	${INSTALL} -m 0644 lib/crypto/*.lua ${SCRIPTS_INSTALL_PATH}/crypto
+	${INSTALL} -m 0644 lib/bpf/*.lua ${SCRIPTS_INSTALL_PATH}/bpf
 	# NOTE: `lib/linux/` exists only as LDoc stubs (see doc-stubs); never install it.
 	${INSTALL} -m 0644 autogen/linux/*.lua ${SCRIPTS_INSTALL_PATH}/linux
 	${INSTALL} -m 0644 autogen/lunatik/*.lua ${SCRIPTS_INSTALL_PATH}/lunatik
@@ -122,6 +124,7 @@ scripts_uninstall:
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/netlink
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/syscall
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/crypto
+	${RM} -r ${SCRIPTS_INSTALL_PATH}/bpf
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/linux
 	${RM} ${LUNATIK_INSTALL_PATH}/lunatik
 	${RM} -r ${LUA_PATH}/lunatik

--- a/config.ld
+++ b/config.ld
@@ -14,6 +14,7 @@ title = 'Lunatik API Documentation'
 -- By manually specifying order, we ensure menu order.
 file = {
 	'./lib/luabpf.c',
+	'./lib/bpf/map.lua',
 	'./lib/luabyteorder.c',
 	'./lib/luacompletion.c',
 	'./lib/luacpu.c',

--- a/lib/bpf/map.lua
+++ b/lib/bpf/map.lua
@@ -1,0 +1,309 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+---
+-- High-level view over pinned eBPF maps.
+-- Each constructor mirrors the one in `bpf`, taking the packing spec of what
+-- the map holds. Key-value maps become table proxies: indexing looks values
+-- up, assignment updates, assigning `nil` deletes, and `pairs` iterates.
+-- Keyless maps become objects, with `push`, `pop` and `peek`.
+--
+-- Keys and values are opaque fixed-size buffers to eBPF. A spec is either a
+-- `string.pack` format (e.g. `"I4"`, `"c6"`) or a `struct` codec, and says both
+-- how many bytes it takes, validated against the map on open, and how to read
+-- them. Specs that pack a single value take and return it as a scalar;
+-- multi-value formats and `struct` codecs take and return an array of values,
+-- in field order.
+--
+-- Operations on a table proxy come from outside it (`close` and `info` are
+-- module functions, as in Lua's `table` library or `rcu.map`), so any key the
+-- spec can encode is a valid map key.
+--
+-- Conditional updates (`BPF_NOEXIST`/`BPF_EXIST`) and the boolean results
+-- belong to the raw API.
+-- @module bpf.map
+-- @see bpf
+-- @usage
+-- local map = require("bpf.map")
+--
+-- local counters <close> = map.hash("/sys/fs/bpf/counters", "I4", "I4")
+-- counters[1] = 42
+-- print(counters[1])
+-- counters[1] = nil                 -- delete
+-- for key, value in pairs(counters) do print(key, value) end
+--
+-- local events <close> = map.queue("/sys/fs/bpf/events", "I8")
+-- events:push(1234)
+-- print(events:pop())
+
+local bpf   = require("bpf")
+local class = require("class")
+
+local pack, unpack, packsize = string.pack, string.unpack, string.packsize
+local tabunpack              = table.unpack
+
+local function collect(...)
+	local values = {...}
+	values[#values] = nil
+	return values
+end
+
+local scalar = class{}
+
+function scalar:encode(value)
+	return pack(self.format, value)
+end
+
+function scalar:decode(buffer)
+	return (unpack(self.format, buffer))
+end
+
+local array = class{}
+
+function array:encode(values)
+	return pack(self.format, tabunpack(values))
+end
+
+function array:decode(buffer)
+	return collect(unpack(self.format, buffer))
+end
+
+local record = class{}
+
+function record:encode(values)
+	return self.struct:pack(tabunpack(values))
+end
+
+function record:decode(buffer)
+	return collect(self.struct:unpack(buffer))
+end
+
+local function isscalar(format, size)
+	return select("#", unpack(format, ("\0"):rep(size))) == 2
+end
+
+local codecs = {}
+
+function codecs.string(format)
+	local size = packsize(format)
+	local codec = isscalar(format, size) and scalar or array
+	return codec:new{format = format, size = size}
+end
+
+function codecs.table(struct)
+	if struct.pack == nil or struct.size == nil then
+		return nil
+	end
+	return record:new{struct = struct, size = struct.size}
+end
+
+local function newcodec(spec, what, expected)
+	local new = codecs[type(spec)]
+	local codec = new and new(spec)
+	if codec == nil then
+		error("invalid " .. what .. " spec")
+	end
+	if codec.size ~= expected then
+		error(("%s spec packs %d bytes, map expects %d"):format(what, codec.size, expected))
+	end
+	return codec
+end
+
+local function decode(codec, raw)
+	if raw == nil then
+		return nil
+	end
+	return codec:decode(raw)
+end
+
+local map_queue = class{}
+
+local states = setmetatable({}, {__mode = "k"})
+
+local map = {}
+
+local function iterate(proxy, key)
+	local state = states[proxy]
+	local rawkey = state.map:next(key ~= nil and state.key:encode(key) or nil)
+	if rawkey == nil then
+		return nil
+	end
+	return state.key:decode(rawkey), decode(state.value, state.map:lookup(rawkey))
+end
+
+---
+-- Releases the map reference.
+-- Also wired as the proxy's `__close` metamethod.
+-- @function close
+-- @tparam map_hash proxy the table proxy
+function map.close(proxy)
+	states[proxy].map:close()
+end
+
+---
+-- Returns the map properties, as `bpf` map `info`.
+-- @function info
+-- @tparam map_hash proxy the table proxy
+-- @treturn table `type`, `key_size`, `value_size` and `max_entries`
+function map.info(proxy)
+	return states[proxy].map:info()
+end
+
+local view = {__close = map.close}
+
+function view.__index(proxy, key)
+	local state = states[proxy]
+	return decode(state.value, state.map:lookup(state.key:encode(key)))
+end
+
+function view.__newindex(proxy, key, value)
+	local state = states[proxy]
+	local rawkey = state.key:encode(key)
+	if value == nil then
+		state.map:delete(rawkey)
+	else
+		state.map:update(rawkey, state.value:encode(value))
+	end
+end
+
+function view.__pairs(proxy)
+	return iterate, proxy, nil
+end
+
+local function openproxy(open, pathname, keyspec, valuespec)
+	local handle = open(pathname)
+	local info = handle:info()
+	local proxy = setmetatable({}, view)
+	states[proxy] = {
+		map = handle,
+		key = newcodec(keyspec, "key", info.key_size),
+		value = newcodec(valuespec, "value", info.value_size),
+	}
+	return proxy
+end
+
+local function openqueue(open, pathname, valuespec)
+	local handle = open(pathname)
+	local info = handle:info()
+	return map_queue:new{map = handle, value = newcodec(valuespec, "value", info.value_size)}
+end
+
+---
+-- Opens a pinned hash map as a table.
+-- @function hash
+-- @tparam string pathname Path to the pinned map.
+-- @tparam string|table keyspec `string.pack` format or `struct` codec for the key.
+-- @tparam string|table valuespec `string.pack` format or `struct` codec for the value.
+-- @treturn map_hash the table proxy
+-- @raise Error if the map cannot be opened or a spec does not match its sizes.
+function map.hash(pathname, keyspec, valuespec)
+	return openproxy(bpf.hash, pathname, keyspec, valuespec)
+end
+
+---
+-- Opens a pinned array map as a table.
+-- Keys are the `u32` indices of the array.
+-- @function array
+-- @tparam string pathname Path to the pinned map.
+-- @tparam string|table keyspec `string.pack` format or `struct` codec for the key.
+-- @tparam string|table valuespec `string.pack` format or `struct` codec for the value.
+-- @treturn map_hash the table proxy
+-- @raise Error if the map cannot be opened or a spec does not match its sizes.
+function map.array(pathname, keyspec, valuespec)
+	return openproxy(bpf.array, pathname, keyspec, valuespec)
+end
+
+---
+-- Opens a pinned LRU hash map as a table.
+-- @function lru_hash
+-- @tparam string pathname Path to the pinned map.
+-- @tparam string|table keyspec `string.pack` format or `struct` codec for the key.
+-- @tparam string|table valuespec `string.pack` format or `struct` codec for the value.
+-- @treturn map_hash the table proxy
+-- @raise Error if the map cannot be opened or a spec does not match its sizes.
+function map.lru_hash(pathname, keyspec, valuespec)
+	return openproxy(bpf.lru_hash, pathname, keyspec, valuespec)
+end
+
+---
+-- Opens a pinned queue map (FIFO).
+-- @function queue
+-- @tparam string pathname Path to the pinned map.
+-- @tparam string|table valuespec `string.pack` format or `struct` codec for the value.
+-- @treturn map_queue the map object
+-- @raise Error if the map cannot be opened or the spec does not match its value size.
+function map.queue(pathname, valuespec)
+	return openqueue(bpf.queue, pathname, valuespec)
+end
+
+---
+-- Opens a pinned stack map (LIFO).
+-- @function stack
+-- @tparam string pathname Path to the pinned map.
+-- @tparam string|table valuespec `string.pack` format or `struct` codec for the value.
+-- @treturn map_queue the map object
+-- @raise Error if the map cannot be opened or the spec does not match its value size.
+function map.stack(pathname, valuespec)
+	return openqueue(bpf.stack, pathname, valuespec)
+end
+
+---
+-- Table view over a key-value map, as returned by `hash`, `array` and
+-- `lru_hash`. It has no methods, so any key the spec can encode is a valid
+-- map key: indexing looks values up, assignment updates, assigning `nil`
+-- deletes, `pairs` iterates, and closing the variable (`<close>`) releases
+-- the map. `close` and `info` are module functions.
+-- @type map_hash
+
+---
+-- Keyless map object, as returned by `queue` and `stack`.
+-- @type map_queue
+
+---
+-- Inserts a value.
+-- @function map_queue:push
+-- @param value the value to insert, as the spec encodes it
+-- @treturn boolean `false` if the map is full, `true` otherwise
+-- @raise Error if the operation fails.
+function map_queue:push(value)
+	return self.map:push(self.value:encode(value))
+end
+
+---
+-- Removes and returns the next value.
+-- @function map_queue:pop
+-- @return the value, or `nil` if the map is empty
+-- @raise Error if the operation fails.
+function map_queue:pop()
+	return decode(self.value, self.map:pop())
+end
+
+---
+-- Returns the next value, leaving it in the map.
+-- @function map_queue:peek
+-- @return the value, or `nil` if the map is empty
+-- @raise Error if the operation fails.
+function map_queue:peek()
+	return decode(self.value, self.map:peek())
+end
+
+---
+-- Returns the map properties, as `bpf` map `info`.
+-- @function map_queue:info
+-- @treturn table `type`, `key_size`, `value_size` and `max_entries`
+function map_queue:info()
+	return self.map:info()
+end
+
+---
+-- Releases the map reference.
+-- Also wired as the object's `__close` metamethod.
+-- @function map_queue:close
+function map_queue:close()
+	self.map:close()
+end
+
+return map
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -54,6 +54,12 @@ Tests for the `bpf` module (pinned eBPF map access). Requires
   push flags, the absence of key-value methods on the handle, the
   cross-type constructor rejection and metadata with `key_size` 0.
 - **stack**: the same for LIFO stack maps.
+- **map**: the `bpf.map` layer — scalar, multi-value and `struct` codec
+  specs, the table proxy (assignment, `nil` delete, `pairs`, `<close>`
+  and function-named keys as plain map keys) over hash, array and
+  lru_hash, the queue and stack objects (`push`/`pop`/`peek`, FIFO and
+  LIFO order, empty `nil`, full `false`, `info`), spec size validation
+  and the cross-type rejection.
 - **map_softirq**: opens and exercises the hash map while loading a
   softirq runtime (atomic-context allocator path).
 - The harness also cross-checks a Lua-written value with

--- a/tests/bpf/map.lua
+++ b/tests/bpf/map.lua
@@ -1,0 +1,201 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the bpf.map layer test (see run.sh).
+
+local map = require("bpf.map")
+local struct = require("struct")
+local bpf = require("linux.bpf")
+local test = require("util").test
+
+local tbl_path   = "/sys/fs/bpf/test_map_tbl"
+local map_path   = "/sys/fs/bpf/test_map"
+local array_path = "/sys/fs/bpf/test_map_array"
+local lru_path   = "/sys/fs/bpf/test_map_lru"
+local queue_path = "/sys/fs/bpf/test_map_queue"
+local stack_path = "/sys/fs/bpf/test_map_stack"
+
+local function drain(m)
+	while m:pop() do
+	end
+end
+
+test("bpf.map hash scalar integer round-trip", function()
+	local t <close> = map.hash(tbl_path, "I4", "I4")
+	t[1] = 42
+	assert(t[1] == 42, "expected 42, got: " .. tostring(t[1]))
+	t[1] = nil
+	assert(t[1] == nil, "expected nil after delete")
+end)
+
+test("bpf.map hash byte-string keys read the seeded map", function()
+	local t <close> = map.hash(map_path, "c3", "c3")
+	assert(t.foo == "bar", "expected seeded 'bar', got: " .. tostring(t.foo))
+	assert(t.zzz == nil, "expected nil for missing key")
+end)
+
+test("bpf.map function-named keys are plain map keys", function()
+	local t <close> = map.hash(tbl_path, "c4", "I4")
+	t.info = 7
+	t.clos = 9
+	assert(t.info == 7, "expected 7, got: " .. tostring(t.info))
+	assert(t.clos == 9, "expected 9, got: " .. tostring(t.clos))
+	t.info = nil
+	t.clos = nil
+	assert(t.info == nil, "expected nil after delete")
+end)
+
+test("bpf.map nil delete of missing key is a no-op", function()
+	local t <close> = map.hash(tbl_path, "I4", "I4")
+	t[99] = nil
+end)
+
+test("bpf.map multi-value format uses arrays", function()
+	local t <close> = map.hash(tbl_path, "I4", "I2I2")
+	t[2] = {258, 772}
+	local v = t[2]
+	assert(v[1] == 258 and v[2] == 772, "expected {258, 772}")
+	t[2] = nil
+end)
+
+test("bpf.map struct codec value", function()
+	local codec = struct({size = 4, fields = {{name = "v", offset = 0, size = 4}}})
+	local t <close> = map.hash(tbl_path, "I4", codec)
+	t[3] = {42}
+	local v = t[3]
+	assert(v[1] == 42, "expected {42}")
+	t[3] = nil
+end)
+
+test("bpf.map pairs iterates decoded entries", function()
+	local t <close> = map.hash(tbl_path, "I4", "I4")
+	t[10] = 100
+	t[20] = 200
+	local seen = {}
+	for k, v in pairs(t) do
+		seen[k] = v
+	end
+	assert(seen[10] == 100 and seen[20] == 200, "expected decoded pairs")
+	t[10] = nil
+	t[20] = nil
+end)
+
+test("bpf.map array indexes by position", function()
+	local t <close> = map.array(array_path, "I4", "I4")
+	t[0] = 11
+	assert(t[0] == 11, "expected 11, got: " .. tostring(t[0]))
+	t[0] = 0
+end)
+
+test("bpf.map lru_hash round-trip", function()
+	local t <close> = map.lru_hash(lru_path, "c3", "c3")
+	t.abc = "xyz"
+	assert(t.abc == "xyz", "expected 'xyz', got: " .. tostring(t.abc))
+	t.abc = nil
+	assert(t.abc == nil, "expected nil after delete")
+end)
+
+test("bpf.map rejects mismatched specs", function()
+	assert(not pcall(map.hash, tbl_path, "I2", "I4"), "expected key size mismatch error")
+	assert(not pcall(map.hash, tbl_path, "I4", "I8"), "expected value size mismatch error")
+	assert(not pcall(map.hash, tbl_path, "I4"), "expected invalid value spec error")
+	assert(not pcall(map.hash, tbl_path, "I4", {}), "expected invalid table spec error")
+	assert(not pcall(map.queue, queue_path, "I4"), "expected value size mismatch error")
+end)
+
+test("bpf.map rejects other map types", function()
+	assert(not pcall(map.hash, queue_path, "I4", "c3"), "expected error on queue map")
+	assert(not pcall(map.queue, tbl_path, "I4"), "expected error on hash map")
+end)
+
+test("bpf.map functions raise after close", function()
+	local t = map.hash(tbl_path, "I4", "I4")
+	map.close(t)
+	assert(not pcall(map.info, t), "expected error after close")
+end)
+
+test("bpf.map closes the proxy on scope exit", function()
+	local escaped
+	do
+		local t <close> = map.hash(tbl_path, "I4", "I4")
+		escaped = t
+	end
+	assert(not pcall(map.info, escaped), "expected the proxy to be closed on scope exit")
+end)
+
+test("bpf.map queue pops in FIFO order", function()
+	local q <close> = map.queue(queue_path, "c3")
+	drain(q)
+	assert(q:push("foo"))
+	assert(q:push("bar"))
+	assert(q:pop() == "foo", "expected first pushed value")
+	assert(q:pop() == "bar", "expected second pushed value")
+end)
+
+test("bpf.map stack pops in LIFO order", function()
+	local s <close> = map.stack(stack_path, "c3")
+	drain(s)
+	assert(s:push("foo"))
+	assert(s:push("bar"))
+	assert(s:pop() == "bar", "expected last pushed value")
+	assert(s:pop() == "foo", "expected first pushed value")
+end)
+
+test("bpf.map queue peek does not remove the value", function()
+	local q <close> = map.queue(queue_path, "c3")
+	drain(q)
+	assert(q:push("foo"))
+	assert(q:peek() == "foo")
+	assert(q:peek() == "foo")
+	drain(q)
+end)
+
+test("bpf.map queue pop and peek on empty return nil", function()
+	local q <close> = map.queue(queue_path, "c3")
+	drain(q)
+	assert(q:pop() == nil, "expected nil from empty queue")
+	assert(q:peek() == nil, "expected nil from empty queue")
+end)
+
+test("bpf.map queue push on a full map returns false", function()
+	local q <close> = map.queue(queue_path, "c3")
+	drain(q)
+	for _ = 1, q:info().max_entries do
+		assert(q:push("xyz"))
+	end
+	assert(q:push("ovr") == false, "expected false when the map is full")
+	drain(q)
+end)
+
+test("bpf.map queue values follow the spec", function()
+	local q <close> = map.queue(queue_path, "I1I2")
+	drain(q)
+	assert(q:push({7, 258}))
+	local v = q:pop()
+	assert(v[1] == 7 and v[2] == 258, "expected {7, 258}")
+end)
+
+test("bpf.map queue info reports map properties", function()
+	local q <close> = map.queue(queue_path, "c3")
+	local info = q:info()
+	assert(info.type == bpf.MAP_TYPE_QUEUE, "expected queue map type")
+	assert(info.value_size == 3, "expected value_size 3")
+	assert(info.max_entries == 128, "expected max_entries 128")
+end)
+
+test("bpf.map queue methods raise after close", function()
+	local q = map.queue(queue_path, "c3")
+	q:close()
+	assert(not pcall(q.info, q), "expected error after close")
+end)
+
+test("bpf.map closes the queue object on scope exit", function()
+	local escaped
+	do
+		local q <close> = map.queue(queue_path, "c3")
+		escaped = q
+	end
+	assert(not pcall(escaped.info, escaped), "expected the object to be closed on scope exit")
+end)
+

--- a/tests/bpf/run.sh
+++ b/tests/bpf/run.sh
@@ -5,11 +5,11 @@
 #
 # Runs all bpf tests and reports aggregated KTAP results.
 #
-# Creates pinned maps with bpftool (hash, array, lru_hash, queue, stack and
-# a percpu hash for the unsupported-type check), seeds the hash map, then
-# exercises the bpf module API from kernel Lua scripts: per-type coverage
-# in process context, a softirq-runtime script, and a Lua-to-bpftool
-# interop check.
+# Creates pinned maps with bpftool (hash, array, lru_hash, queue, stack, a
+# second hash for the bpf.map layer and a percpu hash for the unsupported-type
+# check), seeds the first hash map, then exercises the bpf module API and the
+# bpf.map layer from kernel Lua scripts: per-type coverage in process context,
+# a softirq-runtime script, and a Lua-to-bpftool interop check.
 #
 # Usage: sudo bash tests/bpf/run.sh
 
@@ -21,6 +21,7 @@ BPF_FS=/sys/fs/bpf
 MAP=$BPF_FS/test_map
 ARRAY_MAP=$BPF_FS/test_map_array
 LRU_MAP=$BPF_FS/test_map_lru
+TBL_MAP=$BPF_FS/test_map_tbl
 PERCPU_MAP=$BPF_FS/test_map_percpu
 QUEUE_MAP=$BPF_FS/test_map_queue
 STACK_MAP=$BPF_FS/test_map_stack
@@ -35,7 +36,7 @@ create_map() { bpftool map create "$@" > /dev/null || skip "bpf: cannot create p
 cleanup()
 {
 	lunatik stop "$SOFTIRQ_SCRIPT" 2>/dev/null
-	rm -f "$MAP" "$ARRAY_MAP" "$LRU_MAP" "$PERCPU_MAP" "$QUEUE_MAP" "$STACK_MAP"
+	rm -f "$MAP" "$ARRAY_MAP" "$LRU_MAP" "$TBL_MAP" "$PERCPU_MAP" "$QUEUE_MAP" "$STACK_MAP"
 }
 
 trap cleanup EXIT
@@ -49,13 +50,14 @@ fi
 create_map "$MAP" type hash key 3 value 3 entries 128 name test_map
 create_map "$ARRAY_MAP" type array key 4 value 4 entries 4 name test_array
 create_map "$LRU_MAP" type lru_hash key 3 value 3 entries 128 name test_lru
+create_map "$TBL_MAP" type hash key 4 value 4 entries 16 name test_tbl
 create_map "$PERCPU_MAP" type percpu_hash key 3 value 3 entries 128 name test_percpu
 create_map "$QUEUE_MAP" type queue key 0 value 3 entries 128 name test_queue
 create_map "$STACK_MAP" type stack key 0 value 3 entries 128 name test_stack
 
 bpftool map update pinned "$MAP" key hex 66 6f 6f value hex 62 61 72 || skip "bpf: cannot seed the pinned map"
 
-TESTS="map_values array lru queue stack"
+TESTS="map_values array lru queue stack map"
 TOTAL=$(($(echo $TESTS | wc -w) + 2))
 
 ktap_header


### PR DESCRIPTION
A Lua-level view over pinned maps, on top of the typed constructors from #636. It mirrors them one for one, taking the packing spec of what the map holds:

```lua
local map = require("bpf.map")

local counters <close> = map.hash("/sys/fs/bpf/counters", "I4", "I4")
counters[1] = 42
counters[1] = nil                 -- delete
for key, value in pairs(counters) do print(key, value) end

local events <close> = map.queue("/sys/fs/bpf/events", "I8")
events:push(1234)
print(events:pop())
```

Two shapes, because the map kind decides who owns the name space. In a key-value map the key is the user's, so a proxy driven by `__index`/`__newindex` cannot carry methods: `t:close()` would be a lookup of the key `"close"`. Operations come from outside, as in Lua's own `table` library and as `rcu.map` already does for `rcu.table`. A queue or a stack has no key, nothing of the name space belongs to the user, and the natural form is the one `fifo` uses in the base: `q:push(v)`, `q:pop()`.

Specs are positional, in the order every eBPF API uses (`bpf_map_update_elem(map, key, value)`, `bpf_map_lookup_elem(map, key)`, `bpftool map update ... key ... value ...`), so a keyless map takes one spec and a keyed map takes two. A spec is a `string.pack` format (`"I4"`, `"c6"`, `"I2I2"`) or a `struct` codec: it says how many bytes, validated against `key_size` and `value_size` on open, and how to read them. Single-value formats take and return scalars; multi-value formats and `struct` codecs take and return arrays, in field order.

No `__len`: the raw `#` is `max_entries`, which in a table proxy reads as the entry count and in a queue as the number queued. eBPF exposes no count, so the capacity stays where it has its uapi name, `info(t).max_entries`.

Conditional updates (`BPF_NOEXIST`/`BPF_EXIST`) and the boolean results stay in the raw API: `t[k] = v` has no return value to carry them.

Tests cover the three table kinds and both keyless kinds: scalar, multi-value and `struct` specs, assignment, `nil` delete, `pairs`, `<close>`, keys named after module functions, FIFO and LIFO order, empty `nil`, full `false`, `info`, spec size validation and the cross-type rejection. Verified on 6.8.0-124: bpf suite `pass:8 fail:0`, full suite `pass:72 fail:0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
