### PR TITLE
luabpf: add support for queue, stack maps

### DIFF
--- a/autogen/specs.lua
+++ b/autogen/specs.lua
@@ -39,7 +39,7 @@ return {
 	{ header = "uapi/linux/bpf.h",              prefix = "BPF_",       module = "bpf",
 		desc = "BPF map types and update flags.",
 		include = { "ANY", "NOEXIST", "EXIST",
-			"MAP_TYPE_HASH", "MAP_TYPE_ARRAY", "MAP_TYPE_LRU_HASH" } },
+			"MAP_TYPE_HASH", "MAP_TYPE_ARRAY", "MAP_TYPE_LRU_HASH", "MAP_TYPE_QUEUE", "MAP_TYPE_STACK" } },
 	{ header = "linux/sched.h",                 prefix = "TASK_",      module = "task",
 		desc = "Task state flags." },
 	{ header = "linux/net.h",                   prefix = "SOCK_",      module = "socket.sock",

--- a/lib/luabpf.c
+++ b/lib/luabpf.c
@@ -6,17 +6,24 @@
 /***
 * Lua interface to eBPF.
 *
-* This module provides generic key-value access to pinned eBPF maps,
-* supporting types that implement standard lookup, update, deletion,
-* and iteration operations:
+* This module provides access to pinned eBPF maps of two kinds:
+*
+* Key-value maps, via `lookup`, `update`, `delete`, `remove`, and `next`:
 *   - BPF_MAP_TYPE_HASH
 *   - BPF_MAP_TYPE_ARRAY
 *   - BPF_MAP_TYPE_LRU_HASH
 *
-* Other map types are rejected when opened.
+* Queue/stack maps, via `push`, `pop`, and `peek`:
+*   - BPF_MAP_TYPE_QUEUE (FIFO)
+*   - BPF_MAP_TYPE_STACK (LIFO)
+*
+* Other map types are rejected when opened. Calling an operation that a
+* map type does not implement (e.g. `lookup` on a queue) raises an
+* `EOPNOTSUPP` error.
 *
 * Keys and values are exchanged as packed Lua strings whose sizes must
-* match the map's configured key and value sizes.
+* match the map's configured key and value sizes. Queue/stack maps have
+* no keys, so only `value_size` applies to them.
 *
 * @module bpf
 */
@@ -32,7 +39,8 @@
 LUNATIK_PRIVATECHECKER(luabpf_map_check, struct bpf_map *);
 
 #define luabpf_map_issupported(type)	\
-	((type) == BPF_MAP_TYPE_HASH || (type) == BPF_MAP_TYPE_ARRAY || (type) == BPF_MAP_TYPE_LRU_HASH)
+	((type) == BPF_MAP_TYPE_HASH || (type) == BPF_MAP_TYPE_ARRAY || (type) == BPF_MAP_TYPE_LRU_HASH || \
+	 (type) == BPF_MAP_TYPE_QUEUE || (type) == BPF_MAP_TYPE_STACK)
 
 static const struct inode_operations *luabpf_map_iops;
 
@@ -234,6 +242,61 @@ static int luabpf_map_next(lua_State *L)
 }
 
 /***
+* Pushes a value onto a queue or stack map.
+* @function push
+* @tparam string value Packed value.
+* @tparam[opt=0] integer flags Update flags. `BPF_EXIST` may be set to
+* overwrite the oldest element once the map is full.
+* @treturn boolean success
+* @raise Error if the map does not support this operation (e.g. hash/array maps).
+*/
+static int luabpf_map_push(lua_State *L)
+{
+	struct bpf_map *map = luabpf_map_check(L, 1);
+	const char *value = luabpf_map_checkvalue(L, map, 2);
+	u64 flags = luaL_optinteger(L, 3, 0);
+
+	long ret;
+	luabpf_map_call(ret, map->ops->map_push_elem(map, (void *)value, flags));
+	return luabpf_map_pushresult(L, ret);
+}
+
+/***
+* Pops (removes and returns) the next value from a queue or stack map.
+* Queue maps pop in FIFO order; stack maps pop in LIFO order.
+* @function pop
+* @treturn string value Packed value, or `nil` if the map is empty.
+* @raise Error if the map does not support this operation (e.g. hash/array maps).
+*/
+static int luabpf_map_pop(lua_State *L)
+{
+	struct bpf_map *map = luabpf_map_check(L, 1);
+	luaL_Buffer B;
+	char *value = luaL_buffinitsize(L, &B, map->value_size);
+
+	long ret;
+	luabpf_map_call(ret, map->ops->map_pop_elem(map, value));
+	return luabpf_map_pushbuffer(L, &B, map->value_size, ret);
+}
+
+/***
+* Peeks at the next value of a queue or stack map without removing it.
+* @function peek
+* @treturn string value Packed value, or `nil` if the map is empty.
+* @raise Error if the map does not support this operation (e.g. hash/array maps).
+*/
+static int luabpf_map_peek(lua_State *L)
+{
+	struct bpf_map *map = luabpf_map_check(L, 1);
+	luaL_Buffer B;
+	char *value = luaL_buffinitsize(L, &B, map->value_size);
+
+	long ret;
+	luabpf_map_call(ret, map->ops->map_peek_elem(map, value));
+	return luabpf_map_pushbuffer(L, &B, map->value_size, ret);
+}
+
+/***
 * Returns the map properties.
 * @function info
 * @treturn table `type`, `key_size`, `value_size` and `max_entries`,
@@ -278,6 +341,9 @@ static const luaL_Reg luabpf_map_mt[] = {
 	{"delete",  luabpf_map_delete},
 	{"remove",  luabpf_map_remove},
 	{"next",    luabpf_map_next},
+	{"push",    luabpf_map_push},
+	{"pop",     luabpf_map_pop},
+	{"peek",    luabpf_map_peek},
 	{"info",    luabpf_map_info},
 	{"close",   lunatik_closeobject},
 	{"__len",   luabpf_map_len},
@@ -315,6 +381,13 @@ static const lunatik_class_t luabpf_map_class = {
 *   end
 *   counter:delete(key)
 *   counter:close()
+*
+*   -- Queue/stack maps have no keys; use push/pop/peek instead.
+*   local jobs = bpf.map("/sys/fs/bpf/job_queue")
+*   assert(jobs:push(string.pack("I4", 7)))
+*   local job = jobs:peek()          -- inspect without removing
+*   job = jobs:pop()                 -- remove and return
+*   jobs:close()
 * @within bpf
 */
 static int luabpf_map_open(lua_State *L)

--- a/tests/bpf/queue.lua
+++ b/tests/bpf/queue.lua
@@ -1,0 +1,111 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the bpf queue map test (see run.sh).
+
+local map = require("bpf").map
+local bpf = require("linux.bpf")
+local test = require("util").test
+
+local path = "/sys/fs/bpf/test_map_queue"
+
+local function drain(m)
+	while m:pop() do
+	end
+end
+
+test("bpf.map queue push and peek returns inserted value", function()
+	local m = map(path)
+	assert(m:push("foo"))
+	local value = m:peek()
+	assert(value == "foo", "expected 'foo', got: " .. tostring(value))
+	m:close()
+end)
+
+test("bpf.map queue peek does not remove value", function()
+	local m = map(path)
+	drain(m)
+	assert(m:push("foo"))
+	assert(m:peek() == "foo")
+	assert(m:peek() == "foo")
+	m:close()
+end)
+
+test("bpf.map queue pop removes values in FIFO order", function()
+	local m = map(path)
+	drain(m)
+	assert(m:push("foo"))
+	assert(m:push("bar"))
+	assert(m:push("baz"))
+	assert(m:pop() == "foo", "expected first pushed value")
+	assert(m:pop() == "bar", "expected second pushed value")
+	assert(m:pop() == "baz", "expected third pushed value")
+	m:close()
+end)
+
+test("bpf.map queue pop on empty queue returns nil", function()
+	local m = map(path)
+	drain(m)
+	assert(m:pop() == nil, "expected nil from empty queue")
+	m:close()
+end)
+
+test("bpf.map queue peek on empty queue returns nil", function()
+	local m = map(path)
+	drain(m)
+	assert(m:peek() == nil, "expected nil from empty queue")
+	m:close()
+end)
+
+test("bpf.map queue push full queue raises", function()
+	local m = map(path)
+	drain(m)
+	for i = 1, #m do
+		assert(m:push("xyz"))
+	end
+	assert(not pcall(m.push, m, "overflow"), "expected error when queue is full")
+	m:close()
+end)
+
+test("bpf.map queue lookup returns nil", function()
+	local m = map(path)
+	assert(m:lookup("") == nil, "expected nil: queue lookup unsupported")
+	m:close()
+end)
+
+test("bpf.map queue update raises", function()
+	local m = map(path)
+	assert(not pcall(m.update, m, "", "foo", bpf.ANY), "expected error: queue does not support update")
+	m:close()
+end)
+
+test("bpf.map queue delete raises", function()
+	local m = map(path)
+	assert(not pcall(m.delete, m, ""), "expected error: queue does not support delete")
+	m:close()
+end)
+
+test("bpf.map queue remove raises", function()
+	local m = map(path)
+	assert(not pcall(m.remove, m, ""), "expected error: queue does not support remove")
+	m:close()
+end)
+
+test("bpf.map queue next raises", function()
+	local m = map(path)
+	assert(not pcall(m.next, m), "expected error: queue does not support iteration")
+	m:close()
+end)
+
+test("bpf.map queue info reports map properties", function()
+	local m = map(path)
+	local info = m:info()
+	assert(info.type == bpf.MAP_TYPE_QUEUE, "expected queue map type")
+	assert(info.key_size == 0, "expected key_size 0")
+	assert(info.value_size == 3, "expected value_size 3")
+	assert(info.max_entries == 128, "expected max_entries 128")
+	assert(#m == 128, "expected #m == max_entries")
+	m:close()
+end)
+

--- a/tests/bpf/run.sh
+++ b/tests/bpf/run.sh
@@ -5,8 +5,8 @@
 #
 # Runs all bpf tests and reports aggregated KTAP results.
 #
-# Creates pinned maps with bpftool (hash, array, lru_hash, and a percpu
-# hash for the unsupported-type check), seeds the hash map, then
+# Creates pinned maps with bpftool (hash, array, lru_hash, queue, stack and
+# a percpu hash for the unsupported-type check), seeds the hash map, then
 # exercises the bpf.map API from kernel Lua scripts: per-type coverage
 # in process context, a softirq-runtime script, and a Lua-to-bpftool
 # interop check.
@@ -22,6 +22,8 @@ MAP=$BPF_FS/test_map
 ARRAY_MAP=$BPF_FS/test_map_array
 LRU_MAP=$BPF_FS/test_map_lru
 PERCPU_MAP=$BPF_FS/test_map_percpu
+QUEUE_MAP=$BPF_FS/test_map_queue
+STACK_MAP=$BPF_FS/test_map_stack
 SOFTIRQ_SCRIPT=tests/bpf/map_softirq
 
 skip() { ktap_header; ktap_plan 1; ktap_skip "$1"; ktap_totals; exit 0; }
@@ -31,7 +33,7 @@ command -v bpftool > /dev/null 2>&1 || skip "bpf: bpftool unavailable"
 cleanup()
 {
 	lunatik stop "$SOFTIRQ_SCRIPT" 2>/dev/null
-	rm -f "$MAP" "$ARRAY_MAP" "$LRU_MAP" "$PERCPU_MAP"
+	rm -f "$MAP" "$ARRAY_MAP" "$LRU_MAP" "$PERCPU_MAP" "$QUEUE_MAP"
 }
 
 trap cleanup EXIT
@@ -46,10 +48,12 @@ bpftool map create "$MAP" type hash key 3 value 3 entries 128 name test_map >/de
 bpftool map create "$ARRAY_MAP" type array key 4 value 4 entries 4 name test_array >/dev/null
 bpftool map create "$LRU_MAP" type lru_hash key 3 value 3 entries 128 name test_lru >/dev/null
 bpftool map create "$PERCPU_MAP" type percpu_hash key 3 value 3 entries 128 name test_percpu >/dev/null
+bpftool map create "$QUEUE_MAP" type queue key 0 value 3 entries 128 name test_queue >/dev/null
+bpftool map create "$STACK_MAP" type stack key 0 value 3 entries 128 name test_stack >/dev/null
 
 bpftool map update pinned "$MAP" key hex 66 6f 6f value hex 62 61 72
 
-TESTS="map_values array lru"
+TESTS="map_values array lru queue stack"
 TOTAL=$(($(echo $TESTS | wc -w) + 2))
 
 ktap_header

--- a/tests/bpf/stack.lua
+++ b/tests/bpf/stack.lua
@@ -1,0 +1,113 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the bpf stack map test (see run.sh).
+
+local map = require("bpf").map
+local bpf = require("linux.bpf")
+local test = require("util").test
+
+local path = "/sys/fs/bpf/test_map_stack"
+
+local function drain(m)
+	while m:pop() do
+	end
+end
+
+test("bpf.map stack push and peek returns inserted value", function()
+	local m = map(path)
+	assert(m:push("foo"))
+	local value = m:peek()
+	assert(value == "foo", "expected 'foo', got: " .. tostring(value))
+	drain(m)
+	m:close()
+end)
+
+test("bpf.map stack peek does not remove value", function()
+	local m = map(path)
+	drain(m)
+	assert(m:push("foo"))
+	assert(m:peek() == "foo")
+	assert(m:peek() == "foo")
+	drain(m)
+	m:close()
+end)
+
+test("bpf.map stack pop removes values in LIFO order", function()
+	local m = map(path)
+	drain(m)
+	assert(m:push("foo"))
+	assert(m:push("bar"))
+	assert(m:push("baz"))
+	assert(m:pop() == "baz", "expected last pushed value")
+	assert(m:pop() == "bar", "expected second pushed value")
+	assert(m:pop() == "foo", "expected first pushed value")
+	m:close()
+end)
+
+test("bpf.map stack pop on empty stack returns nil", function()
+	local m = map(path)
+	drain(m)
+	assert(m:pop() == nil, "expected nil from empty stack")
+	m:close()
+end)
+
+test("bpf.map stack peek on empty stack returns nil", function()
+	local m = map(path)
+	drain(m)
+	assert(m:peek() == nil, "expected nil from empty stack")
+	m:close()
+end)
+
+test("bpf.map stack push full stack raises", function()
+	local m = map(path)
+	drain(m)
+	for i = 1, #m do
+		assert(m:push("abc"))
+	end
+	assert(not pcall(m.push, m, "abc"), "expected error when stack is full")
+	m:close()
+end)
+
+test("bpf.map stack lookup returns nil", function()
+	local m = map(path)
+	assert(m:lookup("") == nil, "expected nil: stack lookup unsupported")
+	m:close()
+end)
+
+test("bpf.map stack update raises", function()
+	local m = map(path)
+	assert(not pcall(m.update, m, "", "foo", bpf.ANY), "expected error: stack does not support update")
+	m:close()
+end)
+
+test("bpf.map stack delete raises", function()
+	local m = map(path)
+	assert(not pcall(m.delete, m, ""), "expected error: stack does not support delete")
+	m:close()
+end)
+
+test("bpf.map stack remove raises", function()
+	local m = map(path)
+	assert(not pcall(m.remove, m, ""), "expected error: stack does not support remove")
+	m:close()
+end)
+
+test("bpf.map stack next raises", function()
+	local m = map(path)
+	assert(not pcall(m.next, m), "expected error: stack does not support iteration")
+	m:close()
+end)
+
+test("bpf.map stack info reports map properties", function()
+	local m = map(path)
+	local info = m:info()
+	assert(info.type == bpf.MAP_TYPE_STACK, "expected stack map type")
+	assert(info.key_size == 0, "expected key_size 0")
+	assert(info.value_size == 3, "expected value_size 3")
+	assert(info.max_entries == 128, "expected max_entries 128")
+	assert(#m == 128, "expected #m == max_entries")
+	m:close()
+end)
+


### PR DESCRIPTION
- Queues and stacks do not support `map_update_elem`, `map_get_next_key`. Calling these methods returns in `-EINVAL` (ref: [kernel/bpf/queue_stack_maps.c](https://elixir.bootlin.com/linux/v7.1.4/source/kernel/bpf/queue_stack_maps.c#L264))
- They return NULL for `map_lookup_elem`
- They support `map_pop_elem`, `map_push_elem` and `map_peek_elem`
- Add Lua test suites covering push, pop, peek FIFO/LIFO behavior, unsupported operations, and map metadata for BPF queue and stack map types.