### PR TITLE
tests: fail when a script does not run

### DIFF
--- a/tests/bpf/run.sh
+++ b/tests/bpf/run.sh
@@ -28,7 +28,9 @@ SOFTIRQ_SCRIPT=tests/bpf/map_softirq
 
 skip() { ktap_header; ktap_plan 1; ktap_skip "$1"; ktap_totals; exit 0; }
 
-command -v bpftool > /dev/null 2>&1 || skip "bpf: bpftool unavailable"
+bpftool map show > /dev/null 2>&1 || skip "bpf: bpftool unavailable"
+
+create_map() { bpftool map create "$@" > /dev/null || skip "bpf: cannot create pinned maps"; }
 
 cleanup()
 {
@@ -44,14 +46,14 @@ if ! mountpoint -q "$BPF_FS"; then
 	mount -t bpf bpf "$BPF_FS"
 fi
 
-bpftool map create "$MAP" type hash key 3 value 3 entries 128 name test_map >/dev/null
-bpftool map create "$ARRAY_MAP" type array key 4 value 4 entries 4 name test_array >/dev/null
-bpftool map create "$LRU_MAP" type lru_hash key 3 value 3 entries 128 name test_lru >/dev/null
-bpftool map create "$PERCPU_MAP" type percpu_hash key 3 value 3 entries 128 name test_percpu >/dev/null
-bpftool map create "$QUEUE_MAP" type queue key 0 value 3 entries 128 name test_queue >/dev/null
-bpftool map create "$STACK_MAP" type stack key 0 value 3 entries 128 name test_stack >/dev/null
+create_map "$MAP" type hash key 3 value 3 entries 128 name test_map
+create_map "$ARRAY_MAP" type array key 4 value 4 entries 4 name test_array
+create_map "$LRU_MAP" type lru_hash key 3 value 3 entries 128 name test_lru
+create_map "$PERCPU_MAP" type percpu_hash key 3 value 3 entries 128 name test_percpu
+create_map "$QUEUE_MAP" type queue key 0 value 3 entries 128 name test_queue
+create_map "$STACK_MAP" type stack key 0 value 3 entries 128 name test_stack
 
-bpftool map update pinned "$MAP" key hex 66 6f 6f value hex 62 61 72
+bpftool map update pinned "$MAP" key hex 66 6f 6f value hex 62 61 72 || skip "bpf: cannot seed the pinned map"
 
 TESTS="map_values array lru queue stack"
 TOTAL=$(($(echo $TESTS | wc -w) + 2))
@@ -60,29 +62,17 @@ ktap_header
 ktap_plan $TOTAL
 
 for t in $TESTS; do
-	mark_dmesg
-	if ! lunatik run "tests/bpf/$t" 2>/dev/null; then
-		ktap_fail "bpf/$t: script execution failed"
-		continue
-	fi
-	errs=$(dmesg_since | grep -iE "^[^:]+: FAIL	|\.lua:[0-9]+:" || true)
-	if [ -z "$errs" ]; then
+	if run_test "tests/bpf/$t"; then
 		ktap_pass "bpf/$t"
 	else
 		ktap_fail "bpf/$t"
-		while IFS= read -r line; do
-			echo "# $line"
-		done <<< "$errs"
 	fi
 done
 
-mark_dmesg
-output=$(lunatik run "$SOFTIRQ_SCRIPT" softirq 2>&1)
-if ! echo "$output" | grep -qE "\.lua:[0-9]+:" && [ -z "$(dmesg_since | grep -E '\.lua:[0-9]+:' || true)" ]; then
+if run_test "$SOFTIRQ_SCRIPT" softirq; then
 	ktap_pass "bpf/map_softirq"
 else
 	ktap_fail "bpf/map_softirq"
-	echo "# $output"
 fi
 lunatik stop "$SOFTIRQ_SCRIPT" 2>/dev/null
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -29,14 +29,30 @@ check_dmesg() {
 	return 1
 }
 
+comment() { while IFS= read -r line; do echo "# $line"; done <<< "$1"; }
+
+# a script that fails reports on the output, not on the exit status.
 run_script() {
 	local output
-	output=$(lunatik run "$@")
-	echo "$output" | grep -qE "\.lua:[0-9]+:" || return 0
+	output=$(lunatik run "$@" 2>&1)
+	[ -z "$output" ] && return 0
 	ktap_fail "Lua error in script"
-	echo "# $output"
+	comment "$output"
 	ktap_totals
 	exit 1
+}
+
+# Same, for suites that run several scripts and count each one.
+run_test() {
+	local output errs
+	mark_dmesg
+	output=$(lunatik run "$@" 2>&1)
+	errs=$(dmesg_since | grep -iE "^[^:]+: FAIL	|\.lua:[0-9]+:" || true)
+	[ -z "$output" ] && [ -z "$errs" ] && return 0
+
+	[ -n "$output" ] && comment "$output"
+	[ -n "$errs" ] && comment "$errs"
+	return 1
 }
 
 # Each test script must define cleanup().


### PR DESCRIPTION
The test harness reported success for scripts that never ran.

A script that fails to load reports on the output of `lunatik run`, which exits 0 in that case (`bin/lunatik` ends with `print(dostring(chunk)); os.exit()`), while `dmesg` only carries the per-test failures logged by `util.test`. The suite loops checked the exit status and `dmesg`; `run_script` matched only runtime errors (`file.lua:N:`), which a failed `require` does not produce. Either way, a script that failed to load counted as a pass.

`lunatik run` does exit 1 on a usage error and on a failure of the CLI itself, so the helpers capture `2>&1`: whatever the exit status, the message is on the output, and any output is now a failure.

Injecting `require("modulo_inexistente")` into `tests/bpf/array.lua`, on `master`:

```
ok 2 bpf/array
# Totals: pass:7 fail:0 skip:0
```

with this change:

```
# error loading module 'modulo_inexistente' from file 'modulo_inexistente':
# 	luaopen_modulo_inexistente not found in kernel symbol table
not ok 2 bpf/array
# Totals: pass:6 fail:1 skip:0
```

This fixes `run_script`, used by 23 test scripts, and adds `run_test` to `tests/lib.sh` for the suites that run several scripts and count each one, with `bpf` as its first user. #639 converts the remaining suites.

Also for the `bpf` suite: skip when `bpftool` cannot talk to the kernel (the binary being present is not enough, since the wrapper exists without `linux-tools-$(uname -r)` and fails at runtime, so the suite created no maps and ran against absent pins), and skip when a map cannot be created or seeded.

Full suite on 6.8.0-124: `pass:71 fail:0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
