### PR TITLE
tests/skb: fix the ipproto require in connmark

### DIFF
--- a/tests/skb/connmark.lua
+++ b/tests/skb/connmark.lua
@@ -7,7 +7,7 @@
 local netfilter = require("netfilter")
 local nf        = require("linux.nf")
 local byteorder = require("byteorder")
-local ipproto   = require("linux.ipproto")
+local ipproto   = require("linux.socket").ipproto
 
 local IP_PROTO     <const> = 9
 local UDP_DPORT    <const> = 2


### PR DESCRIPTION
`tests/skb/connmark.sh` has been failing with "no hook output for tracked flow", which reads as a connmark problem. The kernel script never ran: 8d414411 grouped the socket specs under `linux.socket`, so `require("linux.ipproto")` fails to resolve and the script dies on its first lines. connmark landed later (f35780a6) still carrying the old name, and is the last user of it in the tree.

Fixed to the same form `lib/socket/inet.lua` uses. With this, the suite goes from 1 failure to green:

```
# Grand Totals: pass:71 fail:0 skip:0
```

(The failure was invisible in the harness's own output because `lunatik run` always exits 0 and reports script errors on its output — see #637.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
