### PR TITLE
tests: use run_test in the crypto, rcu and set loops

### DIFF
--- a/tests/crypto/run.sh
+++ b/tests/crypto/run.sh
@@ -18,19 +18,10 @@ ktap_header
 ktap_plan $TOTAL
 
 for t in $TESTS; do
-	mark_dmesg
-	if ! lunatik run "tests/crypto/$t" 2>/dev/null; then
-		ktap_fail "crypto/$t: script execution failed"
-		continue
-	fi
-	errs=$(dmesg_since | grep -iE "^[^:]+: FAIL	|\.lua:[0-9]+:" || true)
-	if [ -z "$errs" ]; then
+	if run_test "tests/crypto/$t"; then
 		ktap_pass "crypto/$t"
 	else
 		ktap_fail "crypto/$t"
-		while IFS= read -r line; do
-			echo "# $line"
-		done <<< "$errs"
 	fi
 done
 

--- a/tests/notifier/init_dispatch.sh
+++ b/tests/notifier/init_dispatch.sh
@@ -33,8 +33,7 @@ ktap_plan 2
 mark_dmesg
 
 output=$(lunatik run "$SCRIPT" 2>&1)
-echo "$output" | grep -qE "\.lua:[0-9]+:" && \
-	fail "Lua error during init-time notifier registration: $output"
+[ -n "$output" ] && fail "Lua error during init-time notifier registration: $output"
 ktap_pass "notifier.netdevice() at script init runs without Lua error"
 
 oops=$(dmesg_since | grep -E "Oops:|BUG:|kernel BUG at|NULL pointer dereference|general protection" || true)

--- a/tests/rcu/run.sh
+++ b/tests/rcu/run.sh
@@ -18,19 +18,10 @@ ktap_header
 ktap_plan $TOTAL
 
 for t in $TESTS; do
-	mark_dmesg
-	if ! lunatik run "tests/rcu/$t" 2>/dev/null; then
-		ktap_fail "rcu/$t: script execution failed"
-		continue
-	fi
-	errs=$(dmesg_since | grep -iE "^[^:]+: FAIL	|\.lua:[0-9]+:" || true)
-	if [ -z "$errs" ]; then
+	if run_test "tests/rcu/$t"; then
 		ktap_pass "rcu/$t"
 	else
 		ktap_fail "rcu/$t"
-		while IFS= read -r line; do
-			echo "# $line"
-		done <<< "$errs"
 	fi
 done
 

--- a/tests/set/run.sh
+++ b/tests/set/run.sh
@@ -18,19 +18,10 @@ ktap_header
 ktap_plan $TOTAL
 
 for t in $TESTS; do
-	mark_dmesg
-	if ! lunatik run "tests/set/$t" 2>/dev/null; then
-		ktap_fail "set/$t: script execution failed"
-		continue
-	fi
-	errs=$(dmesg_since | grep -iE "^[^:]+: FAIL	|\.lua:[0-9]+:" || true)
-	if [ -z "$errs" ]; then
+	if run_test "tests/set/$t"; then
 		ktap_pass "set/$t"
 	else
 		ktap_fail "set/$t"
-		while IFS= read -r line; do
-			echo "# $line"
-		done <<< "$errs"
 	fi
 done
 


### PR DESCRIPTION
Stacked on #637, which fixed the helpers in `tests/lib.sh` and the `bpf` suite. This converts the rest.

The crypto, rcu and set loops each carried a copy of the same check: exit status of `lunatik run` plus a `dmesg` grep, never the output, so a script that never ran counted as a pass. They now call `run_test`, which removes the three copies. `notifier/init_dispatch` matched runtime errors only (`file.lua:N:`), which a failed `require` does not print, and now fails on any output.

Injecting `require("modulo_inexistente")` into one script of each suite:

```
not ok 1 crypto/shash
not ok 1 rcu/map_values
not ok 1 set/set
not ok 1 Lua error during init-time notifier registration: error loading module 'modulo_inexistente' ...
```

All four report a pass on `master`. Full suite on 6.8.0-124 with the tree clean: `pass:71 fail:0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
