### PR TITLE
tests/runtime: assert the leak script reached its error

### DIFF
--- a/tests/runtime/refcnt_leak.sh
+++ b/tests/runtime/refcnt_leak.sh
@@ -32,8 +32,10 @@ before=$(cat /sys/module/$MODULE/refcnt 2>/dev/null) || {
 mark_dmesg
 
 # run the script in a non-sleepable runtime (required for netfilter hooks);
-# it is expected to fail — ignore the error
-lunatik run "$SCRIPT" softirq 2>/dev/null || true
+# the failure below is the intentional one
+output=$(lunatik run "$SCRIPT" softirq 2>&1)
+echo "$output" | grep -q "intentional error after first register" || \
+	fail "script did not reach the intentional error: $output"
 
 check_dmesg || { ktap_totals; exit 1; }
 


### PR DESCRIPTION
Found by sweeping the suites for the blind spot #637 and #639 close: `runtime/refcnt_leak` could pass without exercising anything.

The test runs a script that registers a netfilter hook and then raises, and compares the module refcnt before and after. But the run was `lunatik run "$SCRIPT" softirq 2>/dev/null || true`, and `check_dmesg` only matches `file.lua:N:` — so a script that never ran (a shadowed module, a failed `require`, a renamed spec) left the refcnt untouched and the test reported "refcnt restored".

Asserting the intentional error reached the output makes the comparison meaningful again. Replacing the script with a no-op turns the old green into:

```
# FAIL: script did not reach the intentional error:
# Totals: pass:0 fail:1 skip:0
```

and the real script still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
