### PR TITLE
lib: group object methods under their LDoc type

### DIFF
--- a/lib/luacompletion.c
+++ b/lib/luacompletion.c
@@ -24,6 +24,13 @@
 LUNATIK_OBJECTCHECKER(luacompletion_check, struct completion *);
 
 /***
+* Represents a kernel completion object.
+* This is a userdata object returned by `completion.new()`, wrapping a
+* `struct completion` used to wait for and signal an event.
+* @type completion
+*/
+
+/***
 * Signals a completion.
 * This wakes up one task waiting on this completion object.
 * Corresponds to the kernel's `complete()` function.

--- a/lib/luadata.c
+++ b/lib/luadata.c
@@ -72,6 +72,14 @@ LUADATA_NEWINT(uint32);
 LUADATA_NEWINT(int64);
 
 /***
+* Represents a byte buffer.
+* This is a userdata object returned by `data.new()` and by the modules that
+* expose kernel memory (as `skb:data()`), read and written through the
+* `getuint*`/`setuint*` accessors below.
+* @type data
+*/
+
+/***
 * @function getstring
 * @tparam integer offset
 * @tparam[opt] integer length number of bytes; default: from offset to end

--- a/lib/luaskb.c
+++ b/lib/luaskb.c
@@ -52,6 +52,13 @@ LUNATIK_PRIVATECHECKER(luaskb_check, luaskb_t *,
 			ntohs((ip6h)->payload_len), 0))
 
 /***
+* Represents a socket buffer (`sk_buff`).
+* This is a userdata object handed to the hooks that receive packets; it is
+* `SINGLE`, so it cannot be shared with another runtime.
+* @type skb
+*/
+
+/***
 * @function __len
 * @treturn integer skb length in bytes
 */


### PR DESCRIPTION
`skb`, `data` and `completion` define a class and document its methods, but never open a type for them, so LDoc renders the methods as loose module functions. `completion` shows the gap best: its constructor already carries `@within completion`, pointing at a type that was never declared.

With the `@type` blocks, the methods group under the class:

```
Class skb
  Represents a socket buffer (sk_buff).
  skb:__len, skb:ifindex, skb:vlan, skb:data, skb:resize, skb:checksum, skb:forward, skb:copy, skb:connmark
```

`crypto` does the same thing through `@classmod` (one class per file); these three are single-class modules, so they take `@type` as `fifo`, `rcu`, `socket` and the others already do.

Rendered locally with `make doc-site` to confirm the sections come out as classes rather than module functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
