### PR TITLE
Add support for multiple runtimes (perpcu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ Lunatik 4.4  Copyright (C) 2023-2026 Ring Zero Desenvolvimento de Software LTDA.
 ### lunatik
 
 ```Shell
-usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [percpu]
+usage: lunatik [load|unload|reload|status|test|list]
+       lunatik run <script> [softirq|hardirq] [percpu]
+       lunatik spawn <script>
+       lunatik stop <script>
 ```
 
 * `load`: load Lunatik kernel modules
@@ -95,9 +98,9 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [
 * `status`: show which Lunatik kernel modules are currently loaded
 * `test [suite]`: run installed test suites (see [Testing](#testing))
 * `list`: show which runtime environments are currently running
-* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime instance per CPU id, for scripts dispatched by the eBPF bindings, which resolve to the instance of the CPU the hook runs on. The script runs once per instance
+* `run [softirq|hardirq] [percpu]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime instance per CPU id, for scripts dispatched by the eBPF bindings, which resolve to the instance of the CPU the hook runs on. The script runs once per instance
 * `spawn`: create a new runtime environment and spawn a thread to run the script `/lib/modules/lua/<script>.lua`
-* `stop`: stop the runtime environment created to run the script `<script>`
+* `stop`: stop the runtime environment (and kernel thread, if any) created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Lunatik 4.4  Copyright (C) 2023-2026 Ring Zero Desenvolvimento de Software LTDA.
 ### lunatik
 
 ```Shell
-usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>]
+usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [percpu]
 ```
 
 * `load`: load Lunatik kernel modules
@@ -95,7 +95,7 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>]
 * `status`: show which Lunatik kernel modules are currently loaded
 * `test [suite]`: run installed test suites (see [Testing](#testing))
 * `list`: show which runtime environments are currently running
-* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes)
+* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime instance per CPU id, for scripts dispatched by the eBPF bindings, which resolve to the instance of the CPU the hook runs on. The script runs once per instance
 * `spawn`: create a new runtime environment and spawn a thread to run the script `/lib/modules/lua/<script>.lua`
 * `stop`: stop the runtime environment created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_

--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ Lunatik 4.4  Copyright (C) 2023-2026 Ring Zero Desenvolvimento de Software LTDA.
 ### lunatik
 
 ```Shell
-usage: lunatik [load|unload|reload|status|test|list]
-       lunatik run <script> [softirq|hardirq] [percpu]
-       lunatik spawn <script>
-       lunatik stop <script>
+usage:
+	lunatik [load|unload|reload|status|test|list]
+	lunatik run <script> [softirq|hardirq] [percpu]
+	lunatik spawn <script>
+	lunatik stop <script>
 ```
 
 * `load`: load Lunatik kernel modules

--- a/bin/lunatik
+++ b/bin/lunatik
@@ -159,11 +159,16 @@ if #arg >= 1 then
 	local tokens = {run = true, spawn = true, stop = true, list = true}
 	local needs_script = {run = true, spawn = true, stop = true}
 	if not tokens[token] or (needs_script[token] and not script) then
-		print("usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>]")
+		print("usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [percpu]")
 		os.exit(false)
 	end
 	ensure_loaded()
-	local parm  = arg[3] and (', "' .. arg[3] .. '"') or ""
+	local percpu  = arg[3] == "percpu" or arg[4] == "percpu"
+	local context = (arg[3] ~= "percpu" and arg[3]) or (arg[4] ~= "percpu" and arg[4]) or nil
+	local parm    = context and string.format(', "%s"', context) or ""
+	if percpu then
+		parm = (context and parm or ", nil") .. ", true"
+	end
 	local ret   = token == "list" and "return" or ""
 	local chunk = string.format("%s lunatik.runner.%s('%s'%s)", ret, token, script, parm)
 	print(dostring(chunk))

--- a/bin/lunatik
+++ b/bin/lunatik
@@ -153,13 +153,21 @@ if cmd then
 	os.exit()
 end
 
+local USAGE = [[
+usage:
+	lunatik run <script> [softirq|hardirq] [percpu]
+	lunatik spawn <script>
+	lunatik stop <script>
+	lunatik [load|unload|reload|status|test|list]
+]]
+
 if #arg >= 1 then
 	local token  = arg[1]
 	local script = arg[2]
 	local tokens = {run = true, spawn = true, stop = true, list = true}
 	local needs_script = {run = true, spawn = true, stop = true}
 	if not tokens[token] or (needs_script[token] and not script) then
-		print("usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [percpu]")
+		print(USAGE)
 		os.exit(false)
 	end
 	ensure_loaded()

--- a/bin/lunatik
+++ b/bin/lunatik
@@ -155,10 +155,10 @@ end
 
 local USAGE = [[
 usage:
+	lunatik [load|unload|reload|status|test|list]
 	lunatik run <script> [softirq|hardirq] [percpu]
 	lunatik spawn <script>
 	lunatik stop <script>
-	lunatik [load|unload|reload|status|test|list]
 ]]
 
 if #arg >= 1 then

--- a/lib/lualinux.c
+++ b/lib/lualinux.c
@@ -249,6 +249,21 @@ static int lualinux_errname(lua_State *L)
     return 1;
 }
 
+/***
+* Returns the number of possible CPU ids.
+* CPU ids range from `0` to `numcpus() - 1`; the online ones are a subset,
+* so an id in that range may be offline.
+* @function numcpus
+* @treturn integer number of possible CPU ids
+* @usage
+* for cpu = 0, linux.numcpus() - 1 do print(cpu) end
+*/
+static int lualinux_numcpus(lua_State *L)
+{
+	lua_pushinteger(L, nr_cpu_ids);
+	return 1;
+}
+
 static const luaL_Reg lualinux_lib[] = {
 	{"random", lualinux_random},
 	{"schedule", lualinux_schedule},
@@ -259,6 +274,7 @@ static const luaL_Reg lualinux_lib[] = {
 	{"ifindex", lualinux_ifindex},
 	{"ifaddr", lualinux_ifaddr},
 	{"errname", lualinux_errname},
+	{"numcpus", lualinux_numcpus},
 	{NULL, NULL}
 };
 

--- a/lib/luarcu.c
+++ b/lib/luarcu.c
@@ -22,8 +22,6 @@
 
 #include "luarcu.h"
 
-#define LUARCU_MAXKEY	(LUAL_BUFFERSIZE)
-
 typedef struct luarcu_entry_s {
 	lunatik_value_t value;
 	struct hlist_node hlist;

--- a/lib/luarcu.h
+++ b/lib/luarcu.h
@@ -7,6 +7,7 @@
 #define luarcu_h
 
 #define LUARCU_DEFAULT_SIZE	(256)
+#define LUARCU_MAXKEY		(LUAL_BUFFERSIZE)
 
 lunatik_object_t *luarcu_newtable(size_t size, lunatik_opt_t opt);
 void luarcu_getvalue(lunatik_object_t *table, const char *key, size_t keylen, lunatik_value_t *value);

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -38,6 +38,7 @@ __diag_ignore_all("-Wmissing-prototypes",
 #endif
 
 static lunatik_object_t *luaxdp_runtimes = NULL;
+static lunatik_object_t *luaxdp_percpu = NULL;
 
 static inline lunatik_object_t *luaxdp_pushdata(lua_State *L, int upvalue, void *ptr, size_t size)
 {
@@ -96,11 +97,14 @@ out:
 
 static inline int luaxdp_checkruntimes(void)
 {
-	static const char key[] = "runtimes";
-	if (luaxdp_runtimes == NULL &&
-	   (luaxdp_runtimes = luarcu_getobject(lunatik_env, key, sizeof(key) - 1)) == NULL)
-		return -1;
-	return 0;
+	static const char runtimes_key[] = "runtimes";
+	static const char percpu_key[] = "percpu";
+
+	if (luaxdp_runtimes == NULL)
+		luaxdp_runtimes = luarcu_getobject(lunatik_env, runtimes_key, sizeof(runtimes_key) - 1);
+	if (luaxdp_percpu == NULL)
+		luaxdp_percpu = luarcu_getobject(lunatik_env, percpu_key, sizeof(percpu_key) - 1);
+	return luaxdp_runtimes != NULL && luaxdp_percpu != NULL ? 0 : -1;
 }
 
 __bpf_kfunc int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *xdp_ctx, void *arg, size_t arg__sz)
@@ -109,13 +113,21 @@ __bpf_kfunc int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *xdp_ctx
 	struct xdp_buff *ctx = (struct xdp_buff *)xdp_ctx;
 	int action = -1;
 	size_t keylen = key__sz - 1;
+	lunatik_value_t value;
+	char cpu_key[LUARCU_MAXKEY];
 
 	if (unlikely(luaxdp_checkruntimes() != 0)) {
-		pr_err("couldn't find _ENV.runtimes\n");
+		pr_err("couldn't find _ENV.runtimes or _ENV.percpu\n");
 		goto out;
 	}
 
 	key[keylen] = '\0';
+	luarcu_getvalue(luaxdp_percpu, key, keylen, &value);
+	if (value.type == LUA_TBOOLEAN && value.boolean) {
+		keylen = scnprintf(cpu_key, sizeof(cpu_key), "%s:%d", key, raw_smp_processor_id());
+		key = cpu_key;
+	}
+
 	if ((runtime = luarcu_getobject(luaxdp_runtimes, key, keylen)) == NULL) {
 		pr_err("couldn't find runtime '%s'\n", key);
 		goto out;

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -96,9 +96,9 @@ out:
 
 static inline int luaxdp_checkruntimes(void)
 {
-	const char *key = "runtimes";
+	static const char key[] = "runtimes";
 	if (luaxdp_runtimes == NULL &&
-	   (luaxdp_runtimes = luarcu_getobject(lunatik_env, key, sizeof(key))) == NULL)
+	   (luaxdp_runtimes = luarcu_getobject(lunatik_env, key, sizeof(key) - 1)) == NULL)
 		return -1;
 	return 0;
 }

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -259,6 +259,8 @@ static void __exit luaxdp_exit(void)
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0))
 	if (luaxdp_runtimes != NULL)
 		lunatik_putobject(luaxdp_runtimes);
+	if (luaxdp_percpu != NULL)
+		lunatik_putobject(luaxdp_percpu);
 #endif
 }
 

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -47,7 +47,7 @@ end
 -- @tparam string script registry key to test.
 -- @treturn boolean `true` if the key is a per-CPU runtime key, otherwise `false`.
 local function ispercpukey(script)
-	return script:find(":", 1, true) ~= nil
+	return env.percpu[script:match("^(.+):%d+$")] ~= nil
 end
 
 --- Stops an item (runtime or thread) in the given registry.
@@ -72,9 +72,6 @@ end
 -- @function stop_percpu
 -- @tparam string script script name.
 local function stop_percpu(script)
-	if not env.percpu[script] then
-		return
-	end
 	for cpu = 0, linux.numcpus() - 1 do
 		stop(env.runtimes, percpukey(script, cpu))
 	end
@@ -96,7 +93,6 @@ function runner.run(script, context, percpu, ...)
 		error(string.format("%s is already running", script))
 	end
 	if percpu then
-		env.percpu[script] = true
 		local ok, err = pcall(function(...)
 			for cpu = 0, linux.numcpus() - 1 do
 				env.runtimes[percpukey(script, cpu)] = lunatik.runtime(script, context, ...)
@@ -106,6 +102,7 @@ function runner.run(script, context, percpu, ...)
 			stop_percpu(script)
 			error(err, 0)
 		end
+		env.percpu[script] = true
 		return nil
 	end
 	local runtime = lunatik.runtime(script, context, ...)

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -14,6 +14,7 @@
 local lunatik = require("lunatik")
 local thread  = require("thread")
 local rcu     = require("rcu")
+local linux   = require("linux")
 
 local env = lunatik._ENV
 
@@ -28,19 +29,36 @@ local function trim(script) -- drop ".lua" file extension
 	return script:gsub("(%w+).lua", "%1")
 end
 
+local function key(script, cpu)
+	return script .. ":" .. cpu
+end
+
+local function ispercpukey(script)
+	return script:find(":", 1, true) ~= nil
+end
+
 --- Runs a Lunatik script in the current context.
 -- Creates a new Lunatik runtime for the given script and registers it.
 -- Throws an error if a script with the same name is already running.
 -- @tparam string script path or name of the Lua script to run. The ".lua" extension will be trimmed.
 -- @tparam[opt] string context Execution context: `"process"` (default) or `"softirq"` (for netfilter/XDP hooks).
--- @treturn table created Lunatik runtime object.
+-- @tparam[opt] boolean percpu create one runtime per CPU id, registered as `<script>:<cpu>`,
+--   for scripts dispatched by the eBPF bindings; the script runs once per runtime.
+-- @treturn table created Lunatik runtime object, or `nil` when `percpu` is set.
 -- @raise error if the script is already running.
-function runner.run(script, ...)
+function runner.run(script, context, percpu, ...)
 	local script = trim(script)
-	if env.runtimes[script] then
+	if env.runtimes[script] or env.percpu[script] then
 		error(string.format("%s is already running", script))
 	end
-	local runtime = lunatik.runtime(script, ...)
+	if percpu then
+		for cpu = 0, linux.numcpus() - 1 do
+			env.runtimes[key(script, cpu)] = lunatik.runtime(script, context, ...)
+		end
+		env.percpu[script] = true
+		return nil
+	end
+	local runtime = lunatik.runtime(script, context, ...)
 	env.runtimes[script] = runtime
 	return runtime
 end
@@ -51,8 +69,12 @@ end
 -- The spawned script is expected to return a function, which will then be executed in the new thread.
 -- @tparam string script path or name of the Lua script to spawn.
 -- @treturn userdata kernel thread object.
-function runner.spawn(script, ...)
-	local runtime = runner.run(script, ...)
+-- @raise error if the script is already running or `percpu` is set.
+function runner.spawn(script, context, percpu, ...)
+	if percpu then
+		error("spawn does not support percpu scripts")
+	end
+	local runtime = runner.run(script, context, percpu, ...)
 	local name = string.match(script, "(%w*/*%w*)$")
 	local t = thread.run(runtime, name)
 	env.threads[script] = t
@@ -73,6 +95,16 @@ local function stop(registry, script)
 	end
 end
 
+local function stop_percpu(script)
+	if not env.percpu[script] then
+		return
+	end
+	for cpu = 0, linux.numcpus() - 1 do
+		stop(env.runtimes, key(script, cpu))
+	end
+	env.percpu[script] = nil
+end
+
 --- Stops a running script and its associated thread, if any.
 -- It attempts to stop the thread first, then the runtime.
 -- @tparam string script name of the script to stop. The ".lua" extension will be trimmed.
@@ -80,34 +112,46 @@ function runner.stop(script)
 	local script = trim(script)
 	stop(env.threads, script)
 	stop(env.runtimes, script)
+	stop_percpu(script)
 end
 
 --- Lists the names of all currently running scripts.
--- Iterates over the `env.runtimes` RCU table to collect script names.
+-- Iterates over the `env.percpu` and `env.runtimes` RCU tables to collect
+-- script names; a percpu script is named once, not once per CPU id.
 -- @treturn string A comma-separated string of running script names, or an empty string if no scripts are running.
 function runner.list()
 	local list = {}
-	rcu.map(env.runtimes, function (script)
+	rcu.map(env.percpu, function (script)
 		table.insert(list, script)
+	end)
+	rcu.map(env.runtimes, function (script)
+		if not ispercpukey(script) then
+			table.insert(list, script)
+		end
 	end)
 	return table.concat(list, ', ')
 end
 
---- Shuts down all running scripts and their threads.
--- Iterates over `env.runtimes` and calls `runner.stop` for each script.
-function runner.shutdown()
-	rcu.map(env.runtimes, function (script)
+local function stopall(registry)
+	rcu.map(registry, function (script)
 		runner.stop(script)
 	end)
+end
+
+--- Shuts down all running scripts and their threads.
+-- Iterates over `env.percpu` and `env.runtimes` and calls `runner.stop` for each script.
+function runner.shutdown()
+	stopall(env.percpu)
+	stopall(env.runtimes)
 end
 
 --- Initializes the runner's internal state.
 -- Creates RCU-safe tables for storing runtimes and threads.
 -- This is typically called during Lunatik's initialization.
 function runner.startup()
-	if env.runtimes then return end
-	env.runtimes = rcu.table()
-	env.threads = rcu.table()
+	env.runtimes = env.runtimes or rcu.table()
+	env.percpu = env.percpu or rcu.table()
+	env.threads = env.threads or rcu.table()
 end
 
 return runner

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -29,12 +29,56 @@ local function trim(script) -- drop ".lua" file extension
 	return script:gsub("(%w+).lua", "%1")
 end
 
-local function key(script, cpu)
+--- Builds the registry key for a per-CPU runtime.
+-- The key is formed as `<script>:<cpu>` and is used to store
+-- and retrieve runtimes associated with a specific CPU.
+-- @local
+-- @function percpukey
+-- @tparam string script script name.
+-- @tparam integer cpu CPU identifier.
+-- @treturn string per-CPU runtime key.
+local function percpukey(script, cpu)
 	return script .. ":" .. cpu
 end
 
+--- Checks whether a registry key represents a per-CPU runtime.
+-- @local
+-- @function ispercpukey
+-- @tparam string script registry key to test.
+-- @treturn boolean `true` if the key is a per-CPU runtime key, otherwise `false`.
 local function ispercpukey(script)
 	return script:find(":", 1, true) ~= nil
+end
+
+--- Stops an item (runtime or thread) in the given registry.
+-- If the item exists in the registry, its `stop()` method is called,
+-- and it's removed from the registry.
+-- @local
+-- @function stop
+-- @tparam table registry registry table (e.g., `env.threads` or `env.runtimes`).
+-- @tparam string script key (script name) of the item to stop.
+local function stop(registry, script)
+	if registry[script] then
+		registry[script]:stop()
+		registry[script] = nil
+	end
+end
+
+--- Stops all per-CPU runtimes for a script.
+-- If the script is registered as a per-CPU script, all runtimes
+-- associated with each CPU are stopped and removed from
+-- `env.runtimes`, and the script is removed from `env.percpu`.
+-- @local
+-- @function stop_percpu
+-- @tparam string script script name.
+local function stop_percpu(script)
+	if not env.percpu[script] then
+		return
+	end
+	for cpu = 0, linux.numcpus() - 1 do
+		stop(env.runtimes, percpukey(script, cpu))
+	end
+	env.percpu[script] = nil
 end
 
 --- Runs a Lunatik script in the current context.
@@ -45,17 +89,23 @@ end
 -- @tparam[opt] boolean percpu create one runtime per CPU id, registered as `<script>:<cpu>`,
 --   for scripts dispatched by the eBPF bindings; the script runs once per runtime.
 -- @treturn table created Lunatik runtime object, or `nil` when `percpu` is set.
--- @raise error if the script is already running.
+-- @raise error if the script is already running or runtime creation fails.
 function runner.run(script, context, percpu, ...)
 	local script = trim(script)
 	if env.runtimes[script] or env.percpu[script] then
 		error(string.format("%s is already running", script))
 	end
 	if percpu then
-		for cpu = 0, linux.numcpus() - 1 do
-			env.runtimes[key(script, cpu)] = lunatik.runtime(script, context, ...)
-		end
 		env.percpu[script] = true
+		local ok, err = pcall(function(...)
+			for cpu = 0, linux.numcpus() - 1 do
+				env.runtimes[percpukey(script, cpu)] = lunatik.runtime(script, context, ...)
+			end
+		end, ...)
+		if not ok then
+			stop_percpu(script)
+			error(err, 0)
+		end
 		return nil
 	end
 	local runtime = lunatik.runtime(script, context, ...)
@@ -79,30 +129,6 @@ function runner.spawn(script, context, percpu, ...)
 	local t = thread.run(runtime, name)
 	env.threads[script] = t
 	return t
-end
-
---- Stops an item (runtime or thread) in the given registry.
--- If the item exists in the registry, its `stop()` method is called,
--- and it's removed from the registry.
--- @local
--- @function stop
--- @tparam table registry registry table (e.g., `env.threads` or `env.runtimes`).
--- @tparam string script key (script name) of the item to stop.
-local function stop(registry, script)
-	if registry[script] then
-		registry[script]:stop()
-		registry[script] = nil
-	end
-end
-
-local function stop_percpu(script)
-	if not env.percpu[script] then
-		return
-	end
-	for cpu = 0, linux.numcpus() - 1 do
-		stop(env.runtimes, key(script, cpu))
-	end
-	env.percpu[script] = nil
 end
 
 --- Stops a running script and its associated thread, if any.

--- a/tests/README.md
+++ b/tests/README.md
@@ -190,6 +190,12 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   the receiving runtime via `class->opener` (`luaL_requiref`), even when
   that runtime never called `require()` for the module.
 
+- **percpu**: `run <script> percpu` registers one runtime per possible
+  CPU id, as `<script>:<cpu>`, which is the key the eBPF bindings look
+  up; the script is listed once, by name; `stop` drops every instance
+  and lets it run again; and `spawn` refuses percpu without creating
+  any runtime.
+
 ### set
 
 - **set**: `set.new` sorting unsorted input and binary-search membership

--- a/tests/runtime/percpu.lua
+++ b/tests/runtime/percpu.lua
@@ -1,0 +1,8 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu runtime test (see percpu.sh).
+
+return function() end
+

--- a/tests/runtime/percpu.sh
+++ b/tests/runtime/percpu.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for percpu runtimes: `run <script> percpu` registers one
+# runtime per possible CPU id as `<script>:<cpu>`, which is what the eBPF
+# bindings look up; the script is listed once, by name; stopping it drops every
+# instance and lets it run again; and `spawn` refuses percpu without creating
+# any runtime.
+#
+# Usage: sudo bash tests/runtime/percpu.sh
+
+SCRIPT="tests/runtime/percpu"
+CHECK="tests/runtime/percpu_check"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+	lunatik stop "$CHECK" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 4
+
+mark_dmesg
+
+run_script "$SCRIPT" percpu
+run_script "$CHECK"
+check_dmesg || { ktap_totals; exit 1; }
+ktap_pass "one runtime per possible CPU id"
+
+lunatik stop "$CHECK" > /dev/null 2>&1
+
+listed=$(lunatik list)
+case "$listed" in
+	*"$SCRIPT:"*) fail "list shows the per-CPU keys: $listed" ;;
+	*"$SCRIPT"*)  ktap_pass "the script is listed once, by name" ;;
+	*)            fail "the script is not listed: $listed" ;;
+esac
+
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+listed=$(lunatik list)
+case "$listed" in
+	*"$SCRIPT"*) fail "stop left the script running: $listed" ;;
+esac
+run_script "$SCRIPT" percpu
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "stop drops every instance and lets the script run again"
+
+output=$(lunatik spawn "$SCRIPT" percpu 2>&1)
+echo "$output" | grep -q "spawn does not support percpu" || \
+	fail "spawn accepted percpu: $output"
+listed=$(lunatik list)
+case "$listed" in
+	*"$SCRIPT"*) fail "the refused spawn left runtimes behind: $listed" ;;
+esac
+ktap_pass "spawn refuses percpu without creating runtimes"
+
+ktap_totals
+

--- a/tests/runtime/percpu_check.lua
+++ b/tests/runtime/percpu_check.lua
@@ -1,0 +1,20 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu runtime test (see percpu.sh).
+
+local lunatik = require("lunatik")
+local linux   = require("linux")
+local test    = require("util").test
+
+local prefix <const> = "tests/runtime/percpu:"
+
+test("percpu registers one runtime per possible CPU id", function()
+	local runtimes = lunatik._ENV.runtimes
+	for cpu = 0, linux.numcpus() - 1 do
+		assert(runtimes[prefix .. cpu] ~= nil, "missing runtime for CPU " .. cpu)
+	end
+	assert(runtimes[prefix .. linux.numcpus()] == nil, "runtime beyond the last CPU id")
+end)
+

--- a/tests/runtime/run.sh
+++ b/tests/runtime/run.sh
@@ -18,6 +18,7 @@ TESTS=(
 	opt_guards.sh
 	opt_skb_single.sh
 	require_cloneobject.sh
+	percpu.sh
 )
 
 SEP=""


### PR DESCRIPTION
Adds an opt-in percpu mode for Lunatik scripts. Instead of a single shared runtime instance, a percpu script gets one dedicated runtime per online CPU, and eBPF-triggered lookups (luasched, luatc, luaxdp) resolve to the runtime matching the CPU the hook is executing on.