### PR TITLE
docs: add AGENTS.md and the conntrack and NAT project plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,210 @@
+# Working on Lunatik
+
+Conventions for contributors, and for AI coding assistants working on this repository. If you are
+using an assistant that reads a project file automatically (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`),
+point it here.
+
+Lunatik runs Lua inside the Linux kernel. A mistake here does not raise an exception, it panics a
+machine. Two rules follow from that and outrank everything else in this document:
+
+1. **Verify, do not assume.** Before using a kernel API, read its declaration in
+   `/usr/src/linux-headers-$(uname -r)/include` and confirm it is exported in `Module.symvers`.
+   Signatures change between releases. If you have not checked, say so instead of asserting.
+2. **Know your execution context.** Code that may sleep must not run from softirq or hardirq context.
+   See "Execution contexts" below.
+
+## Layout
+
+| Path | What lives there |
+|------|------------------|
+| `lunatik_*.c`, `lunatik.h` | core runtime, object model, C API |
+| `lib/lua*.c` | kernel modules, one `.ko` each, exposing a Lua module |
+| `lib/*.lua`, `lib/*/*.lua` | kernel side Lua libraries, installed to `/lib/modules/lua/` |
+| `autogen/` | build time generation of `linux.*` constant tables from kernel headers |
+| `bin/lunatik` | userspace CLI, talks to the kernel through `/dev/lunatik` |
+| `tests/` | KTAP integration tests, one directory per suite |
+| `examples/` | example kernel scripts |
+| `docs/design/` | design notes for work in progress: gap analysis, proposed APIs, verified kernel references, test strategy |
+| `doc/` | generated LDoc output, plus the hand written C API reference |
+
+## Build, install, test
+
+    sudo apt install linux-headers-$(uname -r)     # after a kernel upgrade
+    make                                           # build every module
+    sudo make install                              # scripts, modules, examples, tests
+    sudo lunatik reload                            # reload the modules
+    sudo lunatik test                              # run every suite
+    sudo lunatik test <suite>                      # run one suite
+
+Use `sudo make install`, not the partial `*_install` targets. Use `sudo lunatik reload`, never
+`rmmod`: the CLI knows the dependency order and unloads cleanly.
+
+`lunatik reload` cannot always replace the core module while something still holds it. If you changed
+`lunatik.ko` itself and the behaviour did not change, verify rather than assume the new core is live.
+
+Never run two `lunatik` operations at once. Concurrent operations wedge `/dev/lunatik` and leave
+processes in D state. Check with `ps` before starting one.
+
+### Running a script
+
+    lunatik run <script> [softirq|hardirq]   # one shot
+    lunatik spawn <script>                   # in a kernel thread, always sleepable
+    lunatik stop <script>
+    lunatik list
+
+Scripts are resolved under `/lib/modules/lua/`. The CLI loads the kernel modules a script needs by
+itself, through `require()`. Never tell a user to `modprobe lua*` by hand.
+
+`lunatik run` exits 0 even when the script fails to load; the error only appears on stdout. Test
+harnesses must assert on output, not on exit status.
+
+## Execution contexts
+
+A runtime is created in one of three contexts, and this decides what its code may do:
+
+| Context | How | Allocation | Lock | May sleep |
+|---------|-----|-----------|------|-----------|
+| process | default, and always for `spawn` | `GFP_KERNEL` | mutex | yes |
+| softirq | `lunatik run <script> softirq` | `GFP_ATOMIC` | `spin_lock_bh` | no |
+| hardirq | `lunatik run <script> hardirq` | `GFP_ATOMIC` | spinlock, IRQs off | no |
+
+Netfilter and XDP hooks fire in softirq, kprobes in hardirq; those scripts need the matching context.
+
+The script body itself runs once at runtime creation, in process context, before the runtime is armed.
+So registering hooks at the top level of a `softirq` script is legal and may sleep. Everything that
+runs later, from a hook, may not.
+
+Use `lunatik_cannotsleep(L, ...)` to reject a sleeping entry point called from an IRQ context runtime
+rather than letting it deadlock the machine.
+
+### Kernel threads
+
+A script for `lunatik spawn` must return the thread body, poll for a stop request, and yield.
+Violating any of these hangs the machine:
+
+    local thread = require("thread")
+    local linux  = require("linux")
+
+    return function()
+        while not thread.shouldstop() do
+            -- non blocking work only
+            linux.schedule(100)
+        end
+    end
+
+Unbounded blocking calls in a kernel thread make it unstoppable: the thread body runs holding the
+runtime lock, and `stop()` waits for the body to return, which a `sock:receive()` with no timeout never
+does — the socket layer does not check `kthread_should_stop()`. To wait indefinitely, bound each call
+(a receive timeout, or `MSG_DONTWAIT`) and poll `shouldstop()` in the loop.
+
+## Object model
+
+`lunatik_newobject(L, class, size, opt)` allocates and pushes a userdata;
+`lunatik_createobject(class, size, ...)` allocates without a Lua state.
+
+* `.pointer = true` means `object->private` is a pointer Lunatik does not own and will not free. The
+  `release` callback still runs.
+* Cleanup belongs in an explicit `detach`/`stop`, not hidden in `release`. `release` should be a noop
+  unless there is no alternative.
+* Do not name a C internal allocator `luaXXX_new`. That name implies the object is constructible from
+  Lua. Use `luaXXX_attach` when it is not.
+* Large allocations use `kvmalloc`, and therefore must be freed with `kvfree`, never `kfree`.
+* Objects a C module pre allocates but exposes to Lua use `lunatik_createobject` plus
+  `lunatik_cloneobject`, which requires `.shared = true`.
+
+The registry pattern for a reusable per hook object (`lunatik_getregistry`, reset, pass to Lua, clear
+afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than inventing a variant.
+
+## C style
+
+* C99: initialize at declaration.
+* `else` on its own line, never `} else {`.
+* Single statement `if` without braces.
+* Block comments `/* */`, never `//`.
+* Symbols in a library are prefixed `LUA<LIBNAME>_` or `lua<libname>_`.
+* Kernel headers first, then a blank line, then `#include <lunatik.h>`. Do not remove that blank line.
+* `<lua.h>` and `<lauxlib.h>` are already pulled in by `lunatik.h`.
+* Every file ends with a trailing blank line. A pre commit hook rejects files that do not.
+* Lunatik has no floats. Do not check `lua_isinteger`.
+* Multi line macros use the `do { ... } while (0)` form.
+* Do not duplicate a struct defined by another module; use its exported API.
+* Prefer a named `static inline` helper over an open coded repetition, and do not inline an existing
+  named helper into its callers while refactoring; they exist for readability and symmetry.
+* When a two line pattern repeats in every method, collapse it into one helper or macro.
+* `/*** @section name */` separates logical sections in a merged C file and groups them in the docs.
+
+## Lua style
+
+* Line length 120.
+* Localize stdlib functions at the top of a new module: `local insert = table.insert`.
+* `require("x")` with parentheses.
+* Use `table.insert`, not `t[#t+1] = v`.
+* No nested function definitions; helpers go at module level.
+* Hooks and callbacks are named `local function`s referenced by name, never anonymous functions inline
+  in a table field.
+* Named constants at the top: `local PORT <const> = 5562`. No magic numbers.
+* Prefer the standard library (`string.match`, `string.gsub`, `table.*`) over hand written loops.
+* The kernel Lua state has no `math.type`; use `type(x) == "number"`.
+
+Inside a CLI dostring, require once at startup and call by name afterwards:
+
+    lunatik.foo = require("lunatik.foo")
+    lunatik.foo.method(...)
+
+Never `require("foo").method()`.
+
+## Comments and documentation
+
+* Comments describe the present, not the history. No "was", "no longer", "used to".
+* No comments restating obvious kernel or Lua API usage. Non obvious rationale is welcome.
+* Public functions and object types get LDoc comments. Use `@type <class>` names that do not collide
+  with a function name, or LDoc will attach the wrong things.
+* A new module needs an entry in `config.ld`, inserted in alphabetical order, and a row in the README
+  module table.
+* Do not insert code between a doc block and the function it documents.
+
+## Tests
+
+Tests are shell scripts emitting KTAP plus a kernel side Lua script.
+
+* the description of what a test does goes in the `.sh`. The `.lua` gets one line pointing back at it;
+* skip, do not fail, when the kernel lacks a required config;
+* mark `dmesg` before the run, read only what came after, and `check_dmesg` at the end;
+* clean up in a `trap`, and run the cleanup once up front as well;
+* coverage means the matrix of operation by type by outcome, including the successes, not a list of
+  features and not only the error paths.
+
+A test is not done until `tests/README.md` describes it, the suite's `run.sh` runs it, and, for a new
+suite, the top level `README.md` lists it. Same commit, or a fixup of it.
+
+## Patches and commits
+
+* Small, auditable, incremental commits. Each one stands alone and adds value.
+* Change only what the task requires. Do not reformat untouched lines, do not move code, do not
+  rename variables in passing. Compare `git diff` against `git diff -w` before committing to catch
+  stray whitespace.
+* No cosmetic changes inside a feature or fix commit, not even a blank line.
+* Never remove an existing comment unless the change made it factually wrong.
+* Restoring something that was removed puts it back exactly where and how it was.
+* Subject line says what changed and why, not how. A body only when there is something the diff does
+  not say: a new API, a behaviour change, a non obvious rationale. No bullet list of every detail.
+* Corrections to a commit on your own branch are `git commit --fixup=<hash>`, not a standalone
+  "address review comments" commit. Never fixup a commit that is already on `master`; that becomes a
+  new commit on a new branch.
+* If a branch adds something in one commit and removes it in another, the second is a fixup of the
+  first.
+* After squashing, re read the comments and commit bodies so they describe the final state rather than
+  the path taken.
+* Do not commit directly to `master`.
+* Copyright years: a new file carries the current year; a modified file extends its range to include
+  it.
+
+## Before opening a pull request
+
+1. `make` is clean, with no new warnings;
+2. `sudo make install && sudo lunatik reload && sudo lunatik test` passes;
+3. new API is documented and listed in `config.ld` and the README;
+4. new tests are wired into their suite and described;
+5. error paths audited: for each raise, everything already acquired is released;
+6. commits are small, ordered, and none of them undoes another.
+

--- a/README.md
+++ b/README.md
@@ -579,6 +579,14 @@ cpu_usage_idle{cpu="cpu0"} 100.0000000000000000 1764094519529162
 * [Port Lua Test Suite to the NetBSD Kernel](https://www.google-melange.com/archive/gsoc/2015/orgs/lablua/projects/gmesalazar.html) — LabLua (2015), Guilherme Salazar
 * [Lua scripting in the NetBSD kernel](http://netbsd-soc.sourceforge.net/projects/luakern/) — The NetBSD Foundation (2010), Lourival Vieira Neto
 
+## Contributing
+
+Conventions for contributors, and for AI coding assistants working on this repository, are in
+[AGENTS.md](AGENTS.md): build and test loop, execution contexts, object model, code style, and commit
+discipline. Design notes for work in progress live under [docs/design](docs/design); what is being
+worked on, and how far along it is, lives in the
+[project boards](https://github.com/orgs/luainkernel/projects).
+
 ## License
 
 Lunatik is dual-licensed under [MIT](LICENSE-MIT) or [GPL-2.0-only](LICENSE-GPL).

--- a/docs/design/conntrack-nat/README.md
+++ b/docs/design/conntrack-nat/README.md
@@ -1,0 +1,37 @@
+# Conntrack and NAT support
+
+Working documents for the conntrack and NAT binding, initially proposed on the
+[LabLua GSoC ideas page](https://github.com/labluapucrio/gsoc/blob/main/2026/ideas.md#conntrack-and-nat-support-for-lunatik)
+and now tracked here as a regular project. They exist so that a new contributor, with or without an AI
+coding assistant, can pick the work up without reverse engineering the netfilter internals first.
+
+| Document | What it is for |
+|----------|----------------|
+| [plan.md](plan.md) | Current state, gap analysis, phases, non goals, definition of done |
+| [api.md](api.md) | Proposed Lua API for the `conntrack` and `nat` modules, with a worked example |
+| [kernel-notes.md](kernel-notes.md) | Verified kernel API reference: symbols, signatures, context rules, config dependencies |
+| [testing.md](testing.md) | Test strategy, the namespace harness the suite needs, and the test matrix |
+
+Start with `plan.md`. Read `kernel-notes.md` before writing any C.
+
+## Working on this
+
+The repository conventions that apply to every change here (build, test, style, kernel context rules,
+commit discipline) are in [AGENTS.md](../../../AGENTS.md) at the root of the repository. Read it once
+before the first patch. If you use an AI assistant, point it at that file and at `kernel-notes.md`.
+
+Two habits matter more than anything else in this project:
+
+1. **Verify kernel APIs against the kernel you are building for.** Netfilter internals move. Several
+   signatures quoted in `kernel-notes.md` changed within the 6.x series. Check the headers under
+   `/usr/src/linux-headers-$(uname -r)/include` and confirm exports in `Module.symvers` before
+   assuming a function exists or takes the arguments you remember.
+2. **Know which context your code runs in.** Registration is process context; hooks are softirq. A
+   sleeping call reached from a hook does not return an error, it wedges the machine.
+
+## Status
+
+These documents describe the design; they do not track progress. What is in flight, and how far along
+each phase is, lives on the [conntrack and NAT board](https://github.com/orgs/luainkernel/projects/1).
+Each phase is an issue there and lands as its own pull request.
+

--- a/docs/design/conntrack-nat/api.md
+++ b/docs/design/conntrack-nat/api.md
@@ -1,0 +1,360 @@
+# Proposed Lua API: `conntrack` and `nat`
+
+This is a design proposal, not a specification. Names and shapes are open for review; the constraints
+behind them (in `kernel-notes.md`) are not. Anything here that turns out to conflict with a kernel
+constraint loses.
+
+Two new kernel modules:
+
+* `conntrack` (`lib/luaconntrack.c`, plus `lib/luaconntrack.h` for the cross-module checker), which
+  owns the `conntrack` object class and everything that reads or writes conntrack state;
+* `nat` (`lib/luanat.c`), which owns NAT hook registration and the translation setup calls.
+
+The split follows the kernel's own split (`nf_conntrack.ko` and `nf_nat.ko`), keeps `CONFIG_NF_NAT`
+out of the conntrack module, and lets a script that only reads connection state avoid pulling in NAT.
+`nat` depends on `conntrack` and `skb`.
+
+## Conventions
+
+* IPv4 addresses are host order integers, matching `net.aton`/`net.ntoa` and the existing socket API.
+* IPv6 addresses are 16 byte binary strings. `lib/net.lua` gains `aton6`/`ntoa6` for them.
+* Ports are host order integers. The C side does the `ntohs`.
+* Constants come from `linux.nf` via autogen: `nf.ct.info`, `nf.ct.status`, `nf.ct.dir`, `nf.ct.tcp`,
+  `nf.ct.event`, `nf.nat.range`.
+* Missing optional kernel features mean a missing method, not a runtime error. A script can probe with
+  `if ct.mark then ... end`, the same way `skb:connmark` behaves today.
+
+## `conntrack`
+
+### `conntrack.get(skb)` -> `ct`, `info`
+
+Wraps `nf_ct_get`. Returns `nil` for `ct` when the packet carries no conntrack. `info` is one of
+`nf.ct.info.*` (`NEW`, `ESTABLISHED`, `RELATED`, and their `_REPLY` forms).
+
+Return `info` even when `ct` is `nil`, because the two nil cases are not the same. A packet the ruleset
+sent through `notrack` carries `ct == NULL` with `ctinfo == IP_CT_UNTRACKED`
+(`nft_ct.c` and `xt_CT.c` both do `nf_ct_set(skb, NULL, IP_CT_UNTRACKED)`), while a packet conntrack
+never saw carries neither. A script that wants to distinguish "deliberately untracked" from "not
+tracked yet" needs the second value.
+
+    local conntrack = require("conntrack")
+    local nf        = require("linux.nf")
+
+    local function hook(skb)
+        local ct, info = conntrack.get(skb)
+        if ct and info == nf.ct.info.NEW then
+            print("new flow", ct:tuple().dport)
+        end
+        return nf.action.ACCEPT
+    end
+
+**Why a module function and not `skb:conntrack()`.** The framework precedent is a method on the object
+(`skb:data()` returns a `data`), but the module dependency decides against it here. `skb:connmark`
+lives inside `luaskb` only because `nf_ct_get` is inline and `ct->mark` is direct struct access, so
+`luaskb.ko` imports no conntrack symbol. A `skb:conntrack()` returning an object of the conntrack
+class would need a constructor exported by `luaconntrack.ko`, chaining
+`luaskb.ko → luaconntrack.ko → nf_conntrack.ko`, and since `require` pins modules, every skb user
+(any L2 filter, any XDP script) would load and pin conntrack forever. `conntrack.get(skb)` keeps the
+arrow pointing the right way: only scripts that want conntrack pay for it.
+
+**Lifetime.** `nf_ct_get` returns a borrowed pointer. The object takes its own reference
+(`nf_conntrack_get`) at creation and drops it on collection (`nf_ct_put` in `release`; the destroy
+path is atomic safe, the kernel runs it from softirq routinely), so a script that stashes a `ct` in a
+global cannot dangle. The cost is one atomic plus one object allocation per call on the packet path,
+which is the right trade for a scripting layer: a use-after-free here is a kernel oops, and Lunatik's
+whole premise is that a bad script must not take the machine down.
+
+Phase 1 benchmarks that cost. If it shows, the optimization is a per-runtime freelist that reuses dead
+`ct` userdata, which changes neither the semantics nor the Lua API. The skb-style registry cache
+(reset per hook, cleared afterwards) is not the fallback here: clearing on return is exactly the
+lifetime problem the refcount closes.
+
+**Class shape.** `LUNATIK_OPT_SOFTIRQ`, and neither `SINGLE` (several `ct` objects can be alive at
+once: `master()`, `lookup()`) nor `MONITOR` (methods are short reads). `.pointer = true`: the
+`struct nf_conn *` is not owned by Lunatik, `release` only drops the reference. Errors follow the base
+convention, negative errno raised via `lunatik_throw`/`pusherrname`.
+
+### The `conntrack` object
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `ct:tuple([dir])` | table | `dir` defaults to `nf.ct.dir.ORIGINAL` |
+| `ct:status()` | integer | test against `nf.ct.status.*` (`SEEN_REPLY`, `ASSURED`, `SRC_NAT`, ...) |
+| `ct:id()` | integer | `nf_ct_get_id`, stable while the entry lives |
+| `ct:timeout()` | integer | milliseconds until expiry |
+| `ct:refresh(ms)` | | extend the timeout |
+| `ct:mark([value])` | integer | `CONFIG_NF_CONNTRACK_MARK`; same storage as `skb:connmark` |
+| `ct:labels()` | 16 byte string | `CONFIG_NF_CONNTRACK_LABELS`; the label bitmap is 128 bits (`XT_CONNLABEL_MAXBIT` is 127), it does not fit a Lua integer |
+| `ct:zone()` | integer | the zone id; the kernel zone also carries `flags` and `dir`, not exposed |
+| `ct:counters([dir])` | packets, bytes | `CONFIG_NF_CONNTRACK_ACCT` |
+| `ct:tcpstate()` | integer | `nf.ct.tcp.*`; `nil` for non TCP |
+| `ct:master()` | `conntrack` | the connection this one is `RELATED` to; the new object takes its own reference |
+| `ct:helper()` | string | helper name, or `nil`; `nfct_help(ct)->helper` is `__rcu`, dereference accordingly |
+| `ct:delete()` | | `nf_ct_delete` |
+| `ct:expect(spec)` | | see below |
+
+The tuple table:
+
+    {
+      family   = nf.proto.IPV4,   -- or IPV6
+      protocol = ipproto.TCP,
+      src = 3232235777, sport = 51234,   -- integer for IPv4, 16 byte string for IPv6
+      dst = 3232235778, dport = 80,
+    }
+
+For ICMP, `sport`/`dport` are absent and `type`/`code`/`id` take their place.
+
+A fresh table per call is fine here: per packet code reads fields straight from `skb:data()`, as
+scripts already do today, so `ct:tuple()` is not hot path material. Its value is the view only
+conntrack has, the reply tuple after NAT and the original tuple seen from a reply. Say so in the LDoc.
+
+`skb:connmark` stays exactly as it is. `ct:mark` is the same 32 bits reached through the conntrack
+object; `skb:connmark` remains the convenient form when a hook only wants the mark and nothing else.
+
+### Table access
+
+    conntrack.count()             -- entries in the table
+    conntrack.max()               -- table limit
+    conntrack.lookup(tuple)       -- ct or nil; takes a reference
+    conntrack.each(function(ct)   -- iterate; return false to stop
+        ...
+    end)
+
+`conntrack.lookup` builds a `struct nf_conntrack_tuple` from the same table shape `ct:tuple()`
+returns, so a tuple can round trip.
+
+`conntrack.each` is the `conntrack -L` equivalent. See `kernel-notes.md` for the walk choice and its
+context restrictions.
+
+### Events
+
+    conntrack.watch(function(events, ct)
+        if events & (1 << nf.ct.event.DESTROY) ~= 0 then
+            ...
+        end
+    end)
+    conntrack.unwatch()
+
+`nf.ct.event.*` are **bit positions**, not masks: `enum ip_conntrack_events` numbers its members 0, 1,
+2, ..., and the kernel builds the mask itself (`nf_conntrack_event` calls
+`nf_conntrack_eventmask_report(1 << event, ...)`). The `events` argument is that mask, so testing a bit
+means shifting first. Writing `events & nf.ct.event.DESTROY` reads naturally and is wrong: with
+`DESTROY = 2` it tests bit 1, which is `RELATED`.
+
+One watcher per netns, enforced by the kernel. The runtime must be `softirq`, but the callback does
+**not** fire only from softirq: the ecache retry path redelivers missed `DESTROY` events from a
+workqueue, in process context (`ecache_work_evict_list` calls `nf_conntrack_event`,
+`nf_conntrack_ecache.c`). A `softirq` runtime handles both, `spin_lock_bh` is callable from process
+context, but the implementation must not assume softirq-only. `conntrack.watch` raises if a notifier
+is already installed rather than stealing ctnetlink's slot.
+
+**Verify before implementing:** whether `nf_conntrack_unregister_notifier` sleeps (a `synchronize_rcu`
+would be typical). If it does, `unwatch` cannot run from the softirq runtime itself, and teardown
+follows the soft-stop convention: cleanup in `release`, on a pinned object, as `netlink.channel` does.
+
+### Creating entries
+
+    local ct = conntrack.new{
+        original = { family = nf.proto.IPV4, protocol = ipproto.UDP,
+                     src = net.aton("10.0.0.1"), sport = 1000,
+                     dst = net.aton("10.0.0.2"), dport = 2000 },
+        reply    = { ... },        -- optional, inverted from original when omitted
+        timeout  = 30000,          -- ms
+        status   = nf.ct.status.CONFIRMED,
+        mark     = 0x10,
+    }
+
+Wraps allocate, populate, insert. Raises on `-EEXIST` when the tuple is already taken. Process context
+only in the first cut.
+
+### Expectations
+
+    ct:expect{
+        family   = nf.proto.IPV4,
+        protocol = ipproto.TCP,
+        src = nil,                 -- nil means "any", as the expectation mask allows
+        dst = net.aton("10.0.0.2"), dport = 5001,
+        timeout = 30000,
+    }
+
+This is how a Lua ALG pre-authorizes a data connection: the expected flow arrives as `RELATED` and,
+under NAT, follows the master's translation.
+
+## `nat`
+
+### `nat.register(opts)` -> `nat_hook`
+
+    local nat = require("nat")
+
+    local function dnat_hook(skb)
+        local ct = conntrack.get(skb)
+        nat.dnat(ct, { addr = net.aton("10.0.0.5"), port = 8080 })
+        return nf.action.ACCEPT
+    end
+
+    nat.register{
+        hook    = dnat_hook,
+        pf      = nf.proto.IPV4,          -- IPV4, IPV6 or INET
+        hooknum = nf.inet.PRE_ROUTING,    -- one of the four NAT hooks
+    }
+
+There is no `priority`: the NAT core owns it. Collecting the returned handle unregisters the hook, the
+same contract `netfilter.register` has today.
+
+The hook is called at most once per connection per direction, and only while no binding exists. Every
+subsequent packet is translated by the kernel with no Lua involvement. Established packets never reach
+the hook, so a script cannot use a NAT hook as a general packet filter; that is what `netfilter.register`
+is for.
+
+The hook signature is `(skb)`, the same as `netfilter.register`. There is no `state` object: everything
+`struct nf_hook_state` carries is either something the script already knows because it registered the
+hook (`hooknum`, `pf`) or reachable through the skb (`skb:ifindex()` is the ingress device at
+`PRE_ROUTING` and the egress device at `POST_ROUTING`). What the C side needs from the state
+(masquerade wants the hooknum and the out device) the binding captures internally: the hook stores the
+`nf_hook_state` pointer in its private struct before the `pcall` and clears it afterwards, under the
+runtime lock, the same reset/clear pattern `luanetfilter` uses for the skb.
+
+### Translation setup
+
+    nat.snat(ct, range)     -- NF_NAT_MANIP_SRC
+    nat.dnat(ct, range)     -- NF_NAT_MANIP_DST
+
+`range`:
+
+    {
+      addr = ..., addr_max = ...,   -- optional; sets NF_NAT_RANGE_MAP_IPS
+      port = ..., port_max = ...,   -- optional; sets NF_NAT_RANGE_PROTO_SPECIFIED
+      flags = nf.nat.range.PROTO_RANDOM_FULLY,   -- optional extras, OR'ed in
+    }
+
+`addr_max`/`port_max` default to their `_min` counterparts. `NF_NAT_RANGE_MAP_IPS` and
+`NF_NAT_RANGE_PROTO_SPECIFIED` are derived from the presence of `addr` and `port`, so the common case
+stays two keys and neither flag belongs in `nf.nat.range`: a script that passed one would either
+duplicate the derivation or contradict it. Both calls raise if the manip type contradicts the hook the
+call is made from (SNAT outside `POST_ROUTING`/`LOCAL_IN`), which is a mistake the kernel would
+otherwise absorb silently.
+
+The flags a script can meaningfully choose are `PROTO_RANDOM`, `PROTO_RANDOM_FULLY` and `PERSISTENT`.
+Two more exist and are not usable as specified, so they stay out until the API grows to fit them:
+
+* `PROTO_OFFSET` reads `range->base_proto` (`nf_nat_core.c:552`), which this range table has no key
+  for. Adding it means adding a `base_port`.
+* `NETMAP` is not implemented by `nf_nat_setup_info` at all. The caller does the arithmetic:
+  `nft_nat_setup_netmap()` computes the mapped address and only passes the flag along. Supporting it
+  means doing that arithmetic in the binding, not forwarding a flag.
+
+### Shorthands
+
+    nat.masquerade(skb[, range])   -- source address of the outgoing interface
+    nat.redirect(skb, range)       -- to a local address on the incoming interface
+
+These wrap `nf_nat_masquerade_ipv4/ipv6` and `nf_nat_redirect_ipv4/ipv6`, which need the hooknum and
+the output device; both come from the internally captured hook state, so the Lua side never sees them.
+The masquerade notifiers are registered once at module init.
+
+## Worked example: L7 load balancer
+
+The project's motivating scenario, end to end. The classifier reads the HTTP `Host` header,
+which is one `string.match` away, rather than parsing a TLS ClientHello for the SNI. Same design, far
+less code in the part that is not the point of the example.
+
+### The constraint that decides the shape
+
+A payload based decision cannot steer the connection that carried it.
+
+For a TCP connection the NAT hook runs on the SYN, because that is the `IP_CT_NEW` packet. The `Host`
+header arrives after the handshake, by which time a binding (possibly the null binding the core
+installs when Lua declines) already exists and the hook is never called again. The same is true of the
+TLS SNI: both live in the first *data* packet, not the first packet.
+
+So the example is sticky by client: the first connection from a client goes to the default backend and
+teaches the map; every later connection from that client is steered on its SYN. That is a real load
+balancing strategy, it exercises `conntrack`, `nat` and `rcu` together, and it is honest about what
+the primitives can do.
+
+A version that steers on the very first connection is possible over UDP, where the first packet
+carries the payload; DNS is the obvious candidate and is worth a second, smaller example.
+
+    local netfilter = require("netfilter")
+    local conntrack = require("conntrack")
+    local nat       = require("nat")
+    local rcu       = require("rcu")
+    local nf        = require("linux.nf")
+    local net       = require("net")
+
+    local BACKENDS <const> = {
+        ["a.example.com"] = net.aton("10.0.0.11"),
+        ["b.example.com"] = net.aton("10.0.0.12"),
+    }
+    local affinity = rcu.table()
+
+    -- On the first data packet of a connection, learn where this client belongs.
+    local function classify(skb)
+        local ct = conntrack.get(skb)
+        if not ct then return nf.action.ACCEPT end
+        local host = string.match(payload(skb), "\r\nHost: ([^\r\n]+)")
+        local backend = host and BACKENDS[host]
+        if backend then affinity[client(ct)] = backend end
+        return nf.action.ACCEPT
+    end
+
+    -- On the SYN of a later connection from the same client, apply what we learned.
+    local function balance(skb)
+        local ct = conntrack.get(skb)
+        local backend = ct and affinity[client(ct)]
+        if backend then
+            nat.dnat(ct, { addr = backend, port = 80 })
+        end
+        return nf.action.ACCEPT
+    end
+
+    netfilter.register{ hook = classify, pf = nf.proto.IPV4,
+                        hooknum = nf.inet.PRE_ROUTING, priority = nf.ip.pri.CONNTRACK + 1 }
+    nat.register{ hook = balance, pf = nf.proto.IPV4, hooknum = nf.inet.PRE_ROUTING }
+
+The classifier still has to run after conntrack has attached an entry, hence the priority. `payload`
+and `client` are small Lua helpers over `skb:data()` and `ct:tuple()`, the latter returning a string
+because `rcu.table` keys are strings; keeping them out of the sketch is the point, since the example is
+about the conntrack and NAT plumbing.
+
+## Autogen additions
+
+New entries in `autogen/specs.lua`. **Each table lands with the phase that consumes it**, not all up
+front: `linux.nf` is published API, and a table whose consumer does not exist yet freezes a shape
+before the API that uses it has been designed.
+
+| Header | Prefix | Module | Lands with |
+|--------|--------|--------|-----------|
+| `uapi/linux/netfilter/nf_conntrack_common.h` | `IP_CT_` | `nf.ct.info` | the `conntrack` object |
+| `uapi/linux/netfilter/nf_conntrack_common.h` | `IPS_` | `nf.ct.status` | the `conntrack` object |
+| `uapi/linux/netfilter/nf_conntrack_tuple_common.h` | `IP_CT_DIR_` | `nf.ct.dir` | the `conntrack` object |
+| `uapi/linux/netfilter/nf_conntrack_tcp.h` | `TCP_CONNTRACK_` | `nf.ct.tcp` | the `conntrack` object |
+| `uapi/linux/netfilter/nf_nat.h` | `NF_NAT_RANGE_` | `nf.nat.range` | the `nat` module |
+| `uapi/linux/netfilter/nf_conntrack_common.h` | `IPCT_` | `nf.ct.event` | conntrack events |
+
+There is no `nf.nat.manip`. `nat.snat` and `nat.dnat` encode the manip type in the function name, so
+nothing would read it, and `NF_NAT_MANIP_*` lives in `net/netfilter/nf_nat.h`, a non-uapi header and
+the most fragile source available. Add it if an API ever needs to name a manip type.
+
+Wrinkles the contributor will hit:
+
+* `IPS_*` defines both `IPS_FOO_BIT` and `IPS_FOO`. `specs.lua` supports `exclude`, but it matches a
+  prefix, so it cannot drop the `_BIT` names. Either add suffix exclusion to `autogen.lua` (small,
+  self contained, a good warm up task) or enumerate with `include`.
+* `IP_CT_` and `IP_CT_DIR_` share a prefix, so the `nf.ct.info` entry needs `exclude = "IP_CT_DIR_"`,
+  the same way `nf.br` excludes `NF_BR_PRI_`.
+* the enums carry sentinels that are not values a script should ever use: `IP_CT_NUMBER` (the kernel
+  asserts this with `BUILD_BUG_ON(IP_CT_UNTRACKED == IP_CT_NUMBER)`), `IP_CT_DIR_MAX`,
+  `TCP_CONNTRACK_MAX`. Exclude them. `IP_CT_IS_REPLY` stays, because the kernel itself compares against
+  it to derive direction, but it shares its value with `IP_CT_ESTABLISHED_REPLY` and the table
+  description has to say so.
+* `TCP_CONNTRACK_IGNORE`, `_RETRANS` and `_UNACK` are not states. `ct->proto.tcp.state` only ever holds
+  0 to 9, the ten entries of the kernel's own `tcp_conntrack_names[]`: `IGNORE` and `MAX` are handled
+  in a switch that returns before the state is assigned, `RETRANS` and `UNACK` are indices into the
+  timeout array, and ctnetlink rejects anything `>= TCP_CONNTRACK_MAX`. Enumerate the real states with
+  `include` rather than excluding sentinels one at a time.
+* `IPS_UNTRACKED` is marked obsolete in the header, and the bit is re-purposed in kernel builds as
+  `IPS_NAT_CLASH`. Both names should be present, the way `nf.ct.tcp` carries both `LISTEN` and its live
+  replacement `SYN_SENT2`.
+* `IPCT_*` are bit positions, not masks. See the events section.
+

--- a/docs/design/conntrack-nat/kernel-notes.md
+++ b/docs/design/conntrack-nat/kernel-notes.md
@@ -1,0 +1,271 @@
+# Kernel notes: conntrack and NAT
+
+Reference sheet for the conntrack/NAT binding. Every symbol and signature below was checked against
+Linux 6.8 (`/usr/src/linux-headers-$(uname -r)/include`, `Module.symvers`) and the upstream sources
+listed at the end. Re-check on the kernel you target before relying on any of it: netfilter internals
+change between releases, and a few of these signatures changed as recently as 6.x.
+
+## Header map
+
+| Header | What you need from it |
+|--------|----------------------|
+| `net/netfilter/nf_conntrack.h` | `struct nf_conn`, `nf_ct_get`, `nf_ct_set`, tuple accessors, alloc/insert, iteration |
+| `net/netfilter/nf_conntrack_core.h` | `nf_conntrack_find_get`, confirm helpers |
+| `net/netfilter/nf_conntrack_tuple.h` | `struct nf_conntrack_tuple` |
+| `net/netfilter/nf_conntrack_acct.h` | `nf_conn_acct_find`, `struct nf_conn_counter` |
+| `net/netfilter/nf_conntrack_labels.h` | `nf_ct_labels_find`, `nf_connlabel_set` |
+| `net/netfilter/nf_conntrack_ecache.h` | `struct nf_ct_event_notifier`, register/unregister |
+| `net/netfilter/nf_conntrack_expect.h` | `nf_ct_expect_alloc/init/related/put` |
+| `net/netfilter/nf_conntrack_zones.h` | `nf_ct_zone`, `nf_ct_zone_dflt` |
+| `net/netfilter/nf_nat.h` | `nf_nat_setup_info`, `nf_nat_packet`, the `*_register_fn` family |
+| `net/netfilter/nf_nat_masquerade.h` | `nf_nat_masquerade_ipv4/ipv6` and their notifiers |
+| `net/netfilter/nf_nat_redirect.h` | `nf_nat_redirect_ipv4/ipv6` |
+| `uapi/linux/netfilter/nf_conntrack_common.h` | `enum ip_conntrack_info`, `enum ip_conntrack_status` (`IPS_*`), `enum ip_conntrack_events` (`IPCT_*`) |
+| `uapi/linux/netfilter/nf_conntrack_tuple_common.h` | `enum ip_conntrack_dir` (`IP_CT_DIR_*`), `CTINFO2DIR` |
+| `uapi/linux/netfilter/nf_conntrack_tcp.h` | `TCP_CONNTRACK_*` |
+| `uapi/linux/netfilter/nf_nat.h` | `NF_NAT_RANGE_*`, `struct nf_nat_range2` |
+
+All of these ship in `linux-headers-$(uname -r)`, so an out-of-tree module can use them without a
+kernel source tree.
+
+## Exported symbols we rely on
+
+Checked in `Module.symvers`. `EXPORT_SYMBOL_GPL` is fine for Lunatik: its modules declare
+`MODULE_LICENSE("Dual MIT/GPL")`, which the module loader treats as GPL compatible.
+
+Read path:
+
+    nf_conntrack_find_get        GPL   lookup by tuple, takes a reference
+    nf_conntrack_count           GPL   number of entries in a netns
+    nf_conntrack_max             GPL   table limit (data symbol)
+    nf_conntrack_hash            GPL   hash table (data symbol, use nf_conntrack_get_ht)
+    nf_conntrack_htable_size     GPL   bucket count (data symbol)
+    nf_ct_iterate_cleanup_net    GPL   sanctioned iteration, may sleep
+    nf_ct_get_id                 GPL   stable per-entry id
+    nf_ct_delete                 GPL   remove an entry
+    nf_ct_kill_acct              GPL   remove and account
+    __nf_ct_refresh_acct         GPL   backing of nf_ct_refresh()
+    nf_ct_zone_dflt              GPL   default zone (data symbol)
+
+Write / create path:
+
+    nf_conntrack_alloc              GPL   allocate an unconfirmed entry
+    nf_conntrack_free               GPL   undo nf_conntrack_alloc
+    nf_conntrack_hash_check_insert  GPL   insert a prepared entry (what ctnetlink NEW uses)
+    nf_conntrack_confirm            (inline over __nf_conntrack_confirm, GPL)
+    nf_ct_expect_alloc/init/put     GPL   expectations
+    nf_ct_expect_related_report     GPL   backing of nf_ct_expect_related()
+    nf_conntrack_helper_register    GPL   register a helper (ALG)
+    nf_ct_netns_get / nf_ct_netns_put  GPL   pin conntrack for a family in a netns
+
+Events:
+
+    nf_conntrack_register_notifier    GPL   void, one notifier per netns
+    nf_conntrack_unregister_notifier  GPL
+
+NAT:
+
+    nf_nat_setup_info             plain EXPORT_SYMBOL
+    nf_nat_alloc_null_binding     GPL
+    nf_nat_packet                 GPL
+    nf_nat_ipv4_register_fn       GPL   plus the ipv6 and inet variants and their unregister twins
+    nf_nat_masquerade_ipv4        GPL   also ipv6
+    nf_nat_masquerade_inet_register_notifiers    GPL
+    nf_nat_redirect_ipv4          GPL   also ipv6
+
+Reference counting is inline in `uapi/linux/netfilter/nf_conntrack_common.h`
+(`nf_conntrack_get`/`nf_conntrack_put`), backed by the exported `nf_conntrack_destroy`.
+
+## Semantics that shape the API
+
+### `nf_ct_get` does not take a reference
+
+    static inline struct nf_conn *
+    nf_ct_get(const struct sk_buff *skb, enum ip_conntrack_info *ctinfo)
+
+The returned `struct nf_conn *` is only guaranteed to live as long as the skb reference held by the
+caller, that is, for the duration of the hook. A Lua object wrapping it must either be cleared when
+the hook returns (the `luaskb` pattern) or take a reference of its own. See `api.md` for the choice
+made and why.
+
+`nf_conntrack_find_get`, by contrast, returns a tuple hash with a reference already taken, so the
+caller owns it and must `nf_ct_put`.
+
+### The NAT core calls your hook only once per connection per direction
+
+`nf_nat_ipv4_register_fn(net, ops)` does not install `ops->hook` as a netfilter hook. It installs the
+NAT core's own hook (`nf_nat_inet_fn`) at the family's four NAT hook points, and chains `ops->hook`
+into a private lookup list. From `net/netfilter/nf_nat_core.c`:
+
+    case IP_CT_NEW:
+        if (!nf_nat_initialized(ct, maniptype)) {
+            ...
+            for (i = 0; i < e->num_hook_entries; i++) {
+                ret = e->hooks[i].hook(e->hooks[i].priv, skb, state);
+                if (ret != NF_ACCEPT)
+                    return ret;
+                if (nf_nat_initialized(ct, maniptype))
+                    goto do_nat;
+            }
+    null_bind:
+            ret = nf_nat_alloc_null_binding(ct, state->hook);
+            ...
+    do_nat:
+        return nf_nat_packet(ct, ctinfo, state->hook, skb);
+
+Consequences for the Lua binding:
+
+* the Lua hook runs for `IP_CT_NEW`, `IP_CT_RELATED` and `IP_CT_RELATED_REPLY` packets only, and only
+  while no binding exists for that manip type. Established packets never reach Lua;
+* the hook's job is to call `nf_nat_setup_info` (via `nat.snat`/`nat.dnat`) and return `NF_ACCEPT`.
+  Returning `NF_ACCEPT` without setting anything up means "no NAT for this connection", and the core
+  installs a null binding;
+* the actual header rewriting is done by `nf_nat_packet` for every packet, not by Lua. This is what
+  makes a Lua L7 load balancer cheap: Lua decides once, the kernel translates forever;
+* `ops->priority` is ignored. The NAT core owns the priorities (`NF_IP_PRI_NAT_DST`, `NF_IP_PRI_NAT_SRC`).
+  `ops->pf` and `ops->hooknum` are used, and `hooknum` must be one of the family's four NAT hooks;
+* `nf_nat_register_fn` takes a mutex and allocates with `GFP_KERNEL`. It must be called from process
+  context (see below).
+
+`HOOK2MANIP(hooknum)` decides SRC versus DST: `POST_ROUTING` and `LOCAL_IN` are SRC, the rest are DST.
+Asking for a SNAT range at `PRE_ROUTING` is a user error the binding should reject up front.
+
+### Registration happens in process context, hooks fire in softirq
+
+Lunatik runs a runtime's script once at creation time, before `lunatik_setready`, with
+`runtime->gfp = GFP_KERNEL` and no runtime lock held (`lunatik_core.c:lunatik_newruntime`). So a
+top-level `nat.register{...}` or `netfilter.register{...}` in the script is process context and may
+sleep, even for a `softirq` runtime.
+
+Everything that runs later from a hook is different: a `softirq` runtime holds `spin_lock_bh` around
+`lua_pcall` and allocates with `GFP_ATOMIC`. Anything reachable from a hook must be atomic safe.
+
+Practical rule for this project:
+
+| Operation | Context |
+|-----------|---------|
+| `nat.register`, `conntrack.watch`, helper registration | process only, at script load |
+| `conntrack.get`, tuple/status/mark/counter reads, `nat.snat`, `nat.dnat` | atomic safe, usable from hooks |
+| `conntrack.each` over the whole table | process only, see below |
+| `conntrack.new` | depends on the gfp used; keep it process only in the first cut |
+
+Use `lunatik_cannotsleep(L, true)` to reject the sleeping entry points when called from an
+IRQ-context runtime rather than letting them crash the machine.
+
+### Iterating the table: two options
+
+`nf_ct_iterate_cleanup_net` changed shape in 6.x. On 6.8 it is:
+
+    struct nf_ct_iter_data { struct net *net; void *data; u32 portid; int report; };
+    void nf_ct_iterate_cleanup_net(int (*iter)(struct nf_conn *i, void *data),
+                                   const struct nf_ct_iter_data *iter_data);
+
+An iterator that always returns 0 never deletes anything, so it can be used read only. It is simple
+and correct, but it is a cleanup shaped API (it takes per bucket locks and reschedules), so it is
+process context only.
+
+The alternative is the RCU hash walk that `ctnetlink_dump_table` performs, using the inline
+`nf_conntrack_get_ht(&hash, &hsize)` from `nf_conntrack.h`, which resolves the seqcount race against a
+hash resize for you. It works from atomic context and is what a `conntrack -L` equivalent should use.
+The nulls list requires the usual restart-on-nulls-mismatch dance.
+
+Recommendation: implement the RCU walk, mirroring `ctnetlink_dump_table`, and document that the Lua
+callback must be short. Prototype both if the walk turns out to be subtle on the target kernel.
+
+### Events
+
+    struct nf_ct_event_notifier {
+        int (*ct_event)(unsigned int events, const struct nf_ct_event *item);
+        int (*exp_event)(unsigned int events, const struct nf_exp_event *item);
+    };
+    void nf_conntrack_register_notifier(struct net *net, const struct nf_ct_event_notifier *nb);
+    void nf_conntrack_unregister_notifier(struct net *net);
+
+Caveats worth putting in the docs:
+
+* there is exactly one notifier slot per netns. Registering while `ctnetlink` has one installed
+  (anything running `conntrack -E`, or conntrackd) triggers a `WARN_ON_ONCE` and steals the slot.
+  The binding should refuse to register twice from Lua and should say so in the error message;
+* events only fire when the ecache extension is present, which requires
+  `CONFIG_NF_CONNTRACK_EVENTS` and `sysctl net.netfilter.nf_conntrack_events=1`;
+* callbacks fire in softirq **and** in process context: the ecache retry path redelivers missed
+  `DESTROY` events from a workqueue (`ecache_work_evict_list` calls `nf_conntrack_event`,
+  `nf_conntrack_ecache.c`). A `softirq` runtime handles both, `spin_lock_bh` is callable from process
+  context, but do not write code that assumes softirq only;
+* not verified yet: whether `nf_conntrack_unregister_notifier` sleeps (a `synchronize_rcu` would be
+  typical). If it does, unregistering cannot run from the softirq runtime itself and teardown follows
+  the soft-stop shape: cleanup in `release`, on a pinned object, as `netlink.channel` does. Settle
+  this before implementing `unwatch`.
+
+### Creating entries
+
+`ctnetlink_create_conntrack` in `net/netfilter/nf_conntrack_netlink.c` is the reference
+implementation. The shape is:
+
+1. `nf_conntrack_alloc(net, zone, &orig_tuple, &repl_tuple, gfp)`;
+2. set `ct->timeout`, status bits, and add the extensions you want (acct, mark, labels, ecache)
+   *before* insertion;
+3. for a NAT'ed entry, call `nf_nat_setup_info` while the entry is still unconfirmed;
+4. `nf_conntrack_hash_check_insert(ct)`, which fails with `-EEXIST` if the tuple is taken.
+
+Getting the reply tuple wrong is the classic way to end up with an entry that never matches traffic.
+`nf_ct_invert_tuple` (exported) builds it from the original.
+
+### Expectations
+
+    struct nf_conntrack_expect *nf_ct_expect_alloc(struct nf_conn *me);
+    void nf_ct_expect_init(struct nf_conntrack_expect *, unsigned int class, u_int8_t family,
+                           const union nf_inet_addr *saddr, const union nf_inet_addr *daddr,
+                           u_int8_t proto, const __be16 *src, const __be16 *dst);
+    int nf_ct_expect_related(struct nf_conntrack_expect *expect, unsigned int flags);
+    void nf_ct_expect_put(struct nf_conntrack_expect *exp);
+
+`nf_ct_expect_related` consumes nothing: the caller still owns its reference and must put it. Set
+`exp->timeout` before relating. `NF_CT_EXPECT_CLASS_DEFAULT` is 0. This is the mechanism behind every
+ALG (FTP, SIP, TFTP) and is what lets a Lua helper pre-authorize a data connection.
+
+### Labels are 128 bits
+
+`struct nf_conn_labels` is `unsigned long bits[]` sized by `XT_CONNLABEL_MAXBIT` (127), 16 bytes. A
+label set does not fit a Lua integer; `ct:labels()` returns a 16 byte binary string.
+
+### Kconfig dependencies
+
+`LUNATIK_CONNTRACK` needs `depends on NF_CONNTRACK` and `LUNATIK_NAT` needs `depends on NF_NAT` in
+`Kconfig`, on top of the per feature guards below.
+
+| Feature | Requires |
+|---------|----------|
+| everything here | `CONFIG_NF_CONNTRACK` |
+| `ct:mark` | `CONFIG_NF_CONNTRACK_MARK` |
+| `ct:labels` | `CONFIG_NF_CONNTRACK_LABELS` |
+| `ct:counters` | `CONFIG_NF_CONNTRACK_ACCT` plus `sysctl net.netfilter.nf_conntrack_acct=1` |
+| `conntrack.watch` | `CONFIG_NF_CONNTRACK_EVENTS` plus `nf_conntrack_events=1` |
+| NAT | `CONFIG_NF_NAT` |
+| masquerade | `CONFIG_NF_NAT_MASQUERADE` |
+| IPv6 NAT | `CONFIG_IPV6` and `CONFIG_NF_NAT` |
+
+Follow the existing `luaskb.c` precedent: guard optional methods with `#if defined(CONFIG_...)` so the
+method is simply absent from the metatable, and let tests skip cleanly when it is missing.
+
+Note that `nf_ct_netns_get(net, pf)` is what makes conntrack actually engage for a family. `iptable_nat`
+and `nft_chain_nat` call it when a chain is registered. Without it, a Lua NAT hook can register
+successfully and then never see a tracked packet on an otherwise idle box.
+
+## Namespaces
+
+Both `luanetfilter.c` and everything proposed here use `init_net`. That is a deliberate scope limit for
+this project, not an oversight, but it constrains testing: NAT tests need two ends, so they use veth
+pairs with the far end in a namespace and the NAT hook in `init_net`. Adding a `net` selector to hook
+registration is tracked as a follow-up, not part of this epic.
+
+## Sources
+
+* `net/netfilter/nf_nat_core.c`, `nf_nat_inet_fn` and `nf_nat_register_fn`
+* `net/netfilter/nf_nat_proto.c`, the `nf_nat_ipv4_ops` / `nf_nat_ipv6_ops` arrays and the
+  `*_register_fn` wrappers
+* `net/netfilter/nf_conntrack_netlink.c`, `ctnetlink_dump_table` and `ctnetlink_create_conntrack`
+* `net/netfilter/nf_conntrack_core.c`, allocation, confirmation and iteration
+* `net/ipv4/netfilter/iptable_nat.c` and `net/netfilter/nft_chain_nat.c`, minimal NAT chain registration
+* in-tree Lunatik: `lib/luaskb.c`, `lib/luanetfilter.c`, `lunatik_core.c`
+

--- a/docs/design/conntrack-nat/plan.md
+++ b/docs/design/conntrack-nat/plan.md
@@ -1,0 +1,165 @@
+# Plan: conntrack and NAT support for Lunatik
+
+Execution plan for conntrack and NAT support in Lunatik (an idea that originated in the
+[LabLua GSoC list](https://github.com/labluapucrio/gsoc/blob/main/2026/ideas.md#conntrack-and-nat-support-for-lunatik),
+now tracked here as a regular project).
+
+## Where we are today
+
+Lunatik's netfilter story is complete for stateless filtering and empty for stateful work:
+
+* `netfilter.register{hook, pf, hooknum, priority, mark}` registers a hook in `init_net` and calls a
+  Lua function with an `skb`, expecting `(verdict[, mark])` back (`lib/luanetfilter.c`);
+* the `skb` object exposes length, ifindex, VLAN, payload as a `data` object, resize, checksum,
+  forward and copy (`lib/luaskb.c`);
+* `linux.nf` carries the netfilter constants generated from the uapi headers: `proto`, `inet`,
+  `netdev`, `arp`, `ip.pri`, `br`, `br.pri`, `action`.
+
+The only conntrack touchpoint that exists is `skb:connmark([value])`, which calls `nf_ct_get` and
+reads or writes `ct->mark` under `CONFIG_NF_CONNTRACK_MARK`. That is one 32 bit field of one
+connection, reachable only from inside a hook.
+
+So "we already did basic conntrack support" means: we can read and write the connection mark. Missing
+is everything the idea actually asks for.
+
+## What is missing
+
+| Idea outcome | Gap |
+|--------------|-----|
+| Retrieve conntrack entries and connection information | No conntrack object at all. No tuples, status, state, timeouts, counters, labels, zone, helper, master. No way to look up an entry by tuple, iterate the table, or observe events. |
+| Add conntrack entries from Lua for NAT operations | No allocation, insertion or expectation API. |
+| Implement NAT for inet protocols | Nothing. No NAT hook registration, no SNAT/DNAT, no masquerade, no redirect. |
+
+Supporting gaps that block the above:
+
+* no conntrack or NAT constants in `linux.nf` (`IP_CT_*`, `IPS_*`, `IPCT_*`, `TCP_CONNTRACK_*`,
+  `NF_NAT_RANGE_*`);
+* no IPv6 address representation in Lua (`net.lua` has `aton`/`ntoa` for IPv4 only), which the idea's
+  "inet protocols" wording requires;
+* no cross module accessor for the `skb` pointer, so a second module cannot validate an `skb` argument;
+* no netns aware test harness; the existing netfilter test drives loopback traffic in `init_net`,
+  which is not enough to prove a translation happened.
+
+## Shape of the work
+
+Two new kernel modules, `conntrack` and `nat`, mirroring the kernel's own `nf_conntrack` /`nf_nat`
+split. The full API proposal is in `api.md`; the kernel constraints that drive it are in
+`kernel-notes.md`. The single most important of those constraints, because it shapes the whole NAT
+design:
+
+> `nf_nat_*_register_fn` does not install your hook. It installs the NAT core's hook and chains yours
+> into a lookup list that runs only for the first packet of a connection in each direction. Lua
+> decides the mapping once; `nf_nat_packet` translates every packet after that.
+
+This is what makes a Lua NAT layer viable rather than a benchmark disaster, and it is worth stating in
+the proposal, the docs and the example comments.
+
+## Phases
+
+Each phase is one or more self contained pull requests. Lunatik's patch discipline is small auditable
+commits, so nothing here lands as a single drop.
+
+### Phase 0: warm up
+
+Land the conntrack constants the object phase will consume: `nf.ct.info`, `nf.ct.status`, `nf.ct.dir`
+and `nf.ct.tcp`. It is a small change that forces a full pass through the build, the generated
+`linux.*` modules and the docs pipeline, so the contributor learns the machinery before touching
+netfilter.
+
+`nf.nat.range` waits for the NAT phase and `nf.ct.event` for the events phase. `linux.nf` is published
+API: a table whose consumer does not exist yet freezes a shape before the API that uses it has been
+designed, and every one of the curation mistakes worth catching (sentinels that are not states, flags
+`nf_nat_setup_info` ignores, bit positions dressed as masks) is only visible once you know who reads
+the table.
+
+Deliverables: `autogen/specs.lua` entries for the four conntrack tables, plus whatever small
+`autogen.lua` change the `IPS_*` prefix collision needs.
+
+### Phase 1: read the connection
+
+The `conntrack` module and object: `conntrack.get(skb)`, tuples, status, state, timeout, id, TCP
+state, counters, labels, zone, master, helper, mark.
+
+Deliverables: `lib/luaconntrack.c`, `lib/luaconntrack.h`, `Kconfig`/`Kbuild` entries, a
+`luaskb_checkskb` accessor in `lib/luaskb.h`, `tests/conntrack/`, README and `config.ld` entries.
+
+### Phase 2: the table
+
+`conntrack.count`, `conntrack.max`, `conntrack.lookup(tuple)`, `conntrack.each(fn)`, `ct:delete`,
+`ct:refresh`. Includes the design decision on how to walk the table, which should be settled with a
+prototype rather than an argument.
+
+### Phase 3: NAT
+
+`nat.register`, `nat.snat`, `nat.dnat`, `nat.masquerade`, `nat.redirect`, plus the `nf.nat.range`
+constants. The hook signature is `(skb)`, like `netfilter.register`; the binding captures the
+`nf_hook_state` internally (see `api.md`). This is the first point at which the project does something
+a user can see.
+
+Deliverables: `lib/luanat.c`, `tests/nat/` with veth and namespace based SNAT and DNAT tests, an
+`examples/` script.
+
+### Phase 4: events
+
+`conntrack.watch(fn)`, `conntrack.unwatch()`, `nf.ct.event` constants, plus the "one notifier per
+netns" guard. Yields a `conntrack -E` equivalent written in Lua.
+
+### Phase 5: create entries and expectations
+
+`conntrack.new{}` and `ct:expect{}`. This is the half of "add conntrack entries from Lua" that the
+L7 load balancing scenario actually needs, since a Lua ALG pre-authorizes its data connection with an
+expectation rather than by inserting a raw entry.
+
+### Phase 6: the demo and the docs
+
+An L7 load balancer example that ties it together (classify on the HTTP `Host` header, record the
+choice, let the NAT core do the work), plus a documentation pass and any API cleanup the demo exposes.
+Write the demo early enough that its findings can still change the API: it already changed the shape
+of the example once, when it turned out that a payload based decision cannot steer the connection that
+carried it.
+
+Each phase is sized by what fits in one reviewable pull request, and the order is chosen so that the
+project is complete at every cut: reaching the end of phase 3 with tests and docs is already a
+mergeable contribution, and every later phase is additive.
+
+## Non goals
+
+Stated explicitly so they do not creep in:
+
+* **Network namespaces.** Everything registers in `init_net`, matching the existing netfilter binding.
+  Adding a `net` selector is a separate change that should be made once for all hook types, not
+  invented here. Tracked as a follow up.
+* **Conntrack helpers written in Lua.** `nf_conntrack_helper_register` would let a script implement a
+  full ALG. It is the natural sequel and it is out of scope; expectations cover the load balancing
+  case without it.
+* **ctnetlink in Lua.** Now that Lunatik has a netlink module and rtnetlink decoders, a `conntrack -L`
+  equivalent could be written in pure Lua over `NETLINK_NETFILTER`. That is a legitimate project, but
+  it does not help the packet path (a hook cannot do a netlink round trip) and it duplicates
+  ctnetlink's wire format. The C binding is needed regardless.
+* **Replacing `skb:connmark`.** It stays. `ct:mark` reaches the same field through the new object.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Conntrack object lifetime (`nf_ct_get` returns a borrowed pointer) | Take a reference in the object. Measure the cost in phase 1; only optimize if it shows. |
+| NAT hook semantics misunderstood, leading to a design that tries to translate packets in Lua | Settled up front in `kernel-notes.md`. Reviewers should check any NAT patch against it. |
+| Kernel version drift (`nf_ct_iterate_cleanup_net` changed signature in 6.x, `nf_conntrack_register_notifier` changed return type) | Verify signatures against the target kernel before writing code, not after. |
+| Testing NAT needs real topology | Build the netns harness in phase 3 before the NAT code, not after. See `testing.md`. |
+| Config matrix (`CONFIG_NF_CONNTRACK_ACCT`, `_LABELS`, `_EVENTS`, `NF_NAT_MASQUERADE`) | Guard per feature, skip cleanly in tests, mirroring `tests/skb/connmark.sh`. |
+
+## Definition of done, per phase
+
+A phase is done when all of the following are true. This list is the review checklist, not a
+suggestion.
+
+1. builds clean on the target kernel, no new warnings;
+2. LDoc comments on every new function and object type, and the module listed in `config.ld` in
+   alphabetical order;
+3. a row in the README module table;
+4. a test in the right suite, wired into that suite's `run.sh`, and described in `tests/README.md`;
+5. the test skips (not fails) when the kernel lacks the config it needs;
+6. the full suite still passes: `sudo lunatik test`;
+7. error paths audited: for every raise, whatever was already acquired is released;
+8. commits are small and each one stands alone.
+

--- a/docs/design/conntrack-nat/testing.md
+++ b/docs/design/conntrack-nat/testing.md
@@ -1,0 +1,98 @@
+# Testing conntrack and NAT
+
+Lunatik's tests are shell scripts emitting KTAP, driving a kernel Lua script and asserting on what it
+prints to `dmesg` or on what userspace observes. `tests/skb/connmark.sh` is the closest existing model
+for this project: it engages conntrack with an `nft` rule, runs a hook, and cross checks the result
+with `conntrack -L`. Read it before writing anything new.
+
+Run everything with `sudo lunatik test`, one suite with `sudo lunatik test conntrack`.
+
+## What is missing from the harness
+
+Stateless netfilter tests get away with loopback traffic in `init_net`. NAT does not: a translation
+that is not observed from the other end of a real path is not proven. The suite needs a small
+namespace helper, added once, in `tests/netns.sh`:
+
+* create a namespace with a veth pair, one end inside, one end in `init_net`;
+* address both ends, bring them up, and enable forwarding when the test needs it;
+* run a command inside the namespace;
+* tear it all down on exit, including on failure.
+
+Build this before the NAT code, not after. A NAT feature that cannot be observed is a NAT feature that
+cannot be reviewed.
+
+Requirements, all of which existing tests already assume or skip on: `iproute2`, `nftables`,
+`conntrack-tools`, plus `socat` or `nc` for the traffic in the NAT tests.
+
+## Test matrix
+
+Fill this in as the phases land. Each row is one `.sh` plus one `.lua`, following the convention that
+the description of the test lives in the shell script and the Lua file carries a single line pointing
+back at it.
+
+### `tests/conntrack/`
+
+| Test | Proves |
+|------|--------|
+| `get.sh` | `conntrack.get` returns an object plus the right `nf.ct.info` state for a new flow and a reply; a `notrack`'d flow yields `nil` plus `nf.ct.info.UNTRACKED` |
+| `tuple.sh` | original and reply tuples match what `conntrack -L` reports for the same flow, both IPv4 and IPv6 |
+| `status.sh` | `SEEN_REPLY` and `ASSURED` appear as the flow progresses; `ct:tcpstate()` walks SYN_SENT to ESTABLISHED |
+| `timeout.sh` | `ct:timeout()` decreases; `ct:refresh(ms)` raises it |
+| `counters.sh` | packet and byte counts match the traffic sent (skip without `CONFIG_NF_CONNTRACK_ACCT`) |
+| `mark.sh` | `ct:mark` and `skb:connmark` read and write the same field |
+| `labels.sh` | `ct:labels()` returns the 16 byte bitmap `conntrack -L` shows after an `nft ct label set` rule (skip without `CONFIG_NF_CONNTRACK_LABELS`) |
+| `meta.sh` | `ct:zone()`, `ct:id()` and `ct:helper()` return what `conntrack -L` reports for a flow with an nft-assigned helper |
+| `lifetime.sh` | a `ct` stashed in a Lua global and used after the hook returned does not oops. This is the one that justifies the refcount |
+| `table.sh` | `conntrack.count` tracks entries; `lookup` finds a flow by tuple and misses on a bogus one; `each` sees a known flow and can stop early |
+| `events.sh` | NEW and DESTROY arrive for a short flow; registering twice raises instead of stealing the slot (skip without `CONFIG_NF_CONNTRACK_EVENTS`) |
+| `new.sh` | `conntrack.new` inserts an entry visible in `conntrack -L`; a duplicate tuple raises |
+| `expect.sh` | an expectation appears in `conntrack -L expect` and the matching flow arrives as `RELATED` |
+
+### `tests/nat/`
+
+| Test | Proves |
+|------|--------|
+| `dnat.sh` | a connection to one port lands on a listener on another; the server sees the original source |
+| `snat.sh` | a connection from the namespace arrives with the rewritten source address |
+| `masquerade.sh` | same, with the interface address chosen automatically |
+| `redirect.sh` | traffic aimed elsewhere is redirected to a local listener |
+| `once.sh` | the Lua hook runs once per connection per direction, not per packet (count invocations against packets sent) |
+| `manip.sh` | asking for SNAT at `PRE_ROUTING` raises rather than silently doing nothing |
+| `unregister.sh` | collecting the hook handle unregisters it and traffic flows untranslated afterwards |
+| `ipv6.sh` | DNAT over IPv6 (skip without `CONFIG_IPV6`) |
+
+`once.sh` is the one that proves the design claim from `kernel-notes.md`. Write it before building on
+the API: if the Lua hook turns out to run per packet, the API is wrong, and that is much cheaper to
+learn before anything depends on it.
+
+Where a test needs to count hook invocations, use one shape across the suite: the hook increments a
+counter in an `rcu.table` and the shell asserts on the delta across the run, never on the absolute
+value, so a previous run cannot make a test pass.
+
+    local shared = rcu.table()
+    shared.calls = (shared.calls or 0) + 1
+
+## Conventions to follow
+
+* skip, do not fail, when the kernel lacks a config. Copy the `skip_all` shape from
+  `tests/skb/connmark.sh`, including the `ktap_skip` per planned test so the plan count stays honest;
+* mark `dmesg` before the run and read only what came after (`mark_dmesg` / `dmesg_since`);
+* `check_dmesg` at the end so a kernel warning fails the test even when the assertions passed;
+* `lunatik run` exits 0 even when the script fails to load, so assert on output, never on exit status;
+* clean up in a `trap`, and call the cleanup once up front too, so a previous crashed run does not
+  poison this one;
+* every new test gets a bullet in `tests/README.md` and a line in the suite's `run.sh`, in the same
+  commit. A new suite also gets added to the list in the top level `README.md`.
+
+## Manual smoke test
+
+Useful while developing, before the automated test exists:
+
+    sudo make install && sudo lunatik reload
+    sudo lunatik run examples/l7lb softirq
+    sudo conntrack -L
+    sudo conntrack -E
+
+Watch `dmesg -w` in another terminal. If the machine hangs, the usual cause is a sleeping call reached
+from softirq context; check `kernel-notes.md` for which entry points are allowed where.
+


### PR DESCRIPTION
Two documentation additions, independent of each other.

`AGENTS.md` collects the conventions a contributor (or an AI assistant working on this repository)
needs before the first patch: build and test loop, the three execution contexts and what may sleep in
each, the object model, C and Lua style, and commit discipline. Linked from the README.

`docs/projects/conntrack-nat/` is the execution material for the conntrack and NAT binding offered as
a GSoC 2026 idea: the gap between what `skb:connmark` gives us today and what the idea asks for, the
proposed `conntrack` and `nat` API, a kernel API reference checked against 6.8 headers and exports,
and the test strategy. The phases are tracked as issues.

The kernel notes exist because the design turns on one fact that is easy to get wrong: `nf_nat_*_register_fn`
does not install your hook, it chains it into the NAT core's lookup list, which runs only for the first
packet of a connection in each direction. That is what makes a Lua NAT layer viable, and it belongs
somewhere reviewable rather than in a comment thread.
