### PR TITLE
netlink: factor the rt object classes over a shared base

### DIFF
--- a/config.ld
+++ b/config.ld
@@ -43,6 +43,7 @@ file = {
 	'./lib/netlink/rt.lua',
 	'./lib/netlink/rt/addr.lua',
 	'./lib/netlink/rt/link.lua',
+	'./lib/netlink/rt/object.lua',
 	'./lib/netlink/rt/route.lua',
 	'./lib/netlink/rt/rule.lua',
 	'./lib/netlink/session.lua',

--- a/lib/netlink/rt/addr.lua
+++ b/lib/netlink/rt/addr.lua
@@ -11,24 +11,20 @@
 -- sleepable runtime.
 --
 -- @module netlink.rt.addr
--- @see netlink.session
+-- @see netlink.rt.object
 --
 
-local session = require("netlink.session")
+local object  = require("netlink.rt.object")
 local message = require("netlink.message")
 local struct  = require("struct")
 
-local nl   = require("linux.netlink")
 local rtnl = require("linux.rtnetlink")
 local sk   = require("linux.socket")
 
-local insert = table.insert
 local str = message.str
 
 local ifaddrmsg  = struct(rtnl.layout.ifaddrmsg)
 local IFADDR_LEN = ifaddrmsg.size
-
-local NEWADDR, GETADDR = rtnl.rtm.NEWADDR, rtnl.rtm.GETADDR
 
 ---
 -- @type addr
@@ -39,29 +35,27 @@ local NEWADDR, GETADDR = rtnl.rtm.NEWADDR, rtnl.rtm.GETADDR
 -- @tparam[opt] table o an initial object table.
 -- @treturn addr the new addr object.
 -- @see class
-local addr = session:new{proto = nl.proto.ROUTE}
+local addr = object:new{GET = rtnl.rtm.GETADDR, NEW = rtnl.rtm.NEWADDR}
+
+function addr:header(family)
+	return ifaddrmsg:pack(family or sk.af.UNSPEC, 0, 0, 0, 0)
+end
+
+function addr:decode(body)
+	local fam, prefix_len, _, scope, ifindex = ifaddrmsg:unpack(body)
+	local attrs = message.attrs(body, IFADDR_LEN + 1)
+	return {
+		family = fam, prefix_len = prefix_len, scope = scope, ifindex = ifindex,
+		address = attrs[rtnl.ifa.ADDRESS] or attrs[rtnl.ifa.LOCAL],
+		label = str(attrs[rtnl.ifa.LABEL]),
+	}
+end
 
 ---
 -- Lists all interface addresses from the kernel.
+-- @function addr:list
 -- @tparam[opt=AF_UNSPEC] integer family address family.
 -- @treturn table list of address tables.
-function addr:list(family)
-	local header = ifaddrmsg:pack(family or sk.af.UNSPEC, 0, 0, 0, 0)
-	local addrs = {}
-	for _, msg in ipairs(self:dump(GETADDR, header)) do
-		if msg.type == NEWADDR then
-			local body = msg.body
-			local fam, prefix_len, _, scope, ifindex = ifaddrmsg:unpack(body)
-			local attrs = message.attrs(body, IFADDR_LEN + 1)
-			insert(addrs, {
-				family = fam, prefix_len = prefix_len, scope = scope, ifindex = ifindex,
-				address = attrs[rtnl.ifa.ADDRESS] or attrs[rtnl.ifa.LOCAL],
-				label = str(attrs[rtnl.ifa.LABEL]),
-			})
-		end
-	end
-	return addrs
-end
 
 return addr
 

--- a/lib/netlink/rt/link.lua
+++ b/lib/netlink/rt/link.lua
@@ -11,24 +11,20 @@
 -- sleepable runtime.
 --
 -- @module netlink.rt.link
--- @see netlink.session
+-- @see netlink.rt.object
 --
 
-local session = require("netlink.session")
+local object  = require("netlink.rt.object")
 local message = require("netlink.message")
 local struct  = require("struct")
 
-local nl   = require("linux.netlink")
 local rtnl = require("linux.rtnetlink")
 local sk   = require("linux.socket")
 
-local insert = table.insert
 local u32, str = message.u32, message.str
 
 local ifinfomsg  = struct(rtnl.layout.ifinfomsg)
 local IFINFO_LEN = ifinfomsg.size
-
-local NEWLINK, GETLINK = rtnl.rtm.NEWLINK, rtnl.rtm.GETLINK
 
 ---
 -- @type link
@@ -39,29 +35,27 @@ local NEWLINK, GETLINK = rtnl.rtm.NEWLINK, rtnl.rtm.GETLINK
 -- @tparam[opt] table o an initial object table.
 -- @treturn link the new link object.
 -- @see class
-local link = session:new{proto = nl.proto.ROUTE}
+local link = object:new{GET = rtnl.rtm.GETLINK, NEW = rtnl.rtm.NEWLINK}
+
+function link:header()
+	return ifinfomsg:pack(sk.af.UNSPEC, 0, 0, 0, 0)
+end
+
+function link:decode(body)
+	local fam, ltype, ifindex, flags, change = ifinfomsg:unpack(body)
+	local attrs = message.attrs(body, IFINFO_LEN + 1)
+	return {
+		family = fam, ltype = ltype, ifindex = ifindex,
+		flags = flags, change = change,
+		name = str(attrs[rtnl.ifla.IFNAME]),
+		mtu = u32(attrs[rtnl.ifla.MTU]),
+	}
+end
 
 ---
 -- Lists all network interfaces from the kernel.
+-- @function link:list
 -- @treturn table list of link tables.
-function link:list()
-	local header = ifinfomsg:pack(sk.af.UNSPEC, 0, 0, 0, 0)
-	local links = {}
-	for _, msg in ipairs(self:dump(GETLINK, header)) do
-		if msg.type == NEWLINK then
-			local body = msg.body
-			local fam, ltype, ifindex, flags, change = ifinfomsg:unpack(body)
-			local attrs = message.attrs(body, IFINFO_LEN + 1)
-			insert(links, {
-				family = fam, ltype = ltype, ifindex = ifindex,
-				flags = flags, change = change,
-				name = str(attrs[rtnl.ifla.IFNAME]),
-				mtu = u32(attrs[rtnl.ifla.MTU]),
-			})
-		end
-	end
-	return links
-end
 
 return link
 

--- a/lib/netlink/rt/object.lua
+++ b/lib/netlink/rt/object.lua
@@ -1,0 +1,57 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+
+---
+-- Base class for the rtnetlink object classes (`route`, `link`, `addr`,
+-- `rule`): a `netlink.session` over the `NETLINK_ROUTE` protocol carrying the
+-- shared dump loop and the routing-table id split. Each object class provides
+-- its request `header`, its record `decode` and its `GET`/`NEW` (and `DEL`)
+-- message types.
+-- @module netlink.rt.object
+-- @see netlink.session
+
+local session = require("netlink.session")
+
+local nl   = require("linux.netlink")
+local rtnl = require("linux.rtnetlink")
+
+local insert = table.insert
+
+local object = session:new{proto = nl.proto.ROUTE}
+
+-- __call is looked up raw on the metatable: pull the constructor down so the
+-- classes deriving from object (session's grandchildren) stay callable
+object.__call = session.__call
+
+-- ids that do not fit the u8 table header field go in the TABLE attribute:
+-- the header side keeps the ids that fit, the attr side carries the others
+function object.tablemax(codec, field)
+	return (1 << 8 * codec:fieldsize(field)) - 1
+end
+
+function object:headertable(tbl)
+	return tbl <= self.TABLE_MAX and tbl or rtnl.table.UNSPEC
+end
+
+function object:attrtable(tbl)
+	return tbl and tbl > self.TABLE_MAX and tbl or nil
+end
+
+---
+-- Dumps and decodes every record of the object type.
+-- @tparam[opt=AF_UNSPEC] integer family address family.
+-- @treturn table list of decoded record tables.
+function object:list(family)
+	local records = {}
+	for _, msg in ipairs(self:dump(self.GET, self:header(family))) do
+		if msg.type == self.NEW then
+			insert(records, self:decode(msg.body))
+		end
+	end
+	return records
+end
+
+return object
+

--- a/lib/netlink/rt/route.lua
+++ b/lib/netlink/rt/route.lua
@@ -11,10 +11,10 @@
 -- runtime.
 --
 -- @module netlink.rt.route
--- @see netlink.session
+-- @see netlink.rt.object
 --
 
-local session = require("netlink.session")
+local object  = require("netlink.rt.object")
 local message = require("netlink.message")
 local struct  = require("struct")
 
@@ -22,16 +22,10 @@ local nl   = require("linux.netlink")
 local rtnl = require("linux.rtnetlink")
 local sk   = require("linux.socket")
 
-local insert = table.insert
 local u32 = message.u32
 
 local rtmsg     = struct(rtnl.layout.rtmsg)
 local RTMSG_LEN = rtmsg.size
-
--- ids that do not fit the u8 table header field go in the TABLE attribute
-local TABLE_MAX = (1 << 8 * rtmsg:fieldsize("rtm_table")) - 1
-
-local NEWROUTE, DELROUTE, GETROUTE = rtnl.rtm.NEWROUTE, rtnl.rtm.DELROUTE, rtnl.rtm.GETROUTE
 
 ---
 -- @type route
@@ -42,39 +36,40 @@ local NEWROUTE, DELROUTE, GETROUTE = rtnl.rtm.NEWROUTE, rtnl.rtm.DELROUTE, rtnl.
 -- @tparam[opt] table o an initial object table.
 -- @treturn route the new route object.
 -- @see class
-local route = session:new{proto = nl.proto.ROUTE}
+local route = object:new{
+	GET = rtnl.rtm.GETROUTE, NEW = rtnl.rtm.NEWROUTE, DEL = rtnl.rtm.DELROUTE,
+	TABLE_MAX = object.tablemax(rtmsg, "rtm_table"),
+}
+
+function route:header(family)
+	return rtmsg:pack(family or sk.af.UNSPEC, 0, 0, 0, 0, 0, 0, 0, 0)
+end
+
+function route:decode(body)
+	local fam, dst_len, src_len, tos, tbl, protocol, scope, rtype, flags = rtmsg:unpack(body)
+	local attrs = message.attrs(body, RTMSG_LEN + 1)
+	return {
+		family = fam, dst_len = dst_len, src_len = src_len, tos = tos,
+		table = u32(attrs[rtnl.rta.TABLE]) or tbl,
+		protocol = protocol, scope = scope, rtype = rtype, flags = flags,
+		dst = attrs[rtnl.rta.DST], gateway = attrs[rtnl.rta.GATEWAY],
+		oif = u32(attrs[rtnl.rta.OIF]),
+		priority = u32(attrs[rtnl.rta.PRIORITY]),
+	}
+end
 
 ---
 -- Lists all routes from the kernel routing tables.
+-- @function route:list
 -- @tparam[opt=AF_UNSPEC] integer family address family.
 -- @treturn table list of route tables.
-function route:list(family)
-	local header = rtmsg:pack(family or sk.af.UNSPEC, 0, 0, 0, 0, 0, 0, 0, 0)
-	local routes = {}
-	for _, msg in ipairs(self:dump(GETROUTE, header)) do
-		if msg.type == NEWROUTE then
-			local body = msg.body
-			local fam, dst_len, src_len, tos, tbl, protocol, scope, rtype, flags = rtmsg:unpack(body)
-			local attrs = message.attrs(body, RTMSG_LEN + 1)
-			insert(routes, {
-				family = fam, dst_len = dst_len, src_len = src_len, tos = tos,
-				table = u32(attrs[rtnl.rta.TABLE]) or tbl,
-				protocol = protocol, scope = scope, rtype = rtype, flags = flags,
-				dst = attrs[rtnl.rta.DST], gateway = attrs[rtnl.rta.GATEWAY],
-				oif = u32(attrs[rtnl.rta.OIF]),
-				priority = u32(attrs[rtnl.rta.PRIORITY]),
-			})
-		end
-	end
-	return routes
-end
 
-local function route_attrs(opts)
+local function route_attrs(route, opts)
 	return message.attrs{
 		[rtnl.rta.DST]     = opts.dst,
 		[rtnl.rta.GATEWAY] = opts.gateway,
 		[rtnl.rta.OIF]     = opts.oif,
-		[rtnl.rta.TABLE]   = opts.table and opts.table > TABLE_MAX and opts.table or nil,
+		[rtnl.rta.TABLE]   = route:attrtable(opts.table),
 	}
 end
 
@@ -83,11 +78,10 @@ end
 -- @tparam table opts route parameters: optional `family` (default `AF_INET`),
 --   `dst_len`, `dst`, `gateway`, `oif`, `table`, `protocol`, `scope`, `rtype`.
 function route:add(opts)
-	local tbl = opts.table or rtnl.table.MAIN
 	local header = rtmsg:pack(opts.family or sk.af.INET, opts.dst_len or 0, 0, 0,
-		tbl <= TABLE_MAX and tbl or rtnl.table.UNSPEC, opts.protocol or rtnl.rtprot.STATIC,
+		self:headertable(opts.table or rtnl.table.MAIN), opts.protocol or rtnl.rtprot.STATIC,
 		opts.scope or rtnl.scope.UNIVERSE, opts.rtype or rtnl.rtn.UNICAST, 0)
-	self:talk(NEWROUTE, nl.flag.CREATE | nl.flag.EXCL, header .. route_attrs(opts))
+	self:talk(self.NEW, nl.flag.CREATE | nl.flag.EXCL, header .. route_attrs(self, opts))
 end
 
 ---
@@ -95,11 +89,10 @@ end
 -- @tparam table opts route parameters: optional `family` (default `AF_INET`),
 --   `dst_len`, `dst`, `oif`, `table`.
 function route:del(opts)
-	local tbl = opts.table or rtnl.table.MAIN
 	-- scope NOWHERE is the deletion wildcard: match the route whatever its scope
 	local header = rtmsg:pack(opts.family or sk.af.INET, opts.dst_len or 0, 0, 0,
-		tbl <= TABLE_MAX and tbl or rtnl.table.UNSPEC, 0, rtnl.scope.NOWHERE, 0, 0)
-	self:talk(DELROUTE, nil, header .. route_attrs(opts))
+		self:headertable(opts.table or rtnl.table.MAIN), 0, rtnl.scope.NOWHERE, 0, 0)
+	self:talk(self.DEL, nil, header .. route_attrs(self, opts))
 end
 
 return route

--- a/lib/netlink/rt/rule.lua
+++ b/lib/netlink/rt/rule.lua
@@ -11,10 +11,10 @@
 -- sleepable runtime.
 --
 -- @module netlink.rt.rule
--- @see netlink.session
+-- @see netlink.rt.object
 --
 
-local session = require("netlink.session")
+local object  = require("netlink.rt.object")
 local message = require("netlink.message")
 local struct  = require("struct")
 
@@ -22,17 +22,11 @@ local nl   = require("linux.netlink")
 local rtnl = require("linux.rtnetlink")
 local sk   = require("linux.socket")
 
-local insert = table.insert
-local pack   = string.pack
+local pack = string.pack
 local u32 = message.u32
 
 local fib_rule     = struct(rtnl.layout.fib_rule_hdr)
 local FIB_RULE_LEN = fib_rule.size
-
--- ids that do not fit the u8 table header field go in the TABLE attribute
-local TABLE_MAX = (1 << 8 * fib_rule:fieldsize("table")) - 1
-
-local NEWRULE, DELRULE, GETRULE = rtnl.rtm.NEWRULE, rtnl.rtm.DELRULE, rtnl.rtm.GETRULE
 
 ---
 -- @type rule
@@ -43,38 +37,38 @@ local NEWRULE, DELRULE, GETRULE = rtnl.rtm.NEWRULE, rtnl.rtm.DELRULE, rtnl.rtm.G
 -- @tparam[opt] table o an initial object table.
 -- @treturn rule the new rule object.
 -- @see class
-local rule = session:new{proto = nl.proto.ROUTE}
+local rule = object:new{
+	GET = rtnl.rtm.GETRULE, NEW = rtnl.rtm.NEWRULE, DEL = rtnl.rtm.DELRULE,
+	TABLE_MAX = object.tablemax(fib_rule, "table"),
+}
+
+function rule:header(family)
+	return fib_rule:pack(family or sk.af.UNSPEC, 0, 0, 0, 0, 0, 0)
+end
+
+function rule:decode(body)
+	local fam, _, _, _, tbl, action, flags = fib_rule:unpack(body)
+	local attrs = message.attrs(body, FIB_RULE_LEN + 1)
+	return {
+		family = fam, action = action, flags = flags,
+		table = u32(attrs[rtnl.fra.TABLE]) or tbl,
+		priority = u32(attrs[rtnl.fra.PRIORITY]),
+		fwmark = u32(attrs[rtnl.fra.FWMARK]),
+	}
+end
 
 ---
 -- Lists all FIB rules from the kernel.
+-- @function rule:list
 -- @tparam[opt=AF_UNSPEC] integer family address family.
 -- @treturn table list of rule tables.
-function rule:list(family)
-	local header = fib_rule:pack(family or sk.af.UNSPEC, 0, 0, 0, 0, 0, 0)
-	local rules = {}
-	for _, msg in ipairs(self:dump(GETRULE, header)) do
-		if msg.type == NEWRULE then
-			local body = msg.body
-			local fam, _, _, _, tbl, action, flags = fib_rule:unpack(body)
-			local attrs = message.attrs(body, FIB_RULE_LEN + 1)
-			insert(rules, {
-				family = fam, action = action, flags = flags,
-				table = u32(attrs[rtnl.fra.TABLE]) or tbl,
-				priority = u32(attrs[rtnl.fra.PRIORITY]),
-				fwmark = u32(attrs[rtnl.fra.FWMARK]),
-			})
-		end
-	end
-	return rules
-end
 
 -- add and delete send the same rule; only the message type and flags differ
-local function rule_message(opts)
-	local tbl = opts.table or rtnl.table.MAIN
+local function rule_message(rule, opts)
 	local header = fib_rule:pack(opts.family or sk.af.INET, 0, 0, 0,
-		tbl <= TABLE_MAX and tbl or rtnl.table.UNSPEC, opts.action or rtnl.fr_act.TO_TBL, 0)
+		rule:headertable(opts.table or rtnl.table.MAIN), opts.action or rtnl.fr_act.TO_TBL, 0)
 	return header .. message.attrs{
-		[rtnl.fra.TABLE]    = opts.table and opts.table > TABLE_MAX and opts.table or nil,
+		[rtnl.fra.TABLE]    = rule:attrtable(opts.table),
 		[rtnl.fra.PRIORITY] = opts.priority,
 		[rtnl.fra.FWMARK]   = opts.fwmark,
 		[rtnl.fra.PROTOCOL] = opts.protocol and pack("B", opts.protocol) or nil,
@@ -86,7 +80,7 @@ end
 -- @tparam table opts rule parameters: optional `family` (default `AF_INET`),
 --   `table`, `priority`, `fwmark`, `protocol`, `action` (default `FR_ACT_TO_TBL`).
 function rule:add(opts)
-	self:talk(NEWRULE, nl.flag.CREATE | nl.flag.EXCL, rule_message(opts))
+	self:talk(self.NEW, nl.flag.CREATE | nl.flag.EXCL, rule_message(self, opts))
 end
 
 ---
@@ -94,7 +88,7 @@ end
 -- @tparam table opts rule parameters: optional `family` (default `AF_INET`),
 --   `table`, `priority`, `fwmark`.
 function rule:del(opts)
-	self:talk(DELRULE, nil, rule_message(opts))
+	self:talk(self.DEL, nil, rule_message(self, opts))
 end
 
 return rule

--- a/tests/README.md
+++ b/tests/README.md
@@ -112,7 +112,8 @@ higher-level `netlink.*` modules built on top of it.
 - **rule_adddel**: `rt.rule():add()` creates a FIB rule directing lookups to an
   isolated table whose id is > 255 (exercising the `FRA_TABLE` attribute),
   confirms it in a dump, asserts a duplicate add raises (`NLM_F_EXCL`), then
-  `del()` removes it.
+  `del()` removes it; a second add/del round uses a table id that fits the u8
+  header field, exercising the header-side id path (no `FRA_TABLE`).
 - **channel**: a softirq runtime registers a generic netlink family, unicasts
   to an absent port id (which returns `false`), and installs a `PRE_ROUTING`
   netfilter hook that, on received traffic (NET_RX softirq), both multicasts to

--- a/tests/netlink/rule_adddel.lua
+++ b/tests/netlink/rule_adddel.lua
@@ -8,13 +8,14 @@ local netlink = require("netlink")
 local af = require("linux.socket").af
 
 local TABLE = 1000  -- isolated table; id > 255 exercises FRA_TABLE
+local SMALL = 100   -- fits the u8 header field: no FRA_TABLE, listed via the header
 local PRIO  = 32100 -- unusual priority so it does not clash with existing rules
 
 local rule <close> = netlink.rt.rule()
 
-local function present()
+local function present(tbl, prio)
 	for _, entry in ipairs(rule:list(af.INET)) do
-		if entry.table == TABLE and entry.priority == PRIO then
+		if entry.table == tbl and entry.priority == prio then
 			return true
 		end
 	end
@@ -22,7 +23,7 @@ local function present()
 end
 
 rule:add{family = af.INET, table = TABLE, priority = PRIO}
-assert(present(), "rule not found after add")
+assert(present(TABLE, PRIO), "rule not found after add")
 print("netlink rule_adddel: added")
 
 -- add sends NLM_F_EXCL, so adding the same rule again must raise
@@ -31,6 +32,14 @@ assert(not pcall(rule.add, rule, {family = af.INET, table = TABLE, priority = PR
 print("netlink rule_adddel: duplicate add raises")
 
 rule:del{family = af.INET, table = TABLE, priority = PRIO}
-assert(not present(), "rule still present after del")
+assert(not present(TABLE, PRIO), "rule still present after del")
 print("netlink rule_adddel: deleted")
+
+rule:add{family = af.INET, table = SMALL, priority = PRIO + 1}
+assert(present(SMALL, PRIO + 1), "small-table rule not found after add")
+print("netlink rule_adddel: small-table added")
+
+rule:del{family = af.INET, table = SMALL, priority = PRIO + 1}
+assert(not present(SMALL, PRIO + 1), "small-table rule still present after del")
+print("netlink rule_adddel: small-table deleted")
 

--- a/tests/netlink/rule_adddel.sh
+++ b/tests/netlink/rule_adddel.sh
@@ -3,25 +3,30 @@
 # SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
 # SPDX-License-Identifier: MIT OR GPL-2.0-only
 #
-# Tests netlink.rt.rule_add()/rule_del(): adds a FIB rule directing lookups to
-# an isolated table whose id is > 255 (so it exercises the FRA_TABLE attribute,
+# Tests netlink.rt.rule():add/del: adds a FIB rule directing lookups to an
+# isolated table whose id is > 255 (so it exercises the FRA_TABLE attribute,
 # not the u8 header field), confirms it appears in a dump, asserts a duplicate
 # add raises (NLM_F_EXCL -> EEXIST via check_error), deletes it, and confirms it
-# is gone.
+# is gone; then repeats add/del with a table id that fits the u8 header field,
+# exercising the header-side id path (no FRA_TABLE).
 #
 # Usage: sudo bash tests/netlink/rule_adddel.sh
 
 SCRIPT="tests/netlink/rule_adddel"
 MODULE="luasocket"
 PRIO=32100
+SMALL_PRIO=32101
 
 source "$(dirname "$(readlink -f "$0")")/../lib.sh"
 
-cleanup() { ip rule del priority "$PRIO" 2>/dev/null; }
+cleanup() {
+	ip rule del priority "$PRIO" 2>/dev/null
+	ip rule del priority "$SMALL_PRIO" 2>/dev/null
+}
 trap cleanup EXIT
 
 ktap_header
-ktap_plan 3
+ktap_plan 5
 
 cat /sys/module/$MODULE/refcnt > /dev/null 2>&1 || {
 	echo "# SKIP: $MODULE not loaded"
@@ -41,6 +46,12 @@ ktap_pass "rule_add: duplicate add raises (NLM_F_EXCL)"
 
 dmesg | grep -q "netlink rule_adddel: deleted" || fail "rule_del did not remove the rule"
 ktap_pass "rule_del: rule removed"
+
+dmesg | grep -q "netlink rule_adddel: small-table added" || fail "small-table add did not create the rule"
+ktap_pass "rule_add: small-table rule created via the header id"
+
+dmesg | grep -q "netlink rule_adddel: small-table deleted" || fail "small-table del did not remove the rule"
+ktap_pass "rule_del: small-table rule removed"
 
 ktap_totals
 


### PR DESCRIPTION
Follow-up to #616, as agreed there: `route`, `link`, `addr` and `rule` repeated the same skeleton — the dump-decode loop (4x), the `NETLINK_ROUTE` session setup (4x) and the routing-table id split between the u8 header field and the `TABLE` attribute (2x, the subtlest of the three).

A new **`netlink.rt.object`** base class (a `netlink.session` specialization, internal — not exported by the `rt` namespace) now carries them:

- `object:list(family)` — the generic dump loop, driven by each class's `GET`/`NEW` message types and its `header`/`decode` methods. A future object (`neigh`, `qdisc`, ...) reduces to `header` + `decode` + constants.
- `object.tablemax(codec, field)` / `:headertable(tbl)` / `:attrtable(tbl)` — the table-id split in one place, parameterized by each class's `TABLE_MAX`.
- `object.__call = session.__call` — metamethod lookup is raw on the metatable, so this one line keeps the object classes (now session's grandchildren) callable.

`add`/`del` stay per class on purpose: route's delete sends its own wildcard header (`scope NOWHERE`), and a generic `add` would have a single user.

No API change — `netlink.rt.route():add{}` and friends are untouched, and the netlink suite (27 tests, route/link/addr/rule all exercised in-kernel) passes unchanged, as does LDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)