### PR TITLE
docs: add the fsnotify and LSM project plans

### DIFF
--- a/docs/design/fsnotify/README.md
+++ b/docs/design/fsnotify/README.md
@@ -1,0 +1,43 @@
+# Filesystem notification and permission binding
+
+Working documents for the `fsnotify` binding: a Lua interface to the kernel's filesystem
+notification subsystem, covering both regimes it offers — asynchronous notification (what `inotify`
+and `fanotify` expose to userspace) and synchronous **permission events**, where the handler's answer
+decides whether the access happens.
+
+They exist so that a new contributor, with or without an AI coding assistant, can pick the work up
+without reverse engineering `fs/notify/` first.
+
+| Document | What it is for |
+|----------|----------------|
+| [plan.md](plan.md) | Current state, gap analysis, phases, sizing, non goals, definition of done |
+| [api.md](api.md) | Proposed Lua API for the `fsnotify` module, with worked examples |
+| [kernel-notes.md](kernel-notes.md) | Verified kernel API reference: symbols, signatures, context rules, version drift |
+| [testing.md](testing.md) | Test strategy and the test matrix |
+
+Start with `plan.md`. Read `kernel-notes.md` before writing any C.
+
+## Working on this
+
+The repository conventions that apply to every change here (build, test, style, kernel context rules,
+commit discipline) are in [AGENTS.md](../../../AGENTS.md) at the root of the repository. Read it once
+before the first patch. If you use an AI assistant, point it at that file and at `kernel-notes.md`.
+
+Three habits matter more than anything else in this project:
+
+1. **Verify kernel APIs against the kernel you are building for.** `fs/notify/` has been reworked
+   repeatedly. `fsnotify_add_mark` alone changed its second parameter between 6.8 and 6.15, and the
+   permission event path changed again in 6.14. Check the headers under
+   `/usr/src/linux-headers-$(uname -r)/include` and confirm exports in `Module.symvers`.
+2. **Respect reentrancy.** A handler runs inside the syscall of the process being watched. If the
+   handler itself touches a watched file, it re-enters. This is not a corner case to fix later; it is
+   the first thing the design has to answer. See `api.md`.
+3. **A denied `open` is a wedged machine when you deny the wrong file.** Test permission rules on a
+   scratch directory, never on `/` or on `/lib/modules/lua`.
+
+## Status
+
+These documents describe the design; they do not track progress. What is in flight, and how far along
+each phase is, lives on the [fsnotify board](https://github.com/orgs/luainkernel/projects/2). Each
+phase is an issue there and lands as its own pull request.
+

--- a/docs/design/fsnotify/api.md
+++ b/docs/design/fsnotify/api.md
@@ -1,0 +1,225 @@
+# Proposed Lua API: `fsnotify`
+
+This is a design proposal, not a specification. Names and shapes are open for review; the constraints
+behind them (in `kernel-notes.md`) are not. Anything here that turns out to conflict with a kernel
+constraint loses.
+
+One new kernel module, `fsnotify` (`lib/luafsnotify.c`), owning two object classes:
+
+* `watch` — an `fsnotify_group` with its ops and its Lua callback;
+* `fsnotify.event` — the object handed to the callback, reset per event and cleared on return,
+  following the registry pattern `lib/luanetfilter.c` uses for its `skb`.
+
+## Conventions
+
+* Event masks are integers from `linux.fs`, combined with `|`: `fs.OPEN | fs.MODIFY`.
+* Object kind selectors are strings, as `skb:data("mac")` already does: `"inode"`, `"mount"`, `"sb"`.
+* Paths are strings, resolved in the kernel with `kern_path`.
+* A missing optional kernel feature means a missing method, not a runtime error.
+* The whole module is process context only. Marking sleeps, and so does the handler.
+
+## Creating a watch
+
+    local fsnotify = require("fsnotify")
+    local fs       = require("linux.fs")
+
+    local function handler(mask, event)
+        print(event:name(), event:ino())
+    end
+
+    local watch = fsnotify.watch(handler)
+
+`fsnotify.watch(callback)` allocates the group and returns the watch object. Nothing is delivered
+until a mark exists.
+
+The callback is invoked as `callback(mask, event)`:
+
+* `mask` — the event mask that fired, testable against `linux.fs` bits;
+* `event` — the event object, valid only for the duration of the call.
+
+For notification events the return value is ignored. For permission events it is the verdict; see
+below.
+
+`mask` comes first, matching `notifier`'s `callback(event, ...)` shape literally: `luanotifier_handler`
+pushes the event integer, then whatever extras the chain supplies. It is a plain integer rather than a
+method on the event because every handler starts by testing it, and the event does **not** also carry
+it: one spelling, not two.
+
+## The `watch` object
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `watch:mark(path, mask[, kind])` | `mark` | `kind` defaults to `"inode"`; `"mount"` and `"sb"` mark the containing mount or superblock |
+| `watch:find(path[, kind])` | `mark` or `nil` | `fsnotify_find_mark`; what this watch already installed |
+| `watch:stop()` | | disarms the callback; the group is torn down on release |
+
+    local mark = watch:mark("/tmp/scratch", fs.OPEN | fs.MODIFY | fs.CREATE | fs.DELETE)
+    watch:mark("/tmp/scratch", fs.OPEN_PERM, "mount")
+
+`watch:stop()` follows the soft-stop convention the repository already uses, and `lib/luanotifier.c`
+is the model to copy: `stop` only clears the registered callback, so the handler becomes a silent
+no-op, and the teardown that can sleep happens in `release`, which always runs in process context
+(`lua_close` → GC → `release`).
+
+That split matters here rather than being a formality: `fsnotify_wait_marks_destroyed()` is a flush and
+sleeps. Destroying the group from `stop` would put a sleeping call wherever a script chose to call it.
+
+### Class shape
+
+Process context, so no `LUNATIK_OPT_SOFTIRQ`. `LUNATIK_OPT_SINGLE`, matching
+`luanotifier_process_class`, which is the closest analogue in the base. Errors follow the base
+convention, negative errno raised through `lunatik_throw`/`pusherrname`.
+
+## The `mark` object
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `mark:mask([mask])` | integer | reads, or sets and recalculates |
+| `mark:ignore([mask])` | integer | the ignore mask, for events this mark should not report |
+| `mark:remove()` | | `fsnotify_destroy_mark` |
+
+Marks are separate objects rather than a table keyed by path inside the watch, because the kernel
+already keys them (`fsnotify_find_mark` on the object's connector) and duplicating that mapping in C
+would be a second source of truth. `watch:find` exists so a script does not have to keep its own.
+
+## The `event` object
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `event:name()` | string or `nil` | dirent name, when the event carries one |
+| `event:ino()` | integer or `nil` | inode number of the object the event is about |
+| `event:dir()` | integer or `nil` | inode number of the parent directory, for dirent events |
+| `event:isdir()` | boolean | `FS_ISDIR` |
+| `event:pid()` | integer | the process performing the access — `current`, valid because delivery is synchronous |
+| `event:path()` | string or `nil` | only when the kernel handed the group a `struct path` |
+
+What is available depends on which data type the kernel attached to the event (`PATH`, `INODE`,
+`DENTRY`, `ERROR`); `kernel-notes.md` has the table. Methods return `nil` rather than raising when the
+event does not carry the field, so a handler can be written once for several masks.
+
+`event:path()` is the expensive one: it needs `d_path` and a page sized buffer. It stays a method, so
+a handler that only matches on the name never pays for it.
+
+## Permission events
+
+    local function guard(mask, event)
+        if mask & fs.OPEN_EXEC_PERM ~= 0 and not allowed[event:name()] then
+            return fsnotify.action.DENY
+        end
+        return fsnotify.action.ALLOW
+    end
+
+    local watch = fsnotify.watch(guard)
+    watch:mark("/tmp/scratch", fs.OPEN_PERM | fs.OPEN_EXEC_PERM, "mount")
+
+`fsnotify.action.ALLOW` is 0 and `fsnotify.action.DENY` is `-EPERM`, which is what the kernel expects
+back from `handle_event`. They are named constants in the module rather than raw numbers because
+returning a bare `-1` from a handler by accident is a denial, and because a boolean would invert
+badly: `nil` (a handler that forgot to return) must mean allow.
+
+Denial surfaces to the process as `EPERM` on the syscall.
+
+Requires `CONFIG_FANOTIFY_ACCESS_PERMISSIONS`. Without it the `*_PERM` constants are absent from
+`linux.fs` and marking with them raises.
+
+## Reentrancy
+
+A handler runs inside the syscall of the process being watched. If it opens a watched file — directly,
+or indirectly through `require`, a `print` to a watched log, or a Lunatik script under a marked
+mount — it re-enters, and with the runtime already locked by the outer call that is a deadlock rather
+than a wrong answer.
+
+The proposal is a guard by task identity in the group's private data:
+
+    if (group_priv->handler == current)
+            return 0;               /* allow, and do not recurse */
+    group_priv->handler = current;
+    ret = lunatik_run(...);
+    group_priv->handler = NULL;
+
+Task identity, not a per-CPU flag: the handler may sleep, so the guard has to survive a reschedule.
+The stored task is written and read only by the task itself in the nesting case, so no additional
+lock is needed, but this is exactly the kind of claim that gets a prototype and a test rather than a
+paragraph — phase 1 owns proving it.
+
+The base already has a mechanism for the adjacent problem, and the prototype should be compared
+against it before settling. `luanotifier_call` detects that its callback is firing while the runtime
+lock is already held and calls `lunatik_handle` (no lock) instead of `lunatik_run` (takes it):
+
+    bool islocked = !notifier->unregister; /* still inside register_fn? */
+    if (islocked) lunatik_handle(...); else lunatik_run(...);
+
+Reusing the held lock would let the nested handler actually run rather than being skipped. The reason
+to skip anyway is that nesting here is unbounded — the nested handler can open a watched file too —
+so the recursion has no floor. Say that in the code, because the alternative is one line away and the
+next reader will wonder.
+
+**Serialization.** A process context runtime locks a mutex around the callback, so every watched access
+on the machine passes through one lock. A slow handler does not only slow the process that triggered
+it, it serializes all watched accesses. That is the mechanism behind "a slow handler is a slow system",
+and it is what phase 4 should measure.
+
+Two conventions on top of the guard, for the examples and the documentation:
+
+* never mark `/`, `/lib/modules/lua`, or the directory holding the script;
+* prefer a mount or inode mark on a scratch subtree to a superblock mark on the root filesystem.
+
+## Worked example: integrity monitor
+
+    local fsnotify = require("fsnotify")
+    local fs       = require("linux.fs")
+
+    local WATCHED <const> = "/etc"
+
+    local function audit(mask, event)
+        if mask & (fs.MODIFY | fs.ATTRIB) ~= 0 then
+            print(string.format("changed: %s (ino %d, pid %d)",
+                event:name() or "?", event:ino() or 0, event:pid()))
+        end
+    end
+
+    local watch = fsnotify.watch(audit)
+    watch:mark(WATCHED, fs.MODIFY | fs.ATTRIB | fs.CREATE | fs.DELETE, "mount")
+
+## Worked example: exec allowlist
+
+    local fsnotify = require("fsnotify")
+    local fs       = require("linux.fs")
+    local set      = require("set")
+
+    local SCRATCH <const> = "/tmp/scratch"
+    local allowed  = set.new{"hello", "true"}
+
+    local function guard(mask, event)
+        local name = event:name()
+        if name and not allowed:has(name) then
+            return fsnotify.action.DENY
+        end
+        return fsnotify.action.ALLOW
+    end
+
+    local watch = fsnotify.watch(guard)
+    watch:mark(SCRATCH, fs.OPEN_EXEC_PERM, "mount")
+
+The matching is Lua's, using `set`; the module supplies the event and takes the verdict. That split is
+the point of the binding.
+
+## Settled by precedent
+
+Three questions that looked open have answers already in the base, so they are recorded here rather
+than left for review:
+
+* **`fsnotify.watch(callback)`, not `fsnotify.new`.** Constructors that register are named for what
+  they do or for what they attach to: `netfilter.register`, `xdp.attach`, `notifier.netdevice`. `new`
+  is for plain construction: `socket.new`, `rcu.table`.
+* **`mask` is the argument, and the event does not also carry it.** One spelling. See above.
+* **One callback per watch.** `notifier` is one callback per object; if you need two behaviours, make
+  two watches. The kernel would allow one per mark, but that puts a dispatch in C that Lua does better.
+
+## Open questions for review
+
+1. Whether `event:pid()` should return a `task` object once `luatask` lands from the eBPF work,
+   rather than a bare integer.
+2. Whether `event:path()` should cache the resolved string for the duration of the event, since a
+   handler that tests it and then logs it pays `d_path` twice.
+

--- a/docs/design/fsnotify/kernel-notes.md
+++ b/docs/design/fsnotify/kernel-notes.md
@@ -1,0 +1,249 @@
+# Kernel notes: fsnotify
+
+Reference sheet for the `fsnotify` binding. Every symbol and signature below was checked against
+Linux 6.8 (`/usr/src/linux-headers-6.8.0-124-generic/include`, its `Module.symvers`) and compared
+against upstream v6.15. Re-check on the kernel you target: `fs/notify/` has been reworked repeatedly,
+and two of the interfaces below changed inside the 6.x series.
+
+## Header map
+
+| Header | What you need from it |
+|--------|----------------------|
+| `linux/fsnotify_backend.h` | `struct fsnotify_group`, `struct fsnotify_ops`, `struct fsnotify_mark`, the `FS_*` masks, group flags and priorities, the mark API |
+| `linux/fsnotify.h` | where the hooks are called from: `fsnotify_open_perm`, `fsnotify_file_perm`, and in 6.14+ `fsnotify_mmap_perm`, `fsnotify_truncate_perm` |
+| `linux/namei.h` | `kern_path` |
+| `linux/dcache.h`, `linux/path.h` | `d_path`, `struct path`, `path_put` |
+
+`linux/fsnotify_backend.h` is **not** a uapi header, but it ships in `linux-headers-$(uname -r)` and
+autogen already reads non-uapi headers (`linux/notifier.h`, `linux/sched.h`), so the `FS_*` constants
+can be generated the usual way.
+
+## Exported symbols we rely on
+
+Checked in `Module.symvers` for 6.8.0-124-generic. All `EXPORT_SYMBOL_GPL`, which is fine for
+Lunatik: its modules declare `MODULE_LICENSE("Dual MIT/GPL")`.
+
+    fsnotify_alloc_group            GPL   create a group
+    fsnotify_put_group              GPL   drop the creation reference (destroys it)
+    fsnotify_init_mark              GPL   initialize a mark for a group
+    fsnotify_add_mark               GPL   attach a mark to an object
+    fsnotify_find_mark              GPL   find this group's mark on an object
+    fsnotify_destroy_mark           GPL   detach and free a mark
+    fsnotify_put_mark               GPL   drop a mark reference
+    fsnotify_wait_marks_destroyed   GPL   flush pending mark destruction
+    fsnotify                        GPL   the dispatcher itself (not needed by a consumer)
+    __fsnotify_parent               GPL   ditto
+    fsnotify_get_cookie              GPL   rename cookie allocation
+
+Path resolution, plain `EXPORT_SYMBOL`:
+
+    kern_path                             path string -> struct path
+    path_put                              release it
+    d_path                                struct path -> string, needs a caller supplied buffer
+
+**Not exported**: `fsnotify_detach_mark` and `fsnotify_free_mark` individually. Use
+`fsnotify_destroy_mark`, which does both.
+
+## In-tree precedents
+
+A kernel module creating its own group is the normal case, not a trick. Consumers in 6.8:
+
+| Consumer | Ops used | Notes |
+|----------|----------|-------|
+| `fs/notify/dnotify/dnotify.c` | `handle_inode_event` | the smallest complete example |
+| `kernel/audit_watch.c`, `audit_tree.c`, `audit_fsnotify.c` | `handle_inode_event` | `fsnotify_alloc_group(&ops, 0)` at `device_initcall` |
+| `fs/nfsd/filecache.c` | `handle_inode_event` | |
+| `fs/notify/fanotify/fanotify_user.c` | `handle_event` | the only permission event user, and the only one setting `priority` |
+
+Read `dnotify.c` first: it is about 400 lines and covers group creation, marks, and teardown.
+
+## Semantics that shape the API
+
+### Permission events are synchronous and the return value is the answer
+
+The dispatcher stops at the first group that objects:
+
+    while (fsnotify_iter_select_report_types(&iter_info)) {
+            ret = send_to_group(mask, data, data_type, dir, file_name, cookie, &iter_info);
+            if (ret && (mask & ALL_FSNOTIFY_PERM_EVENTS))
+                    goto out;
+            fsnotify_iter_next(&iter_info);
+    }
+
+`fs/notify/fsnotify.c`, 6.8. A non zero return from `handle_event` on a permission event is the
+denial, and it propagates up through `fsnotify_open_perm` to `security_file_open` and out of the
+syscall. Return `-EPERM`; the caller does not sanitize the value.
+
+Consequences for the binding:
+
+* the handler runs **in the context of the process performing the access** — `current` is the actor,
+  which is why `event:pid()` is meaningful;
+* it **may sleep** (fanotify parks the syscall there waiting for a userspace answer), so a process
+  context runtime is correct and a `softirq` runtime is not;
+* it **re-enters** if the handler touches a watched path. See the guard in `api.md`.
+
+Where the perm hooks are called from, 6.8:
+
+    security/security.c:3045    security_file_open()  -> fsnotify_open_perm(file)
+    fs/readdir.c:99             fsnotify_file_perm(file, MAY_READ)
+    include/linux/fsnotify.h    fsnotify_file_area_perm() is the FS_ACCESS_PERM entry point
+
+All of this is behind `CONFIG_FANOTIFY_ACCESS_PERMISSIONS`; without it the inline hooks compile to
+`return 0` and no group can deny anything. It is `=y` on Ubuntu's 6.8 kernel.
+
+### `handle_event` versus `handle_inode_event`
+
+`struct fsnotify_ops` offers both:
+
+    int (*handle_event)(struct fsnotify_group *group, u32 mask, const void *data,
+                        int data_type, struct inode *dir, const struct qstr *file_name,
+                        u32 cookie, struct fsnotify_iter_info *iter_info);
+    int (*handle_inode_event)(struct fsnotify_mark *mark, u32 mask, struct inode *inode,
+                              struct inode *dir, const struct qstr *file_name, u32 cookie);
+
+`handle_inode_event` is the simplified form the in-tree kernel consumers use. It hands you the mark,
+the inode and the name, and the core does the iteration bookkeeping
+(`fsnotify_handle_inode_event`, `fs/notify/fsnotify.c:260`). It does **not** give you the
+`struct path`, and it is reached only for marks the core selected as inode-ish.
+
+The proposal starts on `handle_inode_event` for phases 1 to 3 and moves to `handle_event` for phase 4
+if the permission path needs the `path` or the iterator. Prototype before deciding: the two are not
+mutually exclusive across phases, but shipping both ops on the same group is not a design, it is an
+accident.
+
+### Data types: what the event actually carries
+
+    enum fsnotify_data_type {
+            FSNOTIFY_EVENT_NONE,
+            FSNOTIFY_EVENT_PATH,     /* struct path *  — has mnt and dentry */
+            FSNOTIFY_EVENT_INODE,    /* struct inode * */
+            FSNOTIFY_EVENT_DENTRY,   /* struct dentry * */
+            FSNOTIFY_EVENT_ERROR,    /* struct fs_error_report * */
+    };
+
+Accessors are inlines in the same header: `fsnotify_data_inode`, `fsnotify_data_path`,
+`fsnotify_data_dentry`, `fsnotify_data_sb`. `fsnotify_data_path` returns `NULL` for anything but
+`FSNOTIFY_EVENT_PATH`, which is why `event:path()` returns `nil` rather than raising.
+
+### Group flags and priority
+
+    #define FSNOTIFY_GROUP_USER  0x01  /* user allocated group: accounted allocation */
+    #define FSNOTIFY_GROUP_DUPS  0x02  /* allow multiple marks per object */
+    #define FSNOTIFY_GROUP_NOFS  0x04  /* group lock is not direct reclaim safe */
+
+A kernel group passes `0`, as audit does. `FSNOTIFY_GROUP_USER` is for groups backed by a userspace
+fd and changes the allocation accounting; it is not what this binding is.
+
+Priority lives in the group as `group->priority`, but **the constants were renamed inside 6.x** and the
+6.8 names are not the ones the current documentation uses. On 6.8 they are plain defines written inside
+the struct body, and the field is an `unsigned int`:
+
+    /* include/linux/fsnotify_backend.h:208, Linux 6.8 */
+    #define FS_PRIO_0	0 /* normal notifiers, no permissions */
+    #define FS_PRIO_1	1 /* fanotify content based access control */
+    #define FS_PRIO_2	2 /* fanotify pre-content access */
+    unsigned int priority;
+
+From 6.15 the same three values are an enum and the field carries its type:
+
+    enum fsnotify_group_prio {
+            FSNOTIFY_PRIO_NORMAL = 0,       /* normal notifiers, no permissions */
+            FSNOTIFY_PRIO_CONTENT,          /* fanotify permission events */
+            FSNOTIFY_PRIO_PRE_CONTENT,      /* fanotify pre-content events */
+            __FSNOTIFY_PRIO_NUM
+    };
+    enum fsnotify_group_prio priority;
+
+Write the assignment under a version guard, or define a local alias; do not use `FSNOTIFY_PRIO_CONTENT`
+on a 6.8 target, where it does not exist.
+
+fanotify sets the value from the `FAN_CLASS_*` the user asked for. On 6.8 the dispatcher does not gate
+permission delivery on it, but on 6.14+ the open path consults
+`fsnotify_sb_has_priority_watchers(sb, FSNOTIFY_PRIO_CONTENT)` and marks the file
+`FMODE_NONOTIFY_PERM` when no such watcher exists — a group that wants permission events on those
+kernels must set the content priority before its marks are added, or its handler will simply never be
+called. Set it explicitly on every kernel; it costs nothing on 6.8 and is required later.
+
+### Marks
+
+    void fsnotify_init_mark(struct fsnotify_mark *mark, struct fsnotify_group *group);
+    int  fsnotify_add_mark(struct fsnotify_mark *mark, <object>, unsigned int obj_type,
+                           int add_flags);
+    void fsnotify_destroy_mark(struct fsnotify_mark *mark, struct fsnotify_group *group);
+
+`obj_type` is `FSNOTIFY_OBJ_TYPE_INODE`, `_VFSMOUNT` or `_SB`, which is how the same call marks a
+file, a mount or a whole filesystem. Convenience inline: `fsnotify_add_inode_mark`.
+
+The mark's mask is set on the mark (`mark->mask`) before adding, or updated afterwards followed by
+`fsnotify_recalc_mask` on the connector.
+
+### Version drift, verified
+
+| Change | 6.8 | 6.15 |
+|--------|-----|------|
+| `fsnotify_add_mark` second parameter | `fsnotify_connp_t *connp` (`&inode->i_fsnotify_marks`) | `void *obj` (the inode itself) |
+| Group priority constants | `FS_PRIO_0/1/2`, defines inside the struct; field is `unsigned int` | `enum fsnotify_group_prio` (`FSNOTIFY_PRIO_NORMAL/CONTENT/PRE_CONTENT`); field carries the enum type |
+| Permission hooks | `fsnotify_open_perm`, `fsnotify_file_perm` | adds `fsnotify_mmap_perm`, `fsnotify_truncate_perm`; `fsnotify_file_area_perm` also tests `MAY_WRITE`/`MAY_ACCESS` |
+| Priority gating on the open path | none | `fsnotify_sb_has_priority_watchers` + `FMODE_NONOTIFY_PERM` |
+| Pre-content events | absent | `FSNOTIFY_PRIO_PRE_CONTENT`, HSM oriented |
+
+Follow the `LINUX_VERSION_CODE` guard style already used in `lib/luaxdp.c`. Do not paper over the
+`fsnotify_add_mark` difference with a cast; write the two calls under a version guard.
+
+## Event masks
+
+From `linux/fsnotify_backend.h`. These are bit masks, not a dense enum, which matters for the autogen
+spec.
+
+    FS_ACCESS  FS_MODIFY  FS_ATTRIB  FS_CLOSE_WRITE  FS_CLOSE_NOWRITE  FS_OPEN
+    FS_MOVED_FROM  FS_MOVED_TO  FS_CREATE  FS_DELETE  FS_DELETE_SELF  FS_MOVE_SELF
+    FS_OPEN_EXEC  FS_UNMOUNT  FS_Q_OVERFLOW  FS_ERROR
+    FS_OPEN_PERM  FS_ACCESS_PERM  FS_OPEN_EXEC_PERM
+    FS_EVENT_ON_CHILD  FS_RENAME  FS_ISDIR
+
+`ALL_FSNOTIFY_PERM_EVENTS` is the mask of the three `*_PERM` bits, and exists only under
+`CONFIG_FANOTIFY_ACCESS_PERMISSIONS`.
+
+### What a `FS_` prefix actually matches
+
+The header defines 27 names starting with `FS_`, and three more (`FS_PRIO_0/1/2`) indented inside the
+group struct, which `cpp -dD` emits at column zero like any other define. A spec that just says
+`prefix = "FS_"` takes all of them. What each group needs:
+
+* **the event masks** are what the binding wants: `FS_ACCESS`, `FS_MODIFY`, `FS_ATTRIB`,
+  `FS_CLOSE_WRITE`, `FS_CLOSE_NOWRITE`, `FS_OPEN`, `FS_MOVED_FROM`, `FS_MOVED_TO`, `FS_CREATE`,
+  `FS_DELETE`, `FS_DELETE_SELF`, `FS_MOVE_SELF`, `FS_OPEN_EXEC`, `FS_UNMOUNT`, `FS_Q_OVERFLOW`,
+  `FS_ERROR`, `FS_RENAME`, plus the flags `FS_EVENT_ON_CHILD` and `FS_ISDIR`, and the three
+  `*_PERM` bits;
+* **`FS_PRIO_0/1/2`** are group priorities, not event bits. They must not appear in a table of event
+  masks;
+* **`FS_IN_IGNORED`** is inotify's internal overload of the `FS_ERROR` bit and **`FS_DN_MULTISHOT`** is
+  dnotify's. Neither is meaningful to this binding;
+* the composites (`FS_MOVE`, `FS_EVENTS_POSS_ON_CHILD`, `FS_EVENTS_POSS_TO_PARENT`, the
+  `ALL_FSNOTIFY_*` masks) drop out on their own: their values are expressions, and `autogen.lua` keeps
+  only defines whose value is an integer expression.
+
+So no change to `autogen.lua` is needed for the values themselves; the mask constants are plain hex
+literals and resolve like any other. What is needed is an `include` list, the way `nf.action` does it.
+
+`FS_EVENT_ON_CHILD` is what makes a mark on a directory report events on the files inside it; without
+it a directory mark reports only events on the directory itself.
+
+## Config dependencies
+
+| Config | Needed for | On Ubuntu 6.8 |
+|--------|-----------|---------------|
+| `CONFIG_FSNOTIFY` | everything | `y` (implied by `CONFIG_INOTIFY_USER`) |
+| `CONFIG_FANOTIFY` | — (uapi only, not needed by a kernel group) | `y` |
+| `CONFIG_FANOTIFY_ACCESS_PERMISSIONS` | permission events | `y` |
+
+The permission hooks are compiled out without the third; guard the whole phase 4 surface on it and
+skip the tests rather than failing them.
+
+## Sources
+
+* `fs/notify/fsnotify.c`, `fs/notify/group.c`, `fs/notify/mark.c`, `fs/notify/dnotify/dnotify.c`,
+  `kernel/audit_watch.c` (Linux 6.8)
+* `include/linux/fsnotify_backend.h`, `include/linux/fsnotify.h` (6.8 and v6.15)
+* `Module.symvers` from `linux-headers-6.8.0-124-generic`
+

--- a/docs/design/fsnotify/plan.md
+++ b/docs/design/fsnotify/plan.md
@@ -1,0 +1,172 @@
+# Plan: filesystem notification and permission binding
+
+Execution plan for the `fsnotify` binding.
+
+## Expected results
+
+1. A Lua script can watch filesystem events (open, access, modify, attrib, create, delete, move,
+   close, unmount) by marking an inode, a mount or a superblock.
+2. A Lua handler receives **permission** events (`FS_OPEN_PERM`, `FS_ACCESS_PERM`,
+   `FS_OPEN_EXEC_PERM`) and denies the access by returning a verdict, on a stock distribution kernel.
+3. The handler gets the identity of the object involved: event mask, dirent name, inode number,
+   directory context.
+4. Marks are added, removed and re-masked from Lua, without reloading the script.
+5. Two examples — an integrity monitor (notification) and an allow/deny rule (permission) — plus a
+   KTAP suite covering the event × object × outcome matrix.
+
+## Where we are today
+
+Lunatik has no filesystem observability at all. The closest existing things are structurally similar
+but touch nothing in `fs/notify`:
+
+* `notifier` registers on kernel notifier chains (netdevice, keyboard, vt) and calls a Lua function
+  that returns a `linux.notify` status code — the same "callback plus verdict" shape this binding
+  needs (`lib/luanotifier.c`);
+* `netfilter` runs a Lua callback per packet with a registry-cached `skb` object reset per call, and
+  turns the return value into a kernel verdict (`lib/luanetfilter.c`);
+* `probe` can observe `security_*` or VFS functions through kprobes, but only observes: a kprobe
+  cannot change the outcome of what it probes (`lib/luaprobe.c`);
+* `syscall` resolves syscall addresses for probing (`lib/luasyscall.c`).
+
+A full sweep of every local and remote branch found no `fsnotify`, `fanotify` or `inotify` code, and
+no issue or pull request on the subject. This is a clean slate.
+
+## What is missing
+
+| Expected result | Gap |
+|-----------------|-----|
+| Watch filesystem events | No group, no marks, no event delivery. Nothing in `fs/notify` is reachable from Lua. |
+| Deny on permission events | No permission handler, no verdict path, and no reentrancy guard — the missing piece that makes this dangerous rather than merely absent. |
+| Object identity in the handler | No representation of an event. Name, inode, directory and mask are all C-side only. |
+| Dynamic marks | No object lifecycle for a group or a mark, and no path resolution from Lua. |
+| Examples and tests | No suite, and no harness for driving file access from a test and asserting the outcome. |
+
+Supporting gaps:
+
+* no `FS_*` constants in `linux.*`; they live in `linux/fsnotify_backend.h`, which is not a uapi
+  header — autogen already handles non-uapi headers (`linux/notifier.h`, `linux/sched.h`), so this is
+  a spec entry, not a new mechanism;
+* no way to turn a Lua path string into a kernel object (`kern_path`), which every mark needs;
+* the test suite has no pattern for "run a userspace command, assert it was denied".
+
+## Shape of the work
+
+One new kernel module, `fsnotify` (`lib/luafsnotify.c`), owning two object classes: a **watch** (an
+`fsnotify_group` plus its ops) and the **event** passed to the handler. The full API proposal is in
+`api.md`; the kernel constraints that drive it are in `kernel-notes.md`.
+
+The single most important of those constraints, because it shapes the whole design:
+
+> Permission events are delivered **synchronously, in the context of the process performing the
+> access**, and the return value of the group's `handle_event` is the answer: non zero denies. This is
+> not a notification the kernel sends after the fact; the syscall is parked inside your handler. It
+> may sleep, which is why a process context runtime works, and it re-enters if the handler touches a
+> watched path, which is why a reentrancy guard is part of phase 1 rather than a later fix.
+
+The second constraint worth stating up front: this is **not** an LSM. It sees file access, not
+process, credential, capability or socket operations, and it cannot grant anything — it can only
+refuse. The rest of the system surface is the subject of the `lsm-ebpf` project.
+
+## Phases
+
+Each phase is one or more self contained pull requests.
+
+### Phase 0: constants
+
+Add the `FS_*` mask constants to autogen as `linux.fs`. Small change that forces a full pass through
+the build, the generated `linux.*` modules and the docs pipeline before touching `fs/notify`.
+
+Deliverables: an `autogen/specs.lua` entry for `linux/fsnotify_backend.h` with prefix `FS_` and an
+explicit `include` list of the event masks and flags.
+
+No change to `autogen.lua` is needed: the masks are plain hex literals and resolve like any other
+define. The `include` list is, because the prefix also matches the group priorities (`FS_PRIO_0/1/2`)
+and two constants that belong to inotify and dnotify internals (`FS_IN_IGNORED`, `FS_DN_MULTISHOT`).
+`kernel-notes.md` lists what goes in and what stays out. Curating this is most of the work in the
+phase; the entry itself is four lines.
+
+### Phase 1: watch and notify
+
+The `fsnotify` module and the watch object: create a group, mark an inode by path, deliver
+notification events to a Lua callback, tear down explicitly.
+
+Deliverables: `lib/luafsnotify.c`, `Kconfig`/`Kbuild` entries, `tests/fsnotify/`, README module table
+row, `config.ld` entry. The reentrancy guard lands here, with the notification path as its first
+test, because phase 2 cannot be reviewed safely without it.
+
+### Phase 2: event identity
+
+Name, inode number, directory inode, `isdir`, and the pid of the process performing the access.
+Settles the event object shape: which fields are always available, and which depend on the data type
+the kernel handed to the group (`PATH`, `INODE`, `DENTRY`, `ERROR`).
+
+### Phase 3: mark objects
+
+Mount and superblock marks, mask updates on an existing mark, `ignore` masks, mark removal, and
+`fsnotify_find_mark` so a script can query what it already installed. This is where the object
+lifecycle gets its final shape.
+
+### Phase 4: permission events
+
+`FS_OPEN_PERM`, `FS_ACCESS_PERM`, `FS_OPEN_EXEC_PERM`, the verdict return path, the group priority
+requirement, and the version guards for 6.14+ (`fsnotify_mmap_perm`, `fsnotify_truncate_perm`,
+pre-content events). Depends on `CONFIG_FANOTIFY_ACCESS_PERMISSIONS`; skips cleanly without it.
+
+This is the point at which the project does something a user can see, and the point at which a bug
+locks a machine out of its own files. It lands after the guard, the identity and the lifecycle are
+already reviewed.
+
+### Phase 5: examples and documentation
+
+An integrity monitor example (notification: log writes under a directory) and an allow/deny example
+(permission: refuse `exec` outside an allowlist), a documentation pass, and whatever API cleanup the
+examples expose.
+
+## Sizing
+
+Not a GSoC idea, so this is sized by what fits in a reviewable pull request rather than in hours.
+
+| Scope | Phases |
+|-------|--------|
+| Minimum useful | 0 to 2. A working watcher: events reach Lua with enough identity to act on. |
+| Complete | 0 to 5. Adds the lifecycle, enforcement and the examples. |
+
+Phase 4 is the boundary that matters: everything before it is observability and can be merged on its
+own; everything from it on is enforcement and needs the guard and the tests that precede it.
+
+## Non goals
+
+* **Being an LSM.** File access only. Process, credential, capability, socket and IPC surfaces belong
+  to the `lsm-ebpf` project.
+* **A userspace fanotify client.** This binding registers a *kernel* group, the way `dnotify`, `audit`
+  and `nfsd` do. It does not open an fd, does not queue events for userspace, and does not reimplement
+  the fanotify uapi.
+* **Path based policy in C.** The C side delivers the event; matching (globs, allowlists, sets) is
+  Lua's job, using `set`, `rcu` and the string library. The kernel module stays a binding.
+* **Content access from the handler.** Reading the file being opened, from inside the handler that
+  gates the open, is a deadlock waiting to happen. Out of scope; revisit only with pre-content events
+  and a real use case.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Reentrancy: the handler triggers the event it is handling | Guard by task identity in phase 1, before any permission work. See `api.md`. |
+| A denied event locks the system out of its own files | Examples and tests confine marks to a scratch directory. Documented prominently, and the permission example ships with a deny list, not a default deny. |
+| Version drift: `fsnotify_add_mark` signature changed between 6.8 and 6.15; the permission path changed in 6.14 | Version guards from the start, following the `LINUX_VERSION_CODE` pattern already used in `lib/luaxdp.c`. Table of the deltas in `kernel-notes.md`. |
+| Group priority requirement for permission events on newer kernels | Set `group->priority` explicitly; verify on both 6.8 and a 6.14+ kernel before phase 4 is called done. |
+| `handle_inode_event` versus `handle_event` | The simplified op cannot carry everything the permission path needs. Choice and rationale in `kernel-notes.md`. |
+| Sleeping in the handler blocks the watched process, and serializes every other watched access behind the runtime mutex | It is legal and expected here (fanotify parks the syscall waiting for userspace), but the cost is system wide, not per process: one lock, every watched access. Documented as an API contract, measured in phase 4. |
+
+## Definition of done, per phase
+
+1. builds clean on the target kernel, no new warnings;
+2. LDoc comments on every new function and object type, and the module listed in `config.ld` in
+   alphabetical order;
+3. a row in the README module table;
+4. a test in `tests/fsnotify/`, wired into that suite's `run.sh`, and described in `tests/README.md`;
+5. the test skips (not fails) when the kernel lacks the config it needs;
+6. the full suite still passes: `sudo lunatik test`;
+7. error paths audited: for every raise, whatever was already acquired is released;
+8. commits are small and each one stands alone.
+

--- a/docs/design/fsnotify/testing.md
+++ b/docs/design/fsnotify/testing.md
@@ -1,0 +1,123 @@
+# Testing the fsnotify binding
+
+Lunatik's tests are shell scripts emitting KTAP, driving a kernel Lua script and asserting on what it
+prints to `dmesg` or on what userspace observes. `tests/notifier/` is the closest existing model:
+a callback fires from a kernel event, and the test triggers that event from the shell. Read it,
+plus `tests/lib.sh` (`run_test`, `mark_dmesg`, `dmesg_since`, `check_dmesg`, `ktap_skip`), before
+writing anything new.
+
+Run everything with `sudo lunatik test`, one suite with `sudo lunatik test fsnotify`.
+
+## What this suite needs that others do not
+
+**A scratch subtree, created and destroyed per test.** Every mark in every test goes on a directory
+under `/tmp` created by the test itself. No test marks `/`, `/etc`, `/lib/modules/lua`, or the
+directory the script was loaded from. This is not tidiness: a permission test that denies the wrong
+open can make the machine unable to read its own scripts, and the cleanup path then cannot run
+either.
+
+The shape, in the `trap` convention the existing suites already use:
+
+    SCRATCH=$(mktemp -d /tmp/lunatik-fsnotify.XXXXXX)
+    cleanup() { lunatik stop "$SCRIPT" 2>/dev/null; rm -rf "$SCRATCH"; }
+    trap cleanup EXIT
+    cleanup_stale                      # run once up front, as the other suites do
+
+**An escape hatch for the enforcement tests.** A permission test installs a rule that denies, then
+proves the denial. If the script cannot be stopped afterwards, the machine keeps the rule. Every
+permission test therefore:
+
+* marks only the scratch subtree, so nothing outside it can be denied;
+* stops the script in the `trap`, not at the end of the happy path;
+* is written so that the deny rule matches a name that exists only in the scratch subtree.
+
+**A way to assert a denial.** Userspace side, not `dmesg`: run the access and check the error.
+
+    if cat "$SCRATCH/secret" 2>&1 | grep -q "Operation not permitted"; then ...
+
+`EPERM` is what a non zero return from the handler produces. Assert on both the failure of the
+command and the specific error, so that a test does not pass because the file was missing.
+
+## Test matrix
+
+Fill this in as the phases land. Each row is one `.sh` plus one `.lua`, following the convention that
+the description of the test lives in the shell script and the Lua file carries a single line pointing
+back at it.
+
+Coverage here means event × object kind × outcome, including the successes, not a list of features.
+
+### Phase 1 and 2: notification
+
+| Test | Proves |
+|------|--------|
+| `open.sh` | an inode mark reports `FS_OPEN` for that file and not for its neighbour |
+| `modify.sh` | `FS_MODIFY` and `FS_CLOSE_WRITE` arrive in order for a write |
+| `dirent.sh` | a directory mark with `FS_EVENT_ON_CHILD` reports `FS_CREATE`, `FS_DELETE`, `FS_MOVED_FROM`/`FS_MOVED_TO`, and the event carries the child's name |
+| `identity.sh` | `event:name()`, `event:ino()`, `event:dir()`, `event:isdir()` and `event:pid()` match what the shell knows (`stat -c %i`, `$$`) |
+| `nomask.sh` | an event outside the mark's mask does not reach the handler |
+| `reentrancy.sh` | a handler that itself opens a watched file returns instead of deadlocking; the machine survives and the suite continues |
+
+`reentrancy.sh` is the one that justifies the guard. Write it in phase 1, before the permission work
+exists: it is cheap while the worst case is a missed notification, and expensive once the worst case
+is a locked filesystem.
+
+Where a test needs to count handler invocations, use one shape across the suite: the handler
+increments a counter in an `rcu.table` and the shell asserts on the delta across the run, never on the
+absolute value, so a previous run cannot make a test pass.
+
+    local shared = rcu.table()
+    shared.calls = (shared.calls or 0) + 1
+
+### Phase 3: marks
+
+| Test | Proves |
+|------|--------|
+| `mount.sh` | a mount mark reports events for files under it (bind mount a scratch dir to keep the blast radius small) |
+| `sb.sh` | a superblock mark reports events on a scratch filesystem (loop mounted tmpfs), and skips if it cannot create one |
+| `remask.sh` | `mark:mask(new)` changes what arrives, both adding and removing an event |
+| `ignore.sh` | `mark:ignore()` suppresses the named events and nothing else |
+| `find.sh` | `watch:find(path)` returns the mark that was installed and `nil` for a path with none |
+| `remove.sh` | after `mark:remove()` no further events arrive, and `watch:stop()` on a watch with live marks leaks nothing (`fsnotify_wait_marks_destroyed` plus a second run of the same test) |
+| `lifetime.sh` | dropping the last Lua reference to a watch and forcing a collection does not oops and does not keep delivering |
+
+### Phase 4: permission
+
+Every test here skips without `CONFIG_FANOTIFY_ACCESS_PERMISSIONS`, checked once in the suite's
+`run.sh` and reported with `ktap_skip` per planned test so the plan count stays honest.
+
+| Test | Proves |
+|------|--------|
+| `allow.sh` | a handler returning `ALLOW` lets the open through — the success case, which is the one a broken verdict path breaks silently |
+| `deny.sh` | a handler returning `DENY` makes `cat` fail with `EPERM`, and the neighbouring file still opens |
+| `default.sh` | a handler that returns nothing allows, rather than denying |
+| `exec.sh` | `FS_OPEN_EXEC_PERM` denies an exec of a scratch binary while an ordinary read of the same file still succeeds |
+| `access.sh` | `FS_ACCESS_PERM` gates a read after the open |
+| `error.sh` | a handler that raises does not leave the access half decided; the documented behaviour (allow, with the error logged) is what happens |
+| `sleep.sh` | a handler that calls `linux.schedule` completes and the syscall returns afterwards, proving the process context claim |
+
+`default.sh` and `allow.sh` exist because the dangerous failure mode of this feature is a verdict path
+that denies everything: a test suite that only asserts denials passes on a module that never allows.
+
+### Phase 5: examples
+
+| Test | Proves |
+|------|--------|
+| `example_monitor.sh` | the integrity monitor example loads, reports a write under the scratch tree, and stops cleanly |
+| `example_allowlist.sh` | the exec allowlist example denies a name outside the list and permits one inside it |
+
+## Conventions to follow
+
+* skip, do not fail, when the kernel lacks a config;
+* mark `dmesg` before the run, read only what came after, and `check_dmesg` at the end;
+* clean up in a `trap`, and run the cleanup once up front as well;
+* `lunatik run` exits 0 even when the script fails to load — assert on output, never on exit status;
+* one `.sh` per row above, wired into `tests/fsnotify/run.sh` and described in `tests/README.md` in
+  the same commit as the code it tests.
+
+## Manual verification before calling a phase done
+
+The suite runs on one kernel. The version drift table in `kernel-notes.md` covers three interfaces
+that changed inside 6.x, so phase 4 is not done until permission events have been seen working on
+both a 6.8 kernel and a 6.14 or newer one — the priority gating means a wrong `group->priority` shows
+up as "no events at all" on the newer kernel and as "works fine" on the older one.
+

--- a/docs/design/lsm-ebpf/README.md
+++ b/docs/design/lsm-ebpf/README.md
@@ -1,0 +1,45 @@
+# LSM binding through eBPF
+
+Working documents for `lualsm`: reaching the Linux Security Module surface from Lua, by way of eBPF.
+Both regimes the LSM offers are in scope — **observing** security relevant operations (exec,
+credential changes, socket use, module loading, ptrace) and, on the hooks that allow it, **refusing**
+them.
+
+They exist so that a new contributor, with or without an AI coding assistant, can pick the work up
+without first discovering that an out-of-tree module cannot be an LSM.
+
+| Document | What it is for |
+|----------|----------------|
+| [plan.md](plan.md) | Current state, gap analysis, phases, sizing, non goals, definition of done |
+| [api.md](api.md) | Proposed Lua API for the `lsm` and `cgroup` modules, with worked examples |
+| [kernel-notes.md](kernel-notes.md) | Verified kernel API reference: why eBPF, the kfunc contract, attach rules, config and boot requirements |
+| [testing.md](testing.md) | Test strategy, the boot-dependent skip logic, and the test matrix |
+
+Start with `plan.md`. Read `kernel-notes.md` before writing any C — in particular the first section,
+which explains why this project is built on eBPF rather than on a security module of our own.
+
+## Working on this
+
+The repository conventions that apply to every change here (build, test, style, kernel context rules,
+commit discipline) are in [AGENTS.md](../../../AGENTS.md) at the root of the repository. Read it once
+before the first patch. If you use an AI assistant, point it at that file and at `kernel-notes.md`.
+
+Three things decide whether this work goes well:
+
+1. **The LSM framework is closed to loadable modules.** `security_add_hooks()` is `__init` and
+   unexported, and since 6.12 the hook calls are static calls sized at build time. There is no
+   `lunatik_lsm.ko` that registers hooks. eBPF is the supported way in, and this project rides the
+   kfunc bridge Lunatik already uses for XDP and TC.
+2. **The bridge already exists — extend it, do not fork it.** `bpf_luaxdp_run` in `lib/luaxdp.c` is
+   the pattern; `lunatik_ebpf.h` on `sneaky-potato/gsoc26` generalizes it; issue #561 tracks making it
+   a real API. `lualsm` should be its third consumer, not a fourth copy.
+3. **BPF LSM is off on most distributions.** It needs `bpf` in the kernel's `lsm=` list. Ubuntu does
+   not ship it that way; Fedora does. Everything here must detect that and skip rather than fail —
+   and the phase order is chosen so that useful work lands before anyone has to reboot.
+
+## Status
+
+These documents describe the design; they do not track progress. What is in flight, and how far along
+each phase is, lives on the [LSM through eBPF board](https://github.com/orgs/luainkernel/projects/3).
+Each phase is an issue there and lands as its own pull request.
+

--- a/docs/design/lsm-ebpf/api.md
+++ b/docs/design/lsm-ebpf/api.md
@@ -1,0 +1,206 @@
+# Proposed Lua API: `lsm` and `cgroup`
+
+This is a design proposal, not a specification. Names and shapes are open for review; the constraints
+behind them (in `kernel-notes.md`) are not. Anything here that turns out to conflict with a kernel
+constraint loses.
+
+Two new kernel modules, both consumers of the kfunc bridge that `lib/luaxdp.c` established and
+`lunatik_ebpf.h` generalizes:
+
+* `cgroup` (`lib/luacgroup.c`) — reachable from cgroup socket programs, no boot change required;
+* `lsm` (`lib/lualsm.c`) — reachable from `BPF_PROG_TYPE_LSM` programs, requires `lsm=...,bpf`.
+
+Both follow `xdp.attach`, which is on `master`: an eBPF program calls a kfunc naming a runtime, the
+kfunc runs the callback that runtime registered, and the callback's verdict becomes the program's
+return value. `lib/luatc.c` on `sneaky-potato/gsoc26` is the second consumer of the same pattern, but
+it is not merged, so nothing here depends on its shape.
+
+## Conventions
+
+* `attach` is called from a **non-sleepable** runtime (`lunatik run <script> softirq`), like
+  `xdp.attach`, because the kfunc is called from an eBPF program that cannot sleep. Enforce it the
+  same way: `lunatik_checkruntime(L, LUNATIK_OPT_SOFTIRQ)` as the first line of `attach`.
+* Neither module needs an object class for the attachment itself. `xdp.attach` registers the callback
+  as a closure in the registry (`lunatik_register(L, -1, luaxdp_callback)`) and `xdp.detach`
+  unregisters it; there is no handle to collect. Follow that. The `cgroup.ctx` class is
+  `LUNATIK_OPT_SOFTIRQ | LUNATIK_OPT_SINGLE` with `.pointer = true`, reset per call and cleared on
+  return, since it wraps a kernel pointer that outlives nothing.
+* Verdicts are integers: `0` allows, a negative errno refuses. `linux.errno` supplies the names.
+* Hook-specific data reaches Lua as a `data` object the stub filled in, unpacked with `struct` — the
+  same way `luaxdp` passes its `arg`. The C side stays generic; the per-hook knowledge lives in the
+  eBPF stub.
+* The runtime key is the script name, as in `xdp`, so a stub addresses a script by the name it was
+  loaded with.
+
+## `cgroup`
+
+### `cgroup.attach(callback)`
+
+    local cgroup = require("cgroup")
+    local errno  = require("linux.errno")
+
+    local BLOCKED <const> = 0xC0A80001    -- 192.168.0.1
+
+    local function guard(ctx, argument)
+        if ctx:address() == BLOCKED then
+            return -errno.EPERM
+        end
+        return 0
+    end
+
+    cgroup.attach(guard)
+
+The eBPF side, attached with `bpftool cgroup attach /sys/fs/cgroup/<path> cgroup_inet4_connect`:
+
+    char rt_key[] = "examples/netguard/guard";
+
+    SEC("cgroup/connect4")
+    int connect4(struct bpf_sock_addr *ctx)
+    {
+            return bpf_luacgroup_run(rt_key, sizeof(rt_key), ctx, NULL, 0) == 0;
+    }
+
+Note the shape of the last line: a cgroup socket program returns **1 to allow and 0 to deny**, the
+opposite convention from LSM. Lua speaks one language (`0` allow, negative errno deny) and the stub
+translates. Putting the translation in the stub rather than in Lua keeps every callback in this
+project readable the same way.
+
+### The `cgroup.ctx` object
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `ctx:family()` | integer | `linux.socket.af` |
+| `ctx:protocol()` | integer | `linux.socket.ipproto` |
+| `ctx:address([value])` | integer or string | IPv4 as an integer, IPv6 as a 16 byte string; setting rewrites the destination |
+| `ctx:port([value])` | integer | host order |
+
+Whatever the stub packed arrives as a second argument, a `data` object, not as a method on the ctx:
+`callback(ctx, argument)`. That keeps the argument in the same position it has in `lsm.attach`.
+
+`address` and `port` are settable because that is what a cgroup socket program is for: `connect4` can
+redirect as well as refuse, and refusing to expose it would make the binding weaker than the stub it
+wraps. The setter is the one method here that is not yet proven; see `kernel-notes.md`.
+
+These accessors do not read the fields the eBPF program uses. A kfunc receives
+`struct bpf_sock_addr_kern`, which carries `sk` and a `struct sockaddr *uaddr`, not the synthesized
+`user_ip4`/`user_port` of the UAPI view. `kernel-notes.md` has the struct and the reason. This is why
+`cgroup` keeps a `ctx` object while `lsm` does not: there is real decoding to do, and doing it once in
+C beats doing it in every stub.
+
+## `lsm`
+
+### `lsm.attach(callback)`
+
+    local lsm   = require("lsm")
+    local errno = require("linux.errno")
+    local set   = require("set")
+
+    local allowed = set.new{"/usr/bin/hello", "/bin/true"}
+
+    local function guard(hook, argument)
+        local path = argument:getstring(0)
+        if not allowed:has(path) then
+            return -errno.EPERM
+        end
+        return 0
+    end
+
+    lsm.attach(guard)
+
+The eBPF side:
+
+    char rt_key[] = "examples/execguard/guard";
+
+    SEC("lsm/bprm_check_security")
+    int BPF_PROG(exec_guard, struct linux_binprm *bprm, int ret)
+    {
+            struct lualsm_arg arg = {};
+
+            if (ret)
+                    return ret;                    /* an earlier LSM already refused */
+            bpf_probe_read_kernel_str(arg.path, sizeof(arg.path), bprm->filename);
+            return bpf_lualsm_run(rt_key, sizeof(rt_key), LUALSM_BPRM_CHECK, &arg, sizeof(arg));
+    }
+
+Three things in that stub are load bearing, and all three are the stub's job rather than Lua's:
+
+* **`if (ret) return ret;`** — LSM programs run after the other modules in the chain, and a hook that
+  has already been refused must stay refused. An LSM can restrict; it cannot grant. A callback that
+  returns 0 unconditionally must not turn another module's denial into an allow.
+* **the hook id** (`LUALSM_BPRM_CHECK`) — so one runtime can serve several hooks and the callback can
+  tell them apart.
+* **the argument packing** — every hook has a different signature; the stub reads what it needs and
+  hands over bytes.
+
+### There is no `lsm.ctx`
+
+The callback is `callback(hook, argument)`: an integer the stub chose, and a `data` object holding the
+bytes it packed. That is `xdp.attach`'s shape (`luaxdp_callback` pushes two `data` objects and nothing
+else) and `notifier`'s shape (`callback(event, ...)`, integer first) at the same time.
+
+An `lsm.ctx` was considered and dropped. It would have carried four methods: `hook()` and `argument()`
+are the two arguments above; `pid()` is reachable without the hook's help; and `action(verdict)`
+duplicates the return value. A class that exists to hold two values it could pass directly is a class
+that will be asked to justify itself in review.
+
+The verdict is the return value, only. `lib/luatc.c` sets it on a ctx instead, but `luatc` is not on
+`master`, so there is no established second spelling to be symmetric with.
+
+`cgroup` keeps its `ctx` because there the object decodes a kernel struct rather than forwarding
+arguments.
+
+## The policy fast path
+
+The point of the design is that most decisions never reach Lua. Lua owns the ruleset; eBPF reads it.
+
+    local map = require("bpf.map")
+
+    local rules <close> = map.hash("/sys/fs/bpf/execguard", "c64", "I4")
+    rules["/usr/bin/hello"] = 1     -- 1 = allow, 2 = deny, absent = ask Lua
+
+and in the stub:
+
+    __u32 *decision = bpf_map_lookup_elem(&rules, &key);
+
+    if (decision)
+            return *decision == LUALSM_ALLOW ? 0 : -EPERM;
+    return bpf_lualsm_run(rt_key, sizeof(rt_key), LUALSM_BPRM_CHECK, &arg, sizeof(arg));
+
+Lua writes the map from a process runtime; the stub reads it on every exec. The kfunc is the escape
+hatch for what a map cannot express — a rule that needs string matching, state, or a decision that
+depends on something the map does not carry.
+
+This is the same two-layer split that made
+[`secmodel_sandbox`](https://www.cs.wm.edu/~smherwig/pub/17-bsdcan-secmodel_sandbox-slides.pdf)
+usable on NetBSD — boolean rules resolved from its C-side ruleset cost roughly 70 ns, while a rule
+that ran the interpreter cost roughly 4.5 µs (prior art section of `plan.md`). The map is the
+ruleset; the kfunc is its `sandbox.on()`.
+
+## Detecting what the kernel can do
+
+    local lsm = require("lsm")
+
+    if not lsm.available() then
+        print("BPF LSM not active; boot with lsm=...,bpf")
+        return
+    end
+
+`lsm.available()` reports whether `bpf` is in the active LSM list. It exists because the failure mode
+without it is silent: the stub loads, the attach fails with a message nobody reads, and the policy
+appears to be installed while nothing is enforced.
+
+## Open questions for review
+
+1. Whether `cgroup` is its own module or a submodule of `socket`. The kfunc is separate either way;
+   the question is only how a script names it. A program type is not a socket, so the proposal keeps
+   it separate.
+2. Whether the `argument` should stay a raw `data` or gain a per-hook decoder generated from BTF.
+   The raw form ships first; a decoder is a project of its own.
+3. Whether hook ids should be a Lunatik enum passed by the stub, or the BTF id of the attach point,
+   which the stub gets for free but which is not stable across kernels.
+4. Whether `lsm.attach` should accept a table of `hook = callback` rather than one callback that
+   switches on the hook argument. The table reads better; it also puts a dispatch in C that Lua can
+   do.
+5. Whether verdicts should be `linux.errno` negatives or named constants (`lsm.action.DENY`). The
+   errno form composes with the rest of the base; the named form is harder to get wrong.
+

--- a/docs/design/lsm-ebpf/kernel-notes.md
+++ b/docs/design/lsm-ebpf/kernel-notes.md
@@ -1,0 +1,246 @@
+# Kernel notes: LSM through eBPF
+
+Reference sheet for `lualsm`. Everything below was checked against Linux 6.8
+(`/home/ubuntu/linux-hwe-6.8-6.8.0` sources, `/usr/src/linux-headers-6.8.0-124-generic`, its
+`Module.symvers`, and the running `/sys/kernel/security/lsm`), and compared against upstream v6.12
+and v6.15 where the mechanism changed. Re-check on the kernel you target.
+
+## Why eBPF: the LSM framework is closed to modules
+
+This is the fact that decides the whole design. Three independent parts of the kernel close the door:
+
+**1. The registration function is `__init` and unexported.**
+
+    /* security/security.c:609, Linux 6.8 */
+    void __init security_add_hooks(struct security_hook_list *hooks, int count,
+                                   const struct lsm_id *lsmid)
+
+No `EXPORT_SYMBOL` of any kind. `grep EXPORT_SYMBOL security/security.c` returns the `security_*`
+call sites (`security_inode_create`, `security_file_ioctl`, ...) that other subsystems invoke — never
+the registration path.
+
+**2. LSMs are discovered from a link-time section walked at boot.**
+
+    /* include/linux/lsm_hooks.h:150 */
+    #define DEFINE_LSM(lsm) \
+            static struct lsm_info __lsm_##lsm \
+                    __used __section(".lsm_info.init") \
+                    __aligned(sizeof(unsigned long))
+
+`ordered_lsm_init()` walks `__start_lsm_info .. __end_lsm_info` once, during boot, filtered by the
+`lsm=` list. A module loaded later is not in that section and there is no runtime equivalent.
+
+**3. Since v6.12 the hook calls are static calls with a fixed slot count.** The indirect
+`hlist_for_each_entry` dispatch of 6.8 became `DEFINE_STATIC_CALL_NULL` slots unrolled `MAX_LSM_COUNT`
+times, where `MAX_LSM_COUNT` is computed at build time from `CONFIG_LSM`
+(`security/security.c`, `LSM_DEFINE_UNROLL`, and `WARN(last_lsm == MAX_LSM_COUNT, "out of LSM static
+calls!?")`). There is no free slot for a module even in principle.
+
+The supported runtime extension of the security surface on Linux is BPF LSM (KRSI), and that is what
+this project targets.
+
+It is worth knowing what the alternative would look like, because a comparable project exists on
+another system and took the other road. NetBSD's authorization framework, kauth(9), lets a kernel
+module register a listener on an authorization scope **at runtime**:
+
+    /* NetBSD; there is no Linux equivalent of this call */
+    kauth_listen_scope(KAUTH_SCOPE_NETWORK, callback, cookie);
+    kauth_unlisten_scope(listener);
+
+A NetBSD *secmodel* is just a set of such listeners, which is why
+[`secmodel_sandbox`](https://github.com/smherwig/netbsd-sandbox) — Lua policies evaluated in the
+kernel, [BSDCan 2017](https://www.cs.wm.edu/~smherwig/pub/17-bsdcan-secmodel_sandbox-slides.pdf) —
+could be a loadable module there and cannot be one here. See the prior art section of `plan.md` for
+what that project did and what carries over. Reference:
+[kauth(9)](https://man.netbsd.org/kauth.9).
+
+Also worth stating because it shapes the API: **the LSM chain can only restrict.** In 6.8,
+`call_int_hook()` stops at the first non-zero return; a hook that a previous module refused stays
+refused. There is no "allow" that grants anything. `secmodel_sandbox` had to convert its own `ALLOW`
+into `DEFER` to get the same property; on Linux you get it for free, and an API that suggests
+otherwise would be lying.
+
+## BPF LSM: what it needs to exist
+
+    CONFIG_BPF_LSM=y
+
+Present on Ubuntu's 6.8 kernel. **Not sufficient.** `security/bpf/hooks.c` registers through the
+ordinary `DEFINE_LSM(bpf)` with no `LSM_ORDER_LAST`, so `bpf` must appear in the kernel's LSM list:
+
+    $ cat /boot/config-$(uname -r) | grep CONFIG_LSM=
+    CONFIG_LSM="landlock,lockdown,yama,integrity,apparmor"
+    $ cat /sys/kernel/security/lsm
+    lockdown,capability,landlock,yama,apparmor
+
+No `bpf` — on this machine LSM programs cannot attach. Enabling it means a boot parameter and a
+reboot:
+
+    GRUB_CMDLINE_LINUX="lsm=lockdown,capability,landlock,yama,apparmor,bpf"
+
+Fedora ships `bpf` in `CONFIG_LSM`; Ubuntu does not; Oracle's UEK added it. Verified unchanged in
+v6.15: `security/bpf/hooks.c` still has a plain `DEFINE_LSM(bpf)`.
+
+**This is why the phase order starts with cgroup programs.** `CONFIG_CGROUP_BPF` needs no boot
+parameter, and a cgroup socket program enforces per-cgroup network policy on a stock kernel.
+
+## The kfunc bridge
+
+A module can publish a kfunc and eBPF programs can call it. This is exported and supported:
+
+    /* kernel/bpf/btf.c:8002 */
+    EXPORT_SYMBOL_GPL(register_btf_kfunc_id_set);
+
+Program type to kfunc hook mapping, 6.8 (`kernel/bpf/btf.c:7894`):
+
+| Program type | Hook set |
+|--------------|----------|
+| `BPF_PROG_TYPE_LSM` | `BTF_KFUNC_HOOK_TRACING` |
+| `BPF_PROG_TYPE_TRACING` | `BTF_KFUNC_HOOK_TRACING` |
+| `BPF_PROG_TYPE_CGROUP_SKB`, `BPF_PROG_TYPE_CGROUP_SOCK_ADDR` | `BTF_KFUNC_HOOK_CGROUP_SKB` |
+| `BPF_PROG_TYPE_XDP` | `BTF_KFUNC_HOOK_XDP` |
+| `BPF_PROG_TYPE_SCHED_CLS` | `BTF_KFUNC_HOOK_TC` |
+
+Register with the program type; the core maps it. A set registered for `BPF_PROG_TYPE_UNSPEC` lands
+in `BTF_KFUNC_HOOK_COMMON`, which `btf_kfunc_id_set_contains` consults **before** the per-type set
+(`btf.c:7946`), so a kfunc meant for several program types can be registered once — at the cost of
+being callable from all of them, which for a kfunc that runs a Lua interpreter is a decision to make
+deliberately, not by default.
+
+The existing Lunatik pattern to follow, on `master` in `lib/luaxdp.c`:
+
+    __bpf_kfunc int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *xdp_ctx,
+                                   void *arg, size_t arg__sz);
+
+    BTF_KFUNCS_START(bpf_luaxdp_set)
+    BTF_ID_FLAGS(func, bpf_luaxdp_run)
+    BTF_KFUNCS_END(bpf_luaxdp_set)
+
+    static const struct btf_kfunc_id_set bpf_luaxdp_kfunc_set = {
+            .owner = THIS_MODULE,
+            .set   = &bpf_luaxdp_set,
+    };
+
+    register_btf_kfunc_id_set(BPF_PROG_TYPE_XDP, &bpf_luaxdp_kfunc_set);
+
+`lunatik_ebpf.h` on `sneaky-potato/gsoc26` wraps exactly this in
+`LUNATIK_EBPF_KFUNC_DEFINE_SET(subsys, kfunc)` and `LUNATIK_EBPF_KFUNC_INIT(subsys, prog_type)`,
+plus the version guards for the `BTF_SET8_START` to `BTF_KFUNCS_START` rename in 6.9 and the
+`__bpf_kfunc_start_defs` rename in 6.7. Use it; do not re-derive it.
+
+The eBPF side needs the module's BTF to resolve the kfunc, which is what `sudo make btf_install` is
+for. A program that cannot see it fails to load with "kernel function ... not found".
+
+## Attaching an LSM program
+
+Verification rules, `bpf_lsm_verify_prog` (`kernel/bpf/bpf_lsm.c:96`):
+
+* the program must be GPL licensed — `char _license[] SEC("license") = "GPL";`
+* its `attach_btf_id` must be in the `bpf_lsm_hooks` BTF set, which is generated from
+  `linux/lsm_hook_defs.h`: one `bpf_lsm_<hook>` stub per LSM hook.
+
+Return values: the LSM program is an `fmod_ret` style attachment on the `bpf_lsm_<hook>` stub. Hooks
+whose return type is `void` cannot refuse anything, and the verifier knows
+(`kernel/bpf/verifier.c:15308`, "LSM and struct_ops func-ptr's return type could be void"). For the
+`int` hooks, `0` allows and a negative errno refuses.
+
+Sleepable hooks are an explicit allowlist, `sleepable_lsm_hooks` in `kernel/bpf/bpf_lsm.c:259`;
+`SEC("lsm.s/...")` only works for those. A kfunc that a sleepable program calls must be declared
+`KF_SLEEPABLE`. The plan targets the non-sleepable path first, which matches how `luaxdp` already
+runs Lua from a non-sleepable runtime.
+
+`BPF_LSM_CGROUP` (`expected_attach_type`) scopes an LSM program to a cgroup subtree instead of the
+whole system. Its return convention differs — see the verifier note at `verifier.c:15309` — and it is
+phase 5 material, not phase 2.
+
+### Tooling: bpftool cannot attach an LSM program
+
+Verified with `bpftool v7.4.0 / libbpf v1.4` on this machine:
+
+    $ bpftool prog help
+    ATTACH_TYPE := { sk_msg_verdict | sk_skb_verdict | sk_skb_stream_verdict |
+                     sk_skb_stream_parser | flow_dissector }
+    $ bpftool link help
+    Usage: bpftool link { show | list } ... pin ... detach
+
+`bpftool link` can pin and detach an existing link but cannot create one, and `prog attach` does not
+cover LSM. Attaching an LSM program means `bpf_program__attach_lsm()` from libbpf, in a small loader
+that then pins the link so the attachment outlives the process. That loader is a deliverable, not an
+assumption.
+
+Cgroup programs are the opposite, and this is the second reason the cgroup phase comes first:
+
+    $ bpftool cgroup help
+    bpftool cgroup attach CGROUP ATTACH_TYPE PROG [ATTACH_FLAGS]
+    ATTACH_TYPE := { cgroup_inet_ingress | ... | cgroup_inet4_connect | cgroup_inet6_connect |
+                     cgroup_udp4_sendmsg | ... | cgroup_device | ... }
+
+No custom loader needed for phase 1.
+
+## Cgroup socket programs
+
+Attach types relevant here: `cgroup_inet4_connect`, `cgroup_inet6_connect`, `cgroup_inet4_bind`,
+`cgroup_udp4_sendmsg` and their v6 twins; also `cgroup_device` for device access and
+`cgroup_sock_ops`.
+
+Return convention is inverted relative to LSM: **1 allows, 0 refuses**, and refusing surfaces as
+`EPERM` on the syscall. The stub translates between that and the errno convention Lua uses; see
+`api.md`.
+
+**A kfunc does not receive the context the program sees.** The eBPF program manipulates
+`struct bpf_sock_addr` (`user_ip4`, `user_ip6[4]`, `user_port`, `family`, `protocol`, `msg_src_ip4`),
+and those writable fields are what make `connect4` able to redirect rather than only refuse — but that
+struct is a UAPI view the verifier synthesizes. Reads and writes of `ctx->user_ip4` in the program are
+rewritten by `convert_ctx_access` into accesses on the kernel-internal struct, which is what a kfunc
+is handed:
+
+    /* include/linux/filter.h:1328, Linux 6.8 */
+    struct bpf_sock_addr_kern {
+            struct sock *sk;
+            struct sockaddr *uaddr;
+            u64 tmp_reg;
+            void *t_ctx;
+            u32 uaddrlen;
+    };
+
+No `user_ip4`, no `user_port`, no `family`. The binding reads the address and port out of `uaddr`, and
+the socket out of `sk`. `lib/luaxdp.c` already demonstrates the pattern for its own context: the kfunc
+declares `struct xdp_md *xdp_ctx` for the program's benefit and its first line is
+`struct xdp_buff *ctx = (struct xdp_buff *)xdp_ctx;`.
+
+**Verify before promising a rewrite.** Reading `uaddr` is straightforward. Writing it from a kfunc, so
+that `connect4` redirects, is the same mutation the program's `ctx->user_ip4 = x` performs after
+rewriting, but "the same mutation after rewriting" is a claim about `convert_ctx_access`, not a fact
+established here. Prototype the write before the API promises `ctx:address(value)`.
+
+`cgroup_device` has no kfunc hook mapping of its own in 6.8, so a kfunc reachable from it would have
+to be registered in the `COMMON` set. Confirm before promising device policy in Lua.
+
+## Config and boot dependencies
+
+| Requirement | Needed for | Ubuntu 6.8 stock |
+|-------------|-----------|------------------|
+| `CONFIG_BPF_SYSCALL`, `CONFIG_DEBUG_INFO_BTF` | anything here | `y` |
+| `CONFIG_CGROUP_BPF` | phase 1 | `y` |
+| `CONFIG_BPF_LSM` | phases 2+ | `y` |
+| `bpf` in `/sys/kernel/security/lsm` | phases 2+ | **absent** — needs `lsm=...,bpf` and a reboot |
+| `sudo make btf_install` | the eBPF program resolving our kfunc | n/a |
+| `clang` with `-target bpf`, `bpftool` | building and attaching stubs | present |
+
+Check the LSM list at runtime, not the config: `lsm=` on the command line overrides `CONFIG_LSM`, so
+the config can say one thing and the running kernel another.
+
+## Sources
+
+* `security/security.c`, `security/bpf/hooks.c`, `include/linux/lsm_hooks.h`, `kernel/bpf/bpf_lsm.c`,
+  `kernel/bpf/btf.c`, `kernel/bpf/verifier.c` (Linux 6.8; `security/security.c` and
+  `security/bpf/hooks.c` also checked at v6.12 and v6.15)
+* `/sys/kernel/security/lsm` and `/boot/config-6.8.0-124-generic` on the development machine
+* `bpftool v7.4.0` help output on the same machine
+* `lib/luaxdp.c` on `master`; `lunatik_ebpf.h` and `lib/luatc.c` on `sneaky-potato/gsoc26`
+* [LSM BPF programs](https://docs.kernel.org/bpf/prog_lsm.html), kernel documentation
+* S. Herwig, *secmodel_sandbox: An application sandbox for NetBSD*, BSDCan 2017
+  ([slides](https://www.cs.wm.edu/~smherwig/pub/17-bsdcan-secmodel_sandbox-slides.pdf),
+  [source](https://github.com/smherwig/netbsd-sandbox)); [kauth(9)](https://man.netbsd.org/kauth.9)
+* L. V. Neto, R. Ierusalimschy, A. L. de Moura, M. Balmer,
+  [*Scriptable Operating Systems with Lua*](https://netbsd.org/~lneto/dls14.pdf), DLS 2014
+

--- a/docs/design/lsm-ebpf/plan.md
+++ b/docs/design/lsm-ebpf/plan.md
@@ -1,0 +1,243 @@
+# Plan: LSM binding through eBPF
+
+Execution plan for `lualsm`.
+
+## Expected results
+
+1. A Lua script can attach a callback to **any** LSM hook — file, exec, process, credential,
+   capability, socket, IPC, mount, module loading, ptrace — and observe the operation: audit,
+   detection, telemetry written in Lua.
+2. On the hooks that allow it, the callback **denies** the operation by returning an error, giving
+   MAC, sandboxing and system ACLs in Lua.
+3. The hot path of a policy lives in eBPF maps written from Lua: the decision is taken in eBPF
+   without entering the interpreter, and Lua runs only on a miss or on a rule that asks for it.
+4. Per-cgroup network rules (connect, bind, sendmsg) are scriptable in Lua **without** `lsm=bpf` in
+   the boot line, so a stock distribution kernel gets something useful.
+5. Loader tooling that reports whether the running kernel can attach LSM programs at all; examples in
+   both regimes (an exec auditor and an allowlist sandbox); a test suite that skips cleanly when the
+   kernel is not configured for it.
+
+## Where we are today
+
+The bridge this project needs mostly exists, in three places at three levels of maturity:
+
+* **On `master`:** `lib/luaxdp.c` carries the complete kfunc pattern — `bpf_luaxdp_run` declared with
+  `__bpf_kfunc`, published through a `BTF_KFUNCS` set, registered with
+  `register_btf_kfunc_id_set(BPF_PROG_TYPE_XDP, ...)`, plus a runtime lookup by string key in an RCU
+  table and a Lua-side `xdp.attach(callback)`. `make btf_install` exports the module BTF that lets an
+  eBPF program resolve the kfunc.
+* **On `master`:** `lib/luabpf.c`, the map binding (#630, with the typed constructors of #636). Lua
+  can open a pinned map and read and write it. #633 proposes `bpf.map`, a higher level view; useful
+  here, not required.
+* **On `sneaky-potato/gsoc26`, not merged:** `lunatik_ebpf.h`, which factors the pattern into
+  `LUNATIK_EBPF_KFUNC_DEFINE_SET` / `LUNATIK_EBPF_KFUNC_INIT` plus a runtime lookup macro, and
+  `lib/luatc.c`, its second consumer, with a `ctx` object carrying the verdict setter. Issue #561
+  tracks turning this into a generic `lunatik_bpf_run`.
+
+What exists for security specifically: nothing. No branch, issue or pull request in the repository
+mentions LSM, and `security_*` appears nowhere in the tree.
+
+## What is missing
+
+| Expected result | Gap |
+|-----------------|-----|
+| Callback on any LSM hook | No `BPF_PROG_TYPE_LSM` kfunc, no stub programs, no attach path. Nothing today can reach a security hook. |
+| Deny an operation | No verdict representation, and no answer to which hooks can refuse and what they must return. |
+| Policy hot path in maps | The pieces exist on both sides (`luabpf` in Lua, maps in eBPF) but nothing ties a map lookup in the stub to a fallback into Lua. |
+| Per-cgroup network rules without a reboot | No cgroup program type binding, no `ctx` for a socket address operation. |
+| Tooling, examples, tests | `bpftool` cannot create an LSM link, so a loader has to exist. No detection of the active LSM list. No suite. |
+
+Supporting gaps:
+
+* no `errno` constants in `linux.*`, which a verdict API needs (`-EPERM`, `-EACCES`);
+* `lunatik_ebpf.h` is not on `master`, so either this project waits for it, carries it, or duplicates
+  the pattern — the plan below takes a position on that;
+* no test harness knows how to load an eBPF program, attach it, and assert on the result.
+
+## Shape of the work
+
+Two new kernel modules, both thin consumers of the same bridge:
+
+* `cgroup` (`lib/luacgroup.c`) — kfunc callable from cgroup socket programs, with a `ctx` exposing
+  the address and the verdict. Works on a stock kernel.
+* `lsm` (`lib/lualsm.c`) — kfunc callable from `BPF_PROG_TYPE_LSM` programs, with a `ctx` exposing
+  the hook identity, its arguments and the verdict. Needs `lsm=...,bpf`.
+
+The full API proposal is in `api.md`; the kernel constraints that drive it are in `kernel-notes.md`.
+Two of those constraints shape everything.
+
+The first is why this project exists in this form:
+
+> An out-of-tree module cannot be an LSM. `security_add_hooks()` is `__init` and unexported; LSMs are
+> registered from a `.lsm_info` section walked at boot; and since 6.12 the hook calls are static calls
+> with a slot count fixed at build time from `CONFIG_LSM`. Linux has no equivalent of NetBSD's
+> `kauth_listen_scope()`. eBPF is the only supported runtime extension of the security surface, so
+> the binding is a bridge into eBPF rather than a security module of our own.
+
+The second is what makes it fast enough to be real:
+
+> The eBPF program is not just a shim. It is where the policy's hot path belongs: a map lookup, keyed
+> by whatever the hook offers, deciding allow or deny without ever entering the interpreter. The kfunc
+> into Lua is the escape hatch for the rules that need one. Lua writes the maps; eBPF reads them.
+
+That split is not an invention of this project; it is the lesson of the prior art below, with its
+measurements.
+
+## Prior art: the same idea, on NetBSD
+
+This is not the first attempt to write system access control in Lua, and the one that came before is
+worth reading before designing anything here.
+
+**`secmodel_sandbox`** — Stephen Herwig, University of Maryland, BSDCan 2017
+([slides](https://www.cs.wm.edu/~smherwig/pub/17-bsdcan-secmodel_sandbox-slides.pdf),
+[source](https://github.com/smherwig/netbsd-sandbox)) — is a NetBSD kernel module that lets a process
+sandbox itself with a policy written in Lua, evaluated by NetBSD's in-kernel interpreter
+([`lua(4)`](https://man.netbsd.org/lua.4), from
+[Scriptable Operating Systems with Lua](https://netbsd.org/~lneto/dls14.pdf), DLS 2014). A policy
+looks like this:
+
+    sandbox.default('deny')
+    sandbox.allow('vnode.read_data')
+
+    sandbox.on('vnode.write_data', function(req, cred, f)
+        return string.find(f.name, '/tmp/') == 1
+    end)
+
+Three things it established, all of which apply here:
+
+1. **Evaluating the script is not the decision.** Running the policy populates a ruleset in C, keyed
+   by the authorization request; the hot path reads that ruleset. `sandbox.on()` is the escape hatch
+   for the rules a table cannot express, and it may be stateful or rewrite the ruleset as it runs.
+2. **The cost of getting that split wrong is measurable.** Its benchmark, 10 million syscalls, timed
+   the same operation three ways: no sandbox, a boolean rule from the ruleset, and a rule that ran
+   the interpreter. `setpriority` went 1.597 s → 2.281 s → 46.356 s; `socket` went 14.725 s →
+   17.439 s → 51.644 s. Roughly 70 ns per decision resolved in C against roughly 4.5 µs when Lua ran.
+   That is the whole argument for the map-backed fast path in phase 4.
+3. **A policy that can only restrict is the safe shape.** It converts its own `ALLOW` into kauth's
+   `DEFER` so that a sandbox cannot grant a privilege the system would otherwise refuse. Linux gives
+   us that property for free, since the LSM chain stops at the first refusal and has no "allow".
+
+What does **not** carry over is the mechanism. NetBSD's kauth lets a module register listeners at
+runtime ([`kauth_listen_scope(9)`](https://man.netbsd.org/kauth.9)), and a *secmodel* is just a set of
+those listeners; that is why `secmodel_sandbox` could be a loadable module at all. Linux has no such
+call — see `kernel-notes.md` — which is what turns the Linux version of this idea into a bridge to
+eBPF instead of a security module of our own.
+
+The other thing that does not carry over is where the policy comes from. `secmodel_sandbox` is
+self-sandboxing: a process installs a policy on itself through an ioctl, and children inherit it.
+This project is administrator policy attached to a hook or a cgroup. Landlock is the Linux answer to
+the self-sandboxing case, and it is deliberately out of scope.
+
+## Phases
+
+Each phase is one or more self contained pull requests.
+
+### Phase 0: errno constants and the dependency decision
+
+Add `linux.errno` to autogen, which the verdict API needs. Settle, with the maintainer, whether this
+project depends on `lunatik_ebpf.h` landing on `master` first (issue #561), waits for it, or ships
+`lib/lualsm.c` against the `luaxdp` pattern and is refactored onto the generic API afterwards.
+
+The recommendation is to depend on it and sequence the epic behind #561: a third open-coded copy of
+the kfunc pattern is exactly what #561 exists to prevent.
+
+### Phase 1: cgroup socket rules
+
+The `cgroup` module: kfunc for `BPF_PROG_TYPE_CGROUP_SOCK_ADDR`, a `ctx` with address, port, family
+and verdict, `cgroup.attach(callback)` on the Lua side, and an example stub program attached with
+`bpftool cgroup attach`.
+
+This phase is first because it needs no boot change: cgroup programs are attachable on any kernel with
+`CONFIG_CGROUP_BPF`, and `bpftool` can attach them without a custom loader. It delivers per-service
+network ACLs in Lua and exercises the whole path — stub, kfunc, ctx, verdict, tests — before the
+project depends on anything a user has to reboot for.
+
+Deliverables: `lib/luacgroup.c`, `Kconfig`/`Kbuild`, `examples/`, `tests/cgroup/`, README row,
+`config.ld` entry.
+
+### Phase 2: the LSM bridge
+
+The `lsm` module: `bpf_lualsm_run` registered for `BPF_PROG_TYPE_LSM`, a `ctx` carrying the hook
+identity and the verdict, `lsm.attach(callback)`, a stub program for one representative hook
+(`bprm_check_security`), and the loader.
+
+The loader is real work: `bpftool` has no way to create an LSM link, so this needs a small libbpf
+program that loads the object, attaches it and pins the link. Phase 2 owns it, along with detecting
+whether `bpf` is in `/sys/kernel/security/lsm` and saying so plainly when it is not.
+
+### Phase 3: hook coverage and arguments
+
+Beyond one hook: a stub set covering the hooks worth reaching first (`bprm_check_security`,
+`file_open`, `socket_connect`, `task_alloc`, `cred_prepare`, `kernel_module_request`), and the
+question this phase exists to answer — how a Lua callback reads a hook's arguments when every hook has
+a different signature. The proposal in `api.md` is that the stub packs what it wants into a buffer and
+Lua unpacks it with `struct`, exactly as `luaxdp` already passes its `arg`.
+
+### Phase 4: the policy fast path
+
+The map-backed pattern: Lua builds the ruleset into a pinned map, the stub decides from the map, and
+calls the kfunc only on a miss or when the entry says the rule is functional. An example that shows
+both paths and a benchmark that shows the difference, because the claim in "Shape of the work" is
+worth a number in our own tree rather than a citation.
+
+### Phase 5: per-process and per-cgroup policy
+
+`BPF_LSM_CGROUP` attachment, so a policy applies to a cgroup subtree rather than system wide, and BPF
+task storage for per-task state — the closest Linux equivalent of the credential-attached sandbox
+`secmodel_sandbox` gets from kauth. This is the phase that turns "a rule" into "a sandbox".
+
+### Phase 6: examples and documentation
+
+An exec auditor (observation) and an allowlist sandbox (enforcement), a documentation pass, and the
+API cleanup the examples expose.
+
+## Sizing
+
+Sized by what fits in a reviewable pull request.
+
+| Scope | Phases |
+|-------|--------|
+| Minimum useful | 0 to 2. Cgroup rules on a stock kernel, plus one LSM hook proving the bridge. |
+| Complete | 0 to 6. Coverage, the map fast path, scoped policy, examples. |
+
+Phase 2 is the boundary: everything before it works on an unmodified distribution kernel, everything
+after it assumes the operator opted into `lsm=bpf`.
+
+## Non goals
+
+* **Writing an LSM.** Not a kernel patch, not a shim security module, not an upstream submission. If
+  that path is ever taken it is a different project with a different risk profile.
+* **Replacing SELinux or AppArmor.** This is a scripting layer over the same hook surface, useful for
+  policies that are dynamic, small, or specific to one deployment. It stacks with whatever major LSM
+  is loaded; it does not compile a policy for it.
+* **A policy language.** No DSL, no compiler, no rule file format. Lua is the language; `set`, `rcu`
+  and `bpf.map` are the data structures.
+* **Unprivileged sandboxing.** Landlock exists for that, is unprivileged by design, and is not
+  reachable from a kernel module. A script here needs `CAP_BPF`/`CAP_SYS_ADMIN` and is administrator
+  policy, not self-restriction.
+* **Sleepable LSM hooks in phase 1 to 4.** The kfunc runs from a non-sleepable program; the sleepable
+  subset is a documented restriction, not an early feature.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| BPF LSM is not enabled on the developer's or the user's kernel | Phase 1 needs no boot change at all; phases 2 on detect and skip. Documented in the README, checked by the loader, reported by the tests. |
+| `lunatik_ebpf.h` is not on `master`; building on it couples this epic to #561 | Phase 0 settles it explicitly rather than discovering it in phase 2. |
+| Hook argument access differs per hook, and a wrong BTF type is a verifier error at best | Stub-packs-a-buffer keeps the C side generic; the per-hook knowledge lives in the stub, which is where a mistake is a load failure rather than a kernel bug. |
+| A deny rule locks the operator out of the machine | Examples are allowlists over a scratch scope, never system wide defaults. Tests run the enforcement cases against a dedicated cgroup or a scratch binary. |
+| Verdict semantics: not every hook can refuse, and returning the wrong value on a void hook is a verifier rejection | Table of what each hook accepts in `kernel-notes.md`; the stub, not Lua, is responsible for the return type. |
+| The interpreter on a hot hook makes the system crawl | The map fast path is phase 4, but the shape is designed for from phase 1: the ctx carries what a decision needs, so a stub can decide without calling in. |
+
+## Definition of done, per phase
+
+1. builds clean on the target kernel, no new warnings;
+2. LDoc comments on every new function and object type, and the module listed in `config.ld` in
+   alphabetical order;
+3. a row in the README module table;
+4. a test in the right suite, wired into that suite's `run.sh`, and described in `tests/README.md`;
+5. the test skips (not fails) when the kernel lacks the config, the boot parameter, or the tooling;
+6. the full suite still passes: `sudo lunatik test`;
+7. error paths audited: for every raise, whatever was already acquired is released;
+8. commits are small and each one stands alone.
+

--- a/docs/design/lsm-ebpf/testing.md
+++ b/docs/design/lsm-ebpf/testing.md
@@ -1,0 +1,142 @@
+# Testing the LSM binding
+
+Lunatik's tests are shell scripts emitting KTAP, driving a kernel Lua script and asserting on what it
+prints to `dmesg` or on what userspace observes. `tests/bpf/` is the closest existing suite — it
+already deals with maps and pinned objects — and the XDP path in `examples/filter/` shows the build
+and load sequence a stub program needs. Read both, plus `tests/lib.sh`, before writing anything new.
+
+Run everything with `sudo lunatik test`, one suite with `sudo lunatik test lsm`.
+
+## What this suite needs that others do not
+
+**A stub program, built at test time.** Every test here has three parts, not two: the shell script,
+the kernel Lua script, and an eBPF object. The suite needs `clang -target bpf` and `bpftool`, and
+`sudo make btf_install` must have run so the stub can resolve our kfunc. Missing any of them is a
+skip, not a failure.
+
+**Two skip levels, checked in the suite's `run.sh` before anything else.**
+
+    grep -qw bpf /sys/kernel/security/lsm   # phases 2+; absent on stock Ubuntu
+    test -d /sys/fs/cgroup                  # phase 1
+
+The first is the one that matters: on a machine booted without `lsm=...,bpf` every LSM test must skip
+with a message saying so, and report `ktap_skip` per planned test so the plan count stays honest. A
+suite that fails there would fail on most developers' machines and be ignored within a week.
+
+**A scratch cgroup for the enforcement tests.** Phase 1 tests attach to a cgroup created by the test,
+never to the root cgroup:
+
+    CG=/sys/fs/cgroup/lunatik-test
+    mkdir -p "$CG"
+    cleanup() { bpftool cgroup detach "$CG" ... 2>/dev/null; rmdir "$CG" 2>/dev/null; ...; }
+    trap cleanup EXIT
+
+Then run the traffic with `echo $$ > "$CG/cgroup.procs"` in a subshell, so only that subshell is
+subject to the policy. A test that attaches to the root cgroup and denies `connect` takes the machine
+off the network, including whatever the operator was using to watch the test run.
+
+**A way to assert a denial.** Userspace side: run the operation, check the error.
+
+    if ! out=$(timeout 5 nc -w1 "$BLOCKED" 80 2>&1) && echo "$out" | grep -q "Permission denied"; then
+
+Assert on both the failure and the specific error, so a test does not pass because the host was
+unreachable anyway.
+
+**Pinned link cleanup.** LSM attachments are pinned links that outlive the process that made them. A
+test that leaves one behind leaves the policy installed. Unpin in the `trap`, and run the cleanup once
+up front too, so a previous crashed run does not poison the next one.
+
+## Test matrix
+
+Fill this in as the phases land. Each row is one `.sh` plus one `.lua` (plus one `.c` for the stub),
+following the convention that the description of the test lives in the shell script and the Lua file
+carries a single line pointing back at it.
+
+Coverage means the matrix of hook × outcome, including the allows, not a list of features.
+
+### Phase 1: `tests/cgroup/`
+
+| Test | Proves |
+|------|--------|
+| `attach.sh` | `cgroup.attach` from a non-sleepable runtime registers; from a sleepable one it raises |
+| `allow.sh` | a callback returning 0 lets the connection through — the success case a broken verdict path breaks silently |
+| `deny.sh` | a callback returning `-EPERM` makes `connect` fail with `EACCES`/`EPERM` inside the test cgroup, while the same connection succeeds outside it |
+| `address.sh` | `ctx:address()` and `ctx:port()` match what the test dialled |
+| `rewrite.sh` | setting `ctx:address()` redirects the connection to a local listener |
+| `argument.sh` | data packed by the stub arrives intact and unpacks with `struct` |
+| `detach.sh` | after `cgroup.detach()` the traffic flows unfiltered |
+| `nokey.sh` | a stub naming a runtime that does not exist fails loudly rather than silently allowing |
+
+### Phase 2 and 3: `tests/lsm/`
+
+Every test skips without `bpf` in the active LSM list.
+
+| Test | Proves |
+|------|--------|
+| `available.sh` | `lsm.available()` agrees with `/sys/kernel/security/lsm` |
+| `attach.sh` | attach registers, and a second attach on the same runtime replaces rather than duplicates |
+| `allow.sh` | a callback returning 0 lets an exec proceed |
+| `deny.sh` | a callback returning `-EPERM` makes the exec of a scratch binary fail with `EPERM`, and an exec of another binary still works |
+| `default.sh` | a callback that returns nothing allows, rather than denying |
+| `chain.sh` | the stub's `if (ret) return ret` is honoured: a hook already refused upstream stays refused even when the callback returns 0 |
+| `hookid.sh` | the `hook` argument distinguishes two hooks served by one runtime |
+| `argument.sh` | the packed argument arrives and decodes, for each hook in the phase 3 stub set |
+| `pid.sh` | `ctx:pid()` is the process performing the operation |
+| `error.sh` | a callback that raises does not wedge the hook; the documented behaviour is what happens |
+
+`allow.sh`, `default.sh` and `chain.sh` exist because the dangerous failure of this feature is not a
+missed denial, it is a module that denies everything or that converts someone else's denial into an
+allow. A suite that only asserts denials passes on both.
+
+### Phase 4: `tests/lsm/` (fast path)
+
+| Test | Proves |
+|------|--------|
+| `map_hit.sh` | an entry written from Lua decides in the stub, and the Lua callback is never invoked (count invocations) |
+| `map_miss.sh` | a key absent from the map falls through to the callback |
+| `map_update.sh` | rewriting the map from Lua changes the decision without reloading anything |
+| `bench.sh` | reports decisions per second for the map path and the callback path; informational, not a pass/fail gate |
+
+`map_hit.sh` is the one that proves the design claim. Write it as soon as phase 4 starts: if the
+callback runs anyway, the fast path does not exist and the API is wrong.
+
+**Counting invocations**, which two rows above depend on, needs one shape used everywhere rather than
+one per test. The callback increments a counter in an `rcu.table` shared with a reader script, and the
+shell reads it after driving the traffic:
+
+    local shared = rcu.table()          -- in the kernel script
+    shared.calls = (shared.calls or 0) + 1
+
+Assert on the delta across the run, not the absolute value, so a previous run cannot make a test pass.
+`tests/bpf/` already drives pinned maps from the shell and is the model for the plumbing.
+
+### Phase 5 and 6
+
+| Test | Proves |
+|------|--------|
+| `cgroup_scope.sh` | a `BPF_LSM_CGROUP` policy applies inside the cgroup and not outside it |
+| `task_storage.sh` | per-task state survives across hook invocations for the same task and is not shared with another |
+| `example_auditor.sh` | the exec auditor example loads, logs an exec, and stops cleanly |
+| `example_sandbox.sh` | the allowlist sandbox denies a binary outside the list and permits one inside it |
+
+## Conventions to follow
+
+* skip, do not fail, when the kernel lacks a config, the boot parameter or the tooling;
+* mark `dmesg` before the run, read only what came after, and `check_dmesg` at the end;
+* clean up in a `trap` — detach, unpin, remove the cgroup — and run the cleanup once up front;
+* `lunatik run` exits 0 even when the script fails to load; assert on output, never on exit status;
+* one `.sh` per row above, wired into the suite's `run.sh` and described in `tests/README.md` in the
+  same commit as the code it tests.
+
+## Verifying on a kernel that has BPF LSM
+
+The development machine is not enough for phases 2 and later. Before calling one of them done, run
+the suite on a kernel booted with `bpf` in the LSM list:
+
+    GRUB_CMDLINE_LINUX="... lsm=lockdown,capability,landlock,yama,apparmor,bpf"
+    sudo update-grub && sudo reboot
+    grep -w bpf /sys/kernel/security/lsm       # confirm before trusting a green run
+
+A green suite on a machine without `bpf` in that list means every LSM test skipped. Check the totals,
+not the exit status: `# Totals: pass:0 fail:0 skip:12` is not a passing phase.
+


### PR DESCRIPTION
Execution material for two epics, in the same shape as `docs/projects/conntrack-nat/` from the PR this
one stacks on: plan, proposed API, verified kernel reference, test strategy.

`docs/projects/fsnotify/` covers a binding for the kernel's filesystem notification subsystem, in both
regimes: asynchronous notification, and permission events where the handler's return value decides
whether the access happens. Tracked in #657.

`docs/projects/lsm-ebpf/` covers reaching the LSM surface from Lua through eBPF, to observe security
relevant operations and, on the hooks that allow it, refuse them. Tracked in #658.

Each project turns on one kernel fact that decides its design, which is why the notes exist rather
than a comment thread.

For fsnotify: permission events are delivered synchronously, in the context of the process performing
the access, and a non zero return from the group's `handle_event` denies. The syscall is parked inside
the handler, so it may sleep — and it re-enters if the handler touches a watched path. That is why the
reentrancy guard is phase 1 and not a later fix.

For LSM: an out-of-tree module cannot be one. `security_add_hooks()` is `__init` and unexported, LSMs
are discovered from a section walked at boot, and since v6.12 the hook calls are static calls with a
slot count fixed at build time. So the binding is a bridge into eBPF — the third consumer of the kfunc
pattern `lib/luaxdp.c` established, with eBPF maps as the ruleset and the kfunc as the escape hatch
for rules that need the interpreter.

The plan carries a prior art section for that project, because the same idea was built before on
NetBSD: [`secmodel_sandbox`](https://github.com/smherwig/netbsd-sandbox) (Herwig,
[BSDCan 2017](https://www.cs.wm.edu/~smherwig/pub/17-bsdcan-secmodel_sandbox-slides.pdf)) runs Lua
policies in the kernel over [`lua(4)`](https://man.netbsd.org/lua.4). It could be a loadable module
because NetBSD's kauth lets one register an authorization listener at runtime, which is exactly the
call Linux lacks; and its benchmark is where the two-layer design comes from, at roughly 70 ns for a
decision resolved from its C-side ruleset against roughly 4.5 µs when the interpreter ran.

Every symbol, signature and config dependency in both `kernel-notes.md` files was checked against
6.8 headers and `Module.symvers`, and against v6.12 and v6.15 upstream where the mechanism changed:
`fsnotify_add_mark` changed its second parameter, the permission path gained priority gating in 6.14,
and the LSM hook dispatch became static calls in 6.12.

