### PR TITLE
lunatik: add percpu runtimes (consolidated review of #642)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Lunatik 4.4  Copyright (C) 2023-2026 Ring Zero Desenvolvimento de Software LTDA.
 ### lunatik
 
 ```Shell
-usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>]
+usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [percpu]
 ```
 
 * `load`: load Lunatik kernel modules
@@ -95,7 +95,7 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>]
 * `status`: show which Lunatik kernel modules are currently loaded
 * `test [suite]`: run installed test suites (see [Testing](#testing))
 * `list`: show which runtime environments are currently running
-* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes)
+* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime instance per CPU id, for scripts dispatched by the eBPF bindings, which resolve to the instance of the CPU the hook runs on. The script runs once per instance
 * `spawn`: create a new runtime environment and spawn a thread to run the script `/lib/modules/lua/<script>.lua`
 * `stop`: stop the runtime environment created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_

--- a/bin/lunatik
+++ b/bin/lunatik
@@ -113,6 +113,18 @@ local function fallback_reader(prompt)
 	return io.read("l")
 end
 
+local function options(...)
+	local context, percpu
+	for _, opt in ipairs({...}) do
+		if opt == "percpu" then
+			percpu = true
+		else
+			context = opt
+		end
+	end
+	return context, percpu
+end
+
 local function try_as_expr(chunk)
 	return load("return " .. chunk .. ";") ~= nil
 end
@@ -159,13 +171,14 @@ if #arg >= 1 then
 	local tokens = {run = true, spawn = true, stop = true, list = true}
 	local needs_script = {run = true, spawn = true, stop = true}
 	if not tokens[token] or (needs_script[token] and not script) then
-		print("usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>]")
+		print("usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [percpu]")
 		os.exit(false)
 	end
 	ensure_loaded()
-	local parm  = arg[3] and (', "' .. arg[3] .. '"') or ""
+	local context, percpu = options(arg[3], arg[4])
 	local ret   = token == "list" and "return" or ""
-	local chunk = string.format("%s lunatik.runner.%s('%s'%s)", ret, token, script, parm)
+	local chunk = string.format("%s lunatik.runner.%s(%q, %s, %s)", ret, token, script,
+		context and string.format("%q", context) or "nil", percpu and "true" or "nil")
 	print(dostring(chunk))
 	os.exit()
 end

--- a/lib/lualinux.c
+++ b/lib/lualinux.c
@@ -249,6 +249,21 @@ static int lualinux_errname(lua_State *L)
     return 1;
 }
 
+/***
+* Returns the number of possible CPU ids.
+* CPU ids range from `0` to `numcpus() - 1`; the online ones are a subset,
+* so an id in that range may be offline.
+* @function numcpus
+* @treturn integer number of possible CPU ids
+* @usage
+* for cpu = 0, linux.numcpus() - 1 do print(cpu) end
+*/
+static int lualinux_numcpus(lua_State *L)
+{
+	lua_pushinteger(L, nr_cpu_ids);
+	return 1;
+}
+
 static const luaL_Reg lualinux_lib[] = {
 	{"random", lualinux_random},
 	{"schedule", lualinux_schedule},
@@ -259,6 +274,7 @@ static const luaL_Reg lualinux_lib[] = {
 	{"ifindex", lualinux_ifindex},
 	{"ifaddr", lualinux_ifaddr},
 	{"errname", lualinux_errname},
+	{"numcpus", lualinux_numcpus},
 	{NULL, NULL}
 };
 

--- a/lib/luarcu.c
+++ b/lib/luarcu.c
@@ -22,8 +22,6 @@
 
 #include "luarcu.h"
 
-#define LUARCU_MAXKEY	(LUAL_BUFFERSIZE)
-
 typedef struct luarcu_entry_s {
 	lunatik_value_t value;
 	struct hlist_node hlist;

--- a/lib/luarcu.h
+++ b/lib/luarcu.h
@@ -7,6 +7,7 @@
 #define luarcu_h
 
 #define LUARCU_DEFAULT_SIZE	(256)
+#define LUARCU_MAXKEY		(LUAL_BUFFERSIZE)
 
 lunatik_object_t *luarcu_newtable(size_t size, lunatik_opt_t opt);
 void luarcu_getvalue(lunatik_object_t *table, const char *key, size_t keylen, lunatik_value_t *value);

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -38,6 +38,7 @@ __diag_ignore_all("-Wmissing-prototypes",
 #endif
 
 static lunatik_object_t *luaxdp_runtimes = NULL;
+static lunatik_object_t *luaxdp_percpu = NULL;
 
 static inline lunatik_object_t *luaxdp_pushdata(lua_State *L, int upvalue, void *ptr, size_t size)
 {
@@ -96,11 +97,14 @@ out:
 
 static inline int luaxdp_checkruntimes(void)
 {
-	static const char key[] = "runtimes";
-	if (luaxdp_runtimes == NULL &&
-	   (luaxdp_runtimes = luarcu_getobject(lunatik_env, key, sizeof(key) - 1)) == NULL)
-		return -1;
-	return 0;
+	static const char runtimes_key[] = "runtimes";
+	static const char percpu_key[] = "percpu";
+
+	if (luaxdp_runtimes == NULL)
+		luaxdp_runtimes = luarcu_getobject(lunatik_env, runtimes_key, sizeof(runtimes_key) - 1);
+	if (luaxdp_percpu == NULL)
+		luaxdp_percpu = luarcu_getobject(lunatik_env, percpu_key, sizeof(percpu_key) - 1);
+	return luaxdp_runtimes != NULL && luaxdp_percpu != NULL ? 0 : -1;
 }
 
 __bpf_kfunc int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *xdp_ctx, void *arg, size_t arg__sz)
@@ -109,13 +113,21 @@ __bpf_kfunc int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *xdp_ctx
 	struct xdp_buff *ctx = (struct xdp_buff *)xdp_ctx;
 	int action = -1;
 	size_t keylen = key__sz - 1;
+	lunatik_value_t value;
+	char cpu_key[LUARCU_MAXKEY];
 
 	if (unlikely(luaxdp_checkruntimes() != 0)) {
-		pr_err("couldn't find _ENV.runtimes\n");
+		pr_err("couldn't find _ENV.runtimes or _ENV.percpu\n");
 		goto out;
 	}
 
 	key[keylen] = '\0';
+	luarcu_getvalue(luaxdp_percpu, key, keylen, &value);
+	if (value.type == LUA_TBOOLEAN && value.boolean) {
+		keylen = scnprintf(cpu_key, sizeof(cpu_key), "%s:%d", key, raw_smp_processor_id());
+		key = cpu_key;
+	}
+
 	if ((runtime = luarcu_getobject(luaxdp_runtimes, key, keylen)) == NULL) {
 		pr_err("couldn't find runtime '%s'\n", key);
 		goto out;
@@ -247,6 +259,8 @@ static void __exit luaxdp_exit(void)
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0))
 	if (luaxdp_runtimes != NULL)
 		lunatik_putobject(luaxdp_runtimes);
+	if (luaxdp_percpu != NULL)
+		lunatik_putobject(luaxdp_percpu);
 #endif
 }
 

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -96,9 +96,9 @@ out:
 
 static inline int luaxdp_checkruntimes(void)
 {
-	const char *key = "runtimes";
+	static const char key[] = "runtimes";
 	if (luaxdp_runtimes == NULL &&
-	   (luaxdp_runtimes = luarcu_getobject(lunatik_env, key, sizeof(key))) == NULL)
+	   (luaxdp_runtimes = luarcu_getobject(lunatik_env, key, sizeof(key) - 1)) == NULL)
 		return -1;
 	return 0;
 }

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -113,8 +113,6 @@ __bpf_kfunc int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *xdp_ctx
 	struct xdp_buff *ctx = (struct xdp_buff *)xdp_ctx;
 	int action = -1;
 	size_t keylen = key__sz - 1;
-	lunatik_value_t value;
-	char cpu_key[LUARCU_MAXKEY];
 
 	if (unlikely(luaxdp_checkruntimes() != 0)) {
 		pr_err_ratelimited("couldn't find _ENV.runtimes or _ENV.percpu\n");
@@ -122,13 +120,12 @@ __bpf_kfunc int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *xdp_ctx
 	}
 
 	key[keylen] = '\0';
-	luarcu_getvalue(luaxdp_percpu, key, keylen, &value);
-	if (value.type == LUA_TBOOLEAN && value.boolean) {
-		keylen = scnprintf(cpu_key, sizeof(cpu_key), "%s:%d", key, raw_smp_processor_id());
-		key = cpu_key;
-	}
-
 	if ((runtime = luarcu_getobject(luaxdp_runtimes, key, keylen)) == NULL) {
+		char cpu_key[LUARCU_MAXKEY];
+		size_t cpulen = scnprintf(cpu_key, sizeof(cpu_key), "%s:%d", key, raw_smp_processor_id());
+		runtime = luarcu_getobject(luaxdp_percpu, cpu_key, cpulen);
+	}
+	if (runtime == NULL) {
 		pr_err_ratelimited("couldn't find runtime '%s'\n", key);
 		goto out;
 	}

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -117,7 +117,7 @@ __bpf_kfunc int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *xdp_ctx
 	char cpu_key[LUARCU_MAXKEY];
 
 	if (unlikely(luaxdp_checkruntimes() != 0)) {
-		pr_err("couldn't find _ENV.runtimes or _ENV.percpu\n");
+		pr_err_ratelimited("couldn't find _ENV.runtimes or _ENV.percpu\n");
 		goto out;
 	}
 
@@ -129,7 +129,7 @@ __bpf_kfunc int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *xdp_ctx
 	}
 
 	if ((runtime = luarcu_getobject(luaxdp_runtimes, key, keylen)) == NULL) {
-		pr_err("couldn't find runtime '%s'\n", key);
+		pr_err_ratelimited("couldn't find runtime '%s'\n", key);
 		goto out;
 	}
 

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -33,11 +33,6 @@ local function key(script, cpu)
 	return script .. ":" .. cpu
 end
 
-local function ispercpukey(script)
-	local base = string.match(script, "^(.+):%d+$")
-	return base ~= nil and env.percpu[base] ~= nil
-end
-
 --- Stops an item (runtime or thread) in the given registry.
 -- If the item exists in the registry, its `stop()` method is called,
 -- and it's removed from the registry.
@@ -52,33 +47,46 @@ local function stop(registry, script)
 	end
 end
 
+local percpu = {}
+
+function percpu.name(script)
+	return string.match(script, "^(.+):0$")
+end
+
+function percpu.run(script, context, ...)
+	for cpu = 0, linux.numcpus() - 1 do
+		local ok, runtime = pcall(lunatik.runtime, script, context, ...)
+		if not ok then
+			percpu.stop(script)
+			error(runtime, 0)
+		end
+		env.percpu[key(script, cpu)] = runtime
+	end
+end
+
+function percpu.stop(script)
+	for cpu = 0, linux.numcpus() - 1 do
+		stop(env.percpu, key(script, cpu))
+	end
+end
+
 --- Runs a Lunatik script in the current context.
 -- Creates a new Lunatik runtime for the given script and registers it.
 -- Throws an error if a script with the same name is already running.
 -- @tparam string script path or name of the Lua script to run. The ".lua" extension will be trimmed.
 -- @tparam[opt] string context Execution context: `"process"` (default) or `"softirq"` (for netfilter/XDP hooks).
--- @tparam[opt] boolean percpu create one runtime per CPU id, registered as `<script>:<cpu>`,
---   for scripts dispatched by the eBPF bindings; the script runs once per runtime.
+-- @tparam[opt] boolean ispercpu create one runtime per CPU id, registered in `env.percpu`
+--   as `<script>:<cpu>`, for scripts dispatched by the eBPF bindings; the script runs
+--   once per runtime.
 -- @treturn table created Lunatik runtime object, or `nil` when `percpu` is set.
 -- @raise error if the script is already running.
-function runner.run(script, context, percpu, ...)
+function runner.run(script, context, ispercpu, ...)
 	local script = trim(script)
-	if env.runtimes[script] or env.percpu[script] then
+	if env.runtimes[script] or env.percpu[key(script, 0)] then
 		error(string.format("%s is already running", script))
 	end
-	if percpu then
-		for cpu = 0, linux.numcpus() - 1 do
-			local ok, runtime = pcall(lunatik.runtime, script, context, ...)
-			if not ok then
-				for created = 0, cpu - 1 do
-					stop(env.runtimes, key(script, created))
-				end
-				error(runtime, 0)
-			end
-			env.runtimes[key(script, cpu)] = runtime
-		end
-		env.percpu[script] = true
-		return nil
+	if ispercpu then
+		return percpu.run(script, context, ...)
 	end
 	local runtime = lunatik.runtime(script, context, ...)
 	env.runtimes[script] = runtime
@@ -92,39 +100,25 @@ end
 -- @tparam string script path or name of the Lua script to spawn.
 -- @treturn userdata kernel thread object.
 -- @raise error if the script is already running or `percpu` is set.
-function runner.spawn(script, context, percpu, ...)
-	if percpu then
+function runner.spawn(script, context, ispercpu, ...)
+	if ispercpu then
 		error("spawn does not support percpu scripts")
 	end
-	local runtime = runner.run(script, context, percpu, ...)
+	local runtime = runner.run(script, context, ispercpu, ...)
 	local name = string.match(script, "(%w*/*%w*)$")
 	local t = thread.run(runtime, name)
 	env.threads[script] = t
 	return t
 end
 
-local function stop_percpu(script)
-	if not env.percpu[script] then
-		return
-	end
-	for cpu = 0, linux.numcpus() - 1 do
-		stop(env.runtimes, key(script, cpu))
-	end
-	env.percpu[script] = nil
-end
-
 --- Stops a running script and its associated thread, if any.
 -- It attempts to stop the thread first, then the runtime.
 -- @tparam string script name of the script to stop. The ".lua" extension will be trimmed.
--- @raise error on a single instance of a percpu script; stop it by name.
 function runner.stop(script)
 	local script = trim(script)
-	if ispercpukey(script) then
-		error(string.format("%s is a percpu instance; stop the script by name", script))
-	end
 	stop(env.threads, script)
 	stop(env.runtimes, script)
-	stop_percpu(script)
+	percpu.stop(script)
 end
 
 --- Lists the names of all currently running scripts.
@@ -134,27 +128,35 @@ end
 function runner.list()
 	local list = {}
 	rcu.map(env.percpu, function (script)
-		table.insert(list, script)
+		local base = percpu.name(script)
+		if base then
+			table.insert(list, base)
+		end
 	end)
 	rcu.map(env.runtimes, function (script)
-		if not ispercpukey(script) then
-			table.insert(list, script)
-		end
+		table.insert(list, script)
 	end)
 	return table.concat(list, ', ')
 end
 
-local function stopall(registry)
-	rcu.map(registry, function (script)
-		runner.stop(script)
-	end)
-end
-
 --- Shuts down all running scripts and their threads.
--- Iterates over `env.percpu` and `env.runtimes` and calls `runner.stop` for each script.
+-- Collects the names from `env.percpu` and `env.runtimes`, then calls
+-- `runner.stop` for each script; stopping a percpu script removes entries
+-- beyond the current one, which the iteration does not support.
 function runner.shutdown()
-	stopall(env.percpu)
-	stopall(env.runtimes)
+	local scripts = {}
+	rcu.map(env.percpu, function (script)
+		local base = percpu.name(script)
+		if base then
+			table.insert(scripts, base)
+		end
+	end)
+	rcu.map(env.runtimes, function (script)
+		table.insert(scripts, script)
+	end)
+	for _, script in ipairs(scripts) do
+		runner.stop(script)
+	end
 end
 
 --- Initializes the runner's internal state.

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -14,6 +14,7 @@
 local lunatik = require("lunatik")
 local thread  = require("thread")
 local rcu     = require("rcu")
+local linux   = require("linux")
 
 local env = lunatik._ENV
 
@@ -28,35 +29,13 @@ local function trim(script) -- drop ".lua" file extension
 	return script:gsub("(%w+).lua", "%1")
 end
 
---- Runs a Lunatik script in the current context.
--- Creates a new Lunatik runtime for the given script and registers it.
--- Throws an error if a script with the same name is already running.
--- @tparam string script path or name of the Lua script to run. The ".lua" extension will be trimmed.
--- @tparam[opt] string context Execution context: `"process"` (default) or `"softirq"` (for netfilter/XDP hooks).
--- @treturn table created Lunatik runtime object.
--- @raise error if the script is already running.
-function runner.run(script, ...)
-	local script = trim(script)
-	if env.runtimes[script] then
-		error(string.format("%s is already running", script))
-	end
-	local runtime = lunatik.runtime(script, ...)
-	env.runtimes[script] = runtime
-	return runtime
+local function key(script, cpu)
+	return script .. ":" .. cpu
 end
 
---- Spawns a Lunatik script in a new kernel thread.
--- First, it runs the script using `runner.run`, then creates a new kernel thread
--- to execute the runtime. The thread is named based on the script's filename.
--- The spawned script is expected to return a function, which will then be executed in the new thread.
--- @tparam string script path or name of the Lua script to spawn.
--- @treturn userdata kernel thread object.
-function runner.spawn(script, ...)
-	local runtime = runner.run(script, ...)
-	local name = string.match(script, "(%w*/*%w*)$")
-	local t = thread.run(runtime, name)
-	env.threads[script] = t
-	return t
+local function ispercpukey(script)
+	local base = string.match(script, "^(.+):%d+$")
+	return base ~= nil and env.percpu[base] ~= nil
 end
 
 --- Stops an item (runtime or thread) in the given registry.
@@ -73,41 +52,118 @@ local function stop(registry, script)
 	end
 end
 
+--- Runs a Lunatik script in the current context.
+-- Creates a new Lunatik runtime for the given script and registers it.
+-- Throws an error if a script with the same name is already running.
+-- @tparam string script path or name of the Lua script to run. The ".lua" extension will be trimmed.
+-- @tparam[opt] string context Execution context: `"process"` (default) or `"softirq"` (for netfilter/XDP hooks).
+-- @tparam[opt] boolean percpu create one runtime per CPU id, registered as `<script>:<cpu>`,
+--   for scripts dispatched by the eBPF bindings; the script runs once per runtime.
+-- @treturn table created Lunatik runtime object, or `nil` when `percpu` is set.
+-- @raise error if the script is already running.
+function runner.run(script, context, percpu, ...)
+	local script = trim(script)
+	if env.runtimes[script] or env.percpu[script] then
+		error(string.format("%s is already running", script))
+	end
+	if percpu then
+		for cpu = 0, linux.numcpus() - 1 do
+			local ok, runtime = pcall(lunatik.runtime, script, context, ...)
+			if not ok then
+				for created = 0, cpu - 1 do
+					stop(env.runtimes, key(script, created))
+				end
+				error(runtime, 0)
+			end
+			env.runtimes[key(script, cpu)] = runtime
+		end
+		env.percpu[script] = true
+		return nil
+	end
+	local runtime = lunatik.runtime(script, context, ...)
+	env.runtimes[script] = runtime
+	return runtime
+end
+
+--- Spawns a Lunatik script in a new kernel thread.
+-- First, it runs the script using `runner.run`, then creates a new kernel thread
+-- to execute the runtime. The thread is named based on the script's filename.
+-- The spawned script is expected to return a function, which will then be executed in the new thread.
+-- @tparam string script path or name of the Lua script to spawn.
+-- @treturn userdata kernel thread object.
+-- @raise error if the script is already running or `percpu` is set.
+function runner.spawn(script, context, percpu, ...)
+	if percpu then
+		error("spawn does not support percpu scripts")
+	end
+	local runtime = runner.run(script, context, percpu, ...)
+	local name = string.match(script, "(%w*/*%w*)$")
+	local t = thread.run(runtime, name)
+	env.threads[script] = t
+	return t
+end
+
+local function stop_percpu(script)
+	if not env.percpu[script] then
+		return
+	end
+	for cpu = 0, linux.numcpus() - 1 do
+		stop(env.runtimes, key(script, cpu))
+	end
+	env.percpu[script] = nil
+end
+
 --- Stops a running script and its associated thread, if any.
 -- It attempts to stop the thread first, then the runtime.
 -- @tparam string script name of the script to stop. The ".lua" extension will be trimmed.
+-- @raise error on a single instance of a percpu script; stop it by name.
 function runner.stop(script)
 	local script = trim(script)
+	if ispercpukey(script) then
+		error(string.format("%s is a percpu instance; stop the script by name", script))
+	end
 	stop(env.threads, script)
 	stop(env.runtimes, script)
+	stop_percpu(script)
 end
 
 --- Lists the names of all currently running scripts.
--- Iterates over the `env.runtimes` RCU table to collect script names.
+-- Iterates over the `env.percpu` and `env.runtimes` RCU tables to collect
+-- script names; a percpu script is named once, not once per CPU id.
 -- @treturn string A comma-separated string of running script names, or an empty string if no scripts are running.
 function runner.list()
 	local list = {}
-	rcu.map(env.runtimes, function (script)
+	rcu.map(env.percpu, function (script)
 		table.insert(list, script)
+	end)
+	rcu.map(env.runtimes, function (script)
+		if not ispercpukey(script) then
+			table.insert(list, script)
+		end
 	end)
 	return table.concat(list, ', ')
 end
 
---- Shuts down all running scripts and their threads.
--- Iterates over `env.runtimes` and calls `runner.stop` for each script.
-function runner.shutdown()
-	rcu.map(env.runtimes, function (script)
+local function stopall(registry)
+	rcu.map(registry, function (script)
 		runner.stop(script)
 	end)
+end
+
+--- Shuts down all running scripts and their threads.
+-- Iterates over `env.percpu` and `env.runtimes` and calls `runner.stop` for each script.
+function runner.shutdown()
+	stopall(env.percpu)
+	stopall(env.runtimes)
 end
 
 --- Initializes the runner's internal state.
 -- Creates RCU-safe tables for storing runtimes and threads.
 -- This is typically called during Lunatik's initialization.
 function runner.startup()
-	if env.runtimes then return end
-	env.runtimes = rcu.table()
-	env.threads = rcu.table()
+	env.runtimes = env.runtimes or rcu.table()
+	env.percpu = env.percpu or rcu.table()
+	env.threads = env.threads or rcu.table()
 end
 
 return runner

--- a/tests/README.md
+++ b/tests/README.md
@@ -205,8 +205,9 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   CPU id, as `<script>:<cpu>`, which is the key the eBPF bindings look
   up; the script is listed once, by name; `stop` drops every instance
   and lets it run again; `spawn` refuses percpu without creating any
-  runtime; and a script that fails on one instance rolls back the ones
-  already created.
+  runtime; a script that fails on one instance rolls back the ones
+  already created; and the instances are not reachable through a
+  generic stop.
 
 ### set
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -201,6 +201,13 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   the receiving runtime via `class->opener` (`luaL_requiref`), even when
   that runtime never called `require()` for the module.
 
+- **percpu**: `run <script> percpu` registers one runtime per possible
+  CPU id, as `<script>:<cpu>`, which is the key the eBPF bindings look
+  up; the script is listed once, by name; `stop` drops every instance
+  and lets it run again; `spawn` refuses percpu without creating any
+  runtime; and a script that fails on one instance rolls back the ones
+  already created.
+
 ### set
 
 - **set**: `set.new` sorting unsorted input and binary-search membership

--- a/tests/runtime/percpu.lua
+++ b/tests/runtime/percpu.lua
@@ -1,0 +1,8 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu runtime test (see percpu.sh).
+
+return function() end
+

--- a/tests/runtime/percpu.sh
+++ b/tests/runtime/percpu.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for percpu runtimes: `run <script> percpu` registers one
+# runtime per possible CPU id as `<script>:<cpu>`, which is what the eBPF
+# bindings look up; the script is listed once, by name; stopping it drops every
+# instance and lets it run again; `spawn` refuses percpu without creating any
+# runtime; a script that fails on one instance rolls back the ones already
+# created; and stopping a single instance is refused.
+#
+# Usage: sudo bash tests/runtime/percpu.sh
+
+SCRIPT="tests/runtime/percpu"
+CHECK="tests/runtime/percpu_check"
+FAIL_SCRIPT="tests/runtime/percpu_fail"
+FAIL_CHECK="tests/runtime/percpu_fail_check"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+	lunatik stop "$CHECK" > /dev/null 2>&1
+	lunatik stop "$FAIL_SCRIPT" > /dev/null 2>&1
+	lunatik stop "$FAIL_CHECK" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 6
+
+mark_dmesg
+
+run_script "$SCRIPT" percpu
+run_script "$CHECK"
+check_dmesg || { ktap_totals; exit 1; }
+ktap_pass "one runtime per possible CPU id"
+
+lunatik stop "$CHECK" > /dev/null 2>&1
+
+listed=$(lunatik list)
+case "$listed" in
+	*"$SCRIPT:"*) fail "list shows the per-CPU keys: $listed" ;;
+	*"$SCRIPT"*)  ktap_pass "the script is listed once, by name" ;;
+	*)            fail "the script is not listed: $listed" ;;
+esac
+
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+listed=$(lunatik list)
+case "$listed" in
+	*"$SCRIPT"*) fail "stop left the script running: $listed" ;;
+esac
+run_script "$SCRIPT" percpu
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "stop drops every instance and lets the script run again"
+
+output=$(lunatik spawn "$SCRIPT" percpu 2>&1)
+echo "$output" | grep -q "spawn does not support percpu" || \
+	fail "spawn accepted percpu: $output"
+listed=$(lunatik list)
+case "$listed" in
+	*"$SCRIPT"*) fail "the refused spawn left runtimes behind: $listed" ;;
+esac
+ktap_pass "spawn refuses percpu without creating runtimes"
+
+output=$(lunatik run "$FAIL_SCRIPT" percpu 2>&1)
+echo "$output" | grep -q "intentional error on the second instance" || \
+	fail "the percpu run did not fail as intended: $output"
+mark_dmesg
+run_script "$FAIL_CHECK"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$FAIL_CHECK" > /dev/null 2>&1
+run_script "$FAIL_SCRIPT"
+lunatik stop "$FAIL_SCRIPT" > /dev/null 2>&1
+ktap_pass "a failing instance rolls back the ones already created"
+
+run_script "$SCRIPT" percpu
+output=$(lunatik stop "$SCRIPT:0" 2>&1)
+echo "$output" | grep -q "stop the script by name" || \
+	fail "stopping a single instance did not refuse: $output"
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+run_script "$SCRIPT" percpu
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "stopping a single instance is refused"
+
+ktap_totals
+

--- a/tests/runtime/percpu.sh
+++ b/tests/runtime/percpu.sh
@@ -8,7 +8,7 @@
 # bindings look up; the script is listed once, by name; stopping it drops every
 # instance and lets it run again; `spawn` refuses percpu without creating any
 # runtime; a script that fails on one instance rolls back the ones already
-# created; and stopping a single instance is refused.
+# created; and the instances are not reachable through a generic stop.
 #
 # Usage: sudo bash tests/runtime/percpu.sh
 
@@ -79,13 +79,15 @@ lunatik stop "$FAIL_SCRIPT" > /dev/null 2>&1
 ktap_pass "a failing instance rolls back the ones already created"
 
 run_script "$SCRIPT" percpu
-output=$(lunatik stop "$SCRIPT:0" 2>&1)
-echo "$output" | grep -q "stop the script by name" || \
-	fail "stopping a single instance did not refuse: $output"
+lunatik stop "$SCRIPT:0" > /dev/null 2>&1
+mark_dmesg
+run_script "$CHECK"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$CHECK" > /dev/null 2>&1
 lunatik stop "$SCRIPT" > /dev/null 2>&1
 run_script "$SCRIPT" percpu
 lunatik stop "$SCRIPT" > /dev/null 2>&1
-ktap_pass "stopping a single instance is refused"
+ktap_pass "instances are not reachable through a generic stop"
 
 ktap_totals
 

--- a/tests/runtime/percpu_check.lua
+++ b/tests/runtime/percpu_check.lua
@@ -1,0 +1,20 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu runtime test (see percpu.sh).
+
+local lunatik = require("lunatik")
+local linux   = require("linux")
+local test    = require("util").test
+
+local prefix <const> = "tests/runtime/percpu:"
+
+test("percpu registers one runtime per possible CPU id", function()
+	local runtimes = lunatik._ENV.runtimes
+	for cpu = 0, linux.numcpus() - 1 do
+		assert(runtimes[prefix .. cpu] ~= nil, "missing runtime for CPU " .. cpu)
+	end
+	assert(runtimes[prefix .. linux.numcpus()] == nil, "runtime beyond the last CPU id")
+end)
+

--- a/tests/runtime/percpu_check.lua
+++ b/tests/runtime/percpu_check.lua
@@ -8,13 +8,15 @@ local lunatik = require("lunatik")
 local linux   = require("linux")
 local test    = require("util").test
 
-local prefix <const> = "tests/runtime/percpu:"
+local script <const> = "tests/runtime/percpu"
+local prefix <const> = script .. ":"
 
 test("percpu registers one runtime per possible CPU id", function()
-	local runtimes = lunatik._ENV.runtimes
+	local percpu = lunatik._ENV.percpu
 	for cpu = 0, linux.numcpus() - 1 do
-		assert(runtimes[prefix .. cpu] ~= nil, "missing runtime for CPU " .. cpu)
+		assert(percpu[prefix .. cpu] ~= nil, "missing runtime for CPU " .. cpu)
 	end
-	assert(runtimes[prefix .. linux.numcpus()] == nil, "runtime beyond the last CPU id")
+	assert(percpu[prefix .. linux.numcpus()] == nil, "runtime beyond the last CPU id")
+	assert(lunatik._ENV.runtimes[script] == nil, "percpu script leaked into env.runtimes")
 end)
 

--- a/tests/runtime/percpu_fail.lua
+++ b/tests/runtime/percpu_fail.lua
@@ -1,0 +1,18 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu runtime test (see percpu.sh).
+
+local lunatik = require("lunatik")
+
+local env = lunatik._ENV
+local count = (env.percpu_fail_count or 0) + 1
+env.percpu_fail_count = count
+if count == 2 then
+	env.percpu_fail_count = nil
+	error("intentional error on the second instance")
+end
+
+return function() end
+

--- a/tests/runtime/percpu_fail_check.lua
+++ b/tests/runtime/percpu_fail_check.lua
@@ -10,6 +10,6 @@ local test    = require("util").test
 local zombie <const> = "tests/runtime/percpu_fail:0"
 
 test("percpu rollback leaves no instances behind", function()
-	assert(lunatik._ENV.runtimes[zombie] == nil, "instance 0 survived the failed run")
+	assert(lunatik._ENV.percpu[zombie] == nil, "instance 0 survived the failed run")
 end)
 

--- a/tests/runtime/percpu_fail_check.lua
+++ b/tests/runtime/percpu_fail_check.lua
@@ -1,0 +1,15 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu runtime test (see percpu.sh).
+
+local lunatik = require("lunatik")
+local test    = require("util").test
+
+local zombie <const> = "tests/runtime/percpu_fail:0"
+
+test("percpu rollback leaves no instances behind", function()
+	assert(lunatik._ENV.runtimes[zombie] == nil, "instance 0 survived the failed run")
+end)
+

--- a/tests/runtime/run.sh
+++ b/tests/runtime/run.sh
@@ -18,6 +18,7 @@ TESTS=(
 	opt_guards.sh
 	opt_skb_single.sh
 	require_cloneobject.sh
+	percpu.sh
 )
 
 SEP=""


### PR DESCRIPTION
Consolidation of the #642 review, rebuilt on master: the runner half of the series cherry-picked with every fix from the two review passes folded in, the bindings half ported to `luaxdp.c` (the only eBPF-dispatched binding on master), and a final commit restructuring the registries.

A percpu script gets one runtime per possible CPU id, and `bpf_luaxdp_run` resolves to the runtime of the CPU the hook runs on. Authorship of the original series is preserved; each fix is traceable to its inline comment on #642.

The last commit is the part that goes beyond the review: `env.runtimes` kept plain scripts and `<script>:<cpu>` instances in the same namespace, and every consumer had to tell the keys apart. Splitting the instances into `env.percpu` (instance 0 marks a running percpu script) removes the key filtering, the flag, and the single-instance stop hazard, and drops the per-packet flag lookup from the kfunc: a plain script now resolves with one read.

Registration-point enforcement (netfilter affinity, refusal helper) is tracked in #675 and left out of this series.

Tested on 6.8.0-136: full suite twice, `pass:77 fail:0` with a clean dmesg, including a shutdown smoke with live percpu instances (reload, run percpu plus a plain script, unload, three cycles). Builds clean against 5.15 and 6.8 headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
