### PR TITLE
netlink: add interface add/del to nl80211

### DIFF
--- a/autogen/specs.lua
+++ b/autogen/specs.lua
@@ -142,7 +142,7 @@ return {
 	{ header = "uapi/linux/nl80211.h",          prefix = "NL80211_CMD_",    module = "nl80211.cmd",
 		desc = "nl80211 commands (NL80211_CMD_*).",
 		include = { "GET_WIPHY", "NEW_WIPHY", "GET_INTERFACE", "SET_INTERFACE",
-			"NEW_INTERFACE", "GET_STATION", "NEW_STATION",
+			"NEW_INTERFACE", "DEL_INTERFACE", "GET_STATION", "NEW_STATION",
 			"GET_SCAN", "TRIGGER_SCAN", "NEW_SCAN_RESULTS" } },
 	{ header = "uapi/linux/nl80211.h",          prefix = "NL80211_ATTR_",   module = "nl80211.attr",
 		desc = "nl80211 attributes (NL80211_ATTR_*).",

--- a/lib/netlink/nl80211/interface.lua
+++ b/lib/netlink/nl80211/interface.lua
@@ -4,11 +4,11 @@
 --
 
 ---
--- Wireless interface listing. An `nl80211` object over the `"nl80211"` generic
--- netlink family: create an instance with `netlink.nl80211.interface()` and
--- list the wireless interfaces; the underlying socket is closed by `close()`
--- (or the to-be-closed `__close`). All methods block and require a sleepable
--- runtime.
+-- Wireless interface management. An `nl80211` object over the `"nl80211"`
+-- generic netlink family: create an instance with `netlink.nl80211.interface()`
+-- then list, add and delete wireless interfaces; the underlying socket is
+-- closed by `close()` (or the to-be-closed `__close`). All methods block and
+-- require a sleepable runtime.
 --
 -- @module netlink.nl80211.interface
 -- @see netlink.nl80211.object
@@ -20,6 +20,7 @@ local message = require("netlink.message")
 local cmd  = require("linux.nl80211").cmd
 local attr = require("linux.nl80211").attr
 
+local pack = string.pack
 local u32, str = message.u32, message.str
 
 ---
@@ -31,7 +32,9 @@ local u32, str = message.u32, message.str
 -- @tparam[opt] table o an initial object table.
 -- @treturn interface the new interface object.
 -- @see class
-local interface = object:new{GET = cmd.GET_INTERFACE, NEW = cmd.NEW_INTERFACE}
+local interface = object:new{
+	GET = cmd.GET_INTERFACE, NEW = cmd.NEW_INTERFACE, DEL = cmd.DEL_INTERFACE,
+}
 
 function interface:decode(attrs)
 	return {
@@ -48,6 +51,31 @@ end
 -- @function interface:list
 -- @treturn table list of `{ifindex, name, wiphy, iftype, mac}` tables (`mac`
 --   is 6 raw bytes).
+
+---
+-- Adds a virtual interface to a wiphy.
+-- @tparam table opts interface parameters: `wiphy` (radio index, from
+--   `netlink.nl80211.wiphy`), `name` and `iftype` (an `nl80211.iftype`).
+-- @treturn integer the new interface's `ifindex`.
+-- @raise on a netlink error (e.g. the name is taken or the iftype unsupported).
+function interface:add(opts)
+	for _, msg in ipairs(self:call(self.id, self.NEW, 0, message.attrs{
+		[attr.WIPHY]  = opts.wiphy,
+		[attr.IFNAME] = pack("z", opts.name),
+		[attr.IFTYPE] = opts.iftype,
+	})) do
+		local ifindex = u32(msg.attrs[attr.IFINDEX])
+		if ifindex then return ifindex end
+	end
+end
+
+---
+-- Deletes a virtual interface.
+-- @tparam table opts interface parameters: `ifindex`.
+-- @raise on a netlink error.
+function interface:del(opts)
+	self:call(self.id, self.DEL, 0, message.attrs{[attr.IFINDEX] = opts.ifindex})
+end
 
 return interface
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -127,6 +127,10 @@ higher-level `netlink.*` modules built on top of it.
   (asserting one is present, in `STATION` mode and with its fields decoded) and
   asserts both simulated wiphys come out of `netlink.nl80211.wiphy`'s
   fragmented `GET_WIPHY` dump (skips without `mac80211_hwsim`).
+- **nl80211_iface**: `netlink.nl80211.interface():add()` creates an AP interface
+  on the first simulated wiphy, asserts it returns the new `ifindex` and the
+  interface shows up as an AP in a dump, asserts a second add of the same
+  interface raises, then `del()` removes it (skips without `mac80211_hwsim`).
 
 ### notifier
 

--- a/tests/netlink/nl80211_iface.lua
+++ b/tests/netlink/nl80211_iface.lua
@@ -1,0 +1,40 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the netlink nl80211_iface test (see nl80211_iface.sh).
+
+local netlink = require("netlink")
+local iftype  = require("linux.nl80211").iftype
+
+local NAME <const> = "lunatikap0"
+
+local interface <close> = netlink.nl80211.interface()
+
+local wiphy_idx
+do
+	local wiphy <close> = netlink.nl80211.wiphy()
+	wiphy_idx = wiphy:list()[1].wiphy
+end
+
+local function present(ifindex)
+	for _, iface in ipairs(interface:list()) do
+		if iface.ifindex == ifindex then return iface end
+	end
+end
+
+local ifindex = interface:add{wiphy = wiphy_idx, name = NAME, iftype = iftype.AP}
+assert(type(ifindex) == "number", "add did not return an ifindex")
+local iface = present(ifindex)
+assert(iface and iface.name == NAME and iface.iftype == iftype.AP, "added interface not an AP")
+print("netlink nl80211_iface: AP interface added")
+
+-- adding the same interface again must raise the kernel error
+assert(not pcall(interface.add, interface, {wiphy = wiphy_idx, name = NAME, iftype = iftype.AP}),
+	"duplicate add should raise")
+print("netlink nl80211_iface: duplicate add raises")
+
+interface:del{ifindex = ifindex}
+assert(not present(ifindex), "interface still present after del")
+print("netlink nl80211_iface: interface deleted")
+

--- a/tests/netlink/nl80211_iface.sh
+++ b/tests/netlink/nl80211_iface.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Tests netlink.nl80211.interface():add/del: loads mac80211_hwsim, creates an AP
+# interface on the first simulated wiphy, asserts add returns its ifindex and it
+# shows up as an AP in a dump, asserts a second add of the same interface raises,
+# then deletes it and confirms it is gone. Skips if mac80211_hwsim is unavailable.
+#
+# Usage: sudo bash tests/netlink/nl80211_iface.sh
+
+SCRIPT="tests/netlink/nl80211_iface"
+MODULE="luasocket"
+IFNAME="lunatikap0"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+HWSIM_LOADED=0
+cleanup() {
+	ip link del "$IFNAME" 2>/dev/null
+	[ "$HWSIM_LOADED" = 1 ] && rmmod mac80211_hwsim 2>/dev/null
+}
+trap cleanup EXIT
+
+ktap_header
+ktap_plan 3
+
+cat /sys/module/$MODULE/refcnt > /dev/null 2>&1 || {
+	echo "# SKIP: $MODULE not loaded"
+	ktap_totals
+	exit 0
+}
+skip() { ktap_skip "$1"; ktap_totals; exit 0; }
+modinfo mac80211_hwsim > /dev/null 2>&1 || skip "nl80211_iface: mac80211_hwsim unavailable"
+if ! lsmod | grep -q '^mac80211_hwsim'; then
+	modprobe mac80211_hwsim radios=2 2>/dev/null || skip "nl80211_iface: mac80211_hwsim failed to load"
+	HWSIM_LOADED=1
+	for _ in $(seq 1 20); do ip -br link show 2>/dev/null | grep -q wlan && break; sleep 0.1; done
+fi
+
+mark_dmesg
+run_script "$SCRIPT"
+check_dmesg || { ktap_totals; exit 1; }
+
+dmesg | grep -q "netlink nl80211_iface: AP interface added" || fail "interface:add did not create the AP"
+ktap_pass "interface:add creates an AP and returns its ifindex"
+
+dmesg | grep -q "netlink nl80211_iface: duplicate add raises" || fail "duplicate add did not raise"
+ktap_pass "interface:add raises on a rejected interface"
+
+dmesg | grep -q "netlink nl80211_iface: interface deleted" || fail "interface:del did not remove it"
+ktap_pass "interface:del removes the interface"
+
+ktap_totals
+

--- a/tests/netlink/run.sh
+++ b/tests/netlink/run.sh
@@ -13,7 +13,7 @@ FAILED=0
 SEP=$'\n'
 for t in "$DIR"/socket.sh "$DIR"/message.sh "$DIR"/session.sh "$DIR"/genl_family.sh \
 	"$DIR"/link_list.sh "$DIR"/addr_list.sh "$DIR"/route_list.sh "$DIR"/route_adddel.sh "$DIR"/rule_adddel.sh \
-	"$DIR"/channel.sh "$DIR"/nl80211.sh; do
+	"$DIR"/channel.sh "$DIR"/nl80211.sh "$DIR"/nl80211_iface.sh; do
 	echo "${SEP}# --- $(basename "$t") ---"
 	bash "$t" || FAILED=$((FAILED+1))
 done


### PR DESCRIPTION
Second step of the nl80211 AP work (after #674): the first write command of the control-plane — creating and destroying virtual interfaces.

```lua
local iface <close> = netlink.nl80211.interface()
local ifindex = iface:add{wiphy = 0, name = "ap0", iftype = iftype.AP}  -- returns the new ifindex
iface:del{ifindex = ifindex}
```

- `interface:add{wiphy, name, iftype}` → `NL80211_CMD_NEW_INTERFACE` with `WIPHY` (target radio), `IFNAME` (required by the kernel) and `IFTYPE`; decodes the reply and returns the new `ifindex` (to chain into `ap()`/`station()` later). `iftype` has no default — the caller states AP/STATION/monitor.
- `interface:del{ifindex}` → `NL80211_CMD_DEL_INTERFACE` (`NEED_WDEV` resolves the target from `IFINDEX`).

Verified against `net/wireless/nl80211.c` (6.8): `NEW_INTERFACE` needs `IFNAME` and resolves the wiphy from `WIPHY`; `DEL_INTERFACE` resolves the wdev from `IFINDEX`. Only `DEL_INTERFACE` was missing from the autogen command allowlist; the attributes were already there.

Test creates an AP interface on the first hwsim wiphy, asserts the returned ifindex and its AP iftype in a dump, then deletes it (cross-checked externally with `iw dev`). Full netlink suite (34) and project suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)