### PR TITLE
lunatik: enforce per-CPU semantics at the registration points

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [
 * `status`: show which Lunatik kernel modules are currently loaded
 * `test [suite]`: run installed test suites (see [Testing](#testing))
 * `list`: show which runtime environments are currently running
-* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime instance per CPU id, for scripts dispatched by the eBPF bindings, which resolve to the instance of the CPU the hook runs on. The script runs once per instance
+* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime instance per CPU id, for scripts dispatched by the eBPF bindings, which resolve to the instance of the CPU the hook runs on. The script runs once per instance and can read its id with `lunatik.cpu()`; constructors whose registration is global fail at load in a percpu instance
 * `spawn`: create a new runtime environment and spawn a thread to run the script `/lib/modules/lua/<script>.lua`
 * `stop`: stop the runtime environment created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [
 * `status`: show which Lunatik kernel modules are currently loaded
 * `test [suite]`: run installed test suites (see [Testing](#testing))
 * `list`: show which runtime environments are currently running
-* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime instance per CPU id, for scripts dispatched by the eBPF bindings, which resolve to the instance of the CPU the hook runs on. The script runs once per instance and can read its id with `lunatik.cpu()`; constructors whose registration is global fail at load in a percpu instance
+* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime instance per CPU id, for scripts dispatched by the eBPF bindings, which resolve to the instance of the CPU the hook runs on. The script runs once per instance and can read its id with `lunatik.cpu()`; netfilter hooks and constructors whose registration is global fail at load in a percpu instance
 * `spawn`: create a new runtime environment and spawn a thread to run the script `/lib/modules/lua/<script>.lua`
 * `stop`: stop the runtime environment created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_

--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -309,7 +309,7 @@ static int luadevice_stop(lua_State *L)
 * @treturn userdata A Lunatik object representing the newly created device.
 *   This object can be used to explicitly stop the device using the `:stop()` method.
 * @raise Error if the device cannot be allocated or registered in the kernel,
-*   or if the `name` field is missing or not a string.
+*   if the `name` field is missing or not a string, or if called from a percpu runtime.
 * @usage
 *   local device = require("device")
 *   local stat   = require("linux.stat")
@@ -353,6 +353,7 @@ static int luadevice_new(lua_State *L)
 	const char *name;
 	int ret;
 
+	lunatik_checkpercpu(L);
 	luaL_checktype(L, 1, LUA_TTABLE); /* driver */
 
 	lunatik_checkfield(L, 1, "name", LUA_TSTRING);

--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -281,10 +281,12 @@ static int luahid_raw_event(struct hid_device *hdev, struct hid_report *report, 
 * @tparam table opts driver options: `name` (string), `id_table` (array of device ID tables,
 *   each with optional integer fields `bus`, `group`, `vendor`, `product`, `driver_data`)
 * @treturn hid_driver
-* @raise if required fields are missing, `id_table` is invalid, or driver registration fails
+* @raise if required fields are missing, `id_table` is invalid, driver registration fails,
+*   or if called from a percpu runtime
 */
 static int luahid_register(lua_State *L)
 {
+	lunatik_checkpercpu(L);
 	luaL_checktype(L, 1, LUA_TTABLE);
 
 	lunatik_object_t *object = lunatik_newobject(L, &luahid_class, sizeof(luahid_t), LUNATIK_OPT_NONE);

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -127,9 +127,11 @@ static const lunatik_class_t luanetfilter_class = {
 * @tparam table opts Hook options: `hook` (function), `pf`, `hooknum`, `priority` (integers),
 *   and optionally `mark` (integer, default 0).
 * @treturn netfilter_hook Registered hook handle.
+* @raise if the hook cannot be registered, or if called from a percpu runtime
 */
 static int luanetfilter_register(lua_State *L)
 {
+	lunatik_checkpercpu(L);
 	luaL_checktype(L, 1, LUA_TTABLE);
 	lunatik_object_t *object = lunatik_newobject(L, &luanetfilter_class, sizeof(luanetfilter_t), LUNATIK_OPT_NONE);
 	luanetfilter_t *nf = (luanetfilter_t *)object->private;

--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -134,6 +134,7 @@ static int luanotifier_netdevice_handler(lua_State *L, void *data)
 *   is a `linux.netdev` code and `name` is the device name (e.g. `"eth0"`).
 *   Returns a `linux.notify` status code.
 * @treturn notifier
+* @raise if called from a percpu runtime
 * @within notifier
 */
 LUANOTIFIER_NEWCHAIN(netdevice, &luanotifier_process_class);
@@ -159,6 +160,7 @@ static int luanotifier_keyboard_handler(lua_State *L, void *data)
 *   `shift` is a boolean (modifier held), and `value` is the keycode or
 *   keysym depending on `event`. Returns a `linux.notify` status code.
 * @treturn notifier
+* @raise if called from a percpu runtime
 * @within notifier
 */
 LUANOTIFIER_NEWCHAIN(keyboard,  &luanotifier_hardirq_class);
@@ -182,6 +184,7 @@ static int luanotifier_vt_handler(lua_State *L, void *data)
 *   `vc_num` is the virtual console number. Returns a `linux.notify`
 *   status code.
 * @treturn notifier
+* @raise if called from a percpu runtime
 * @within notifier
 */
 LUANOTIFIER_NEWCHAIN(vt, &luanotifier_hardirq_class);
@@ -222,6 +225,7 @@ static const lunatik_class_t luanotifier_hardirq_class = {
 static int luanotifier_new(lua_State *L, luanotifier_register_t register_fn, luanotifier_register_t unregister_fn,
 	luanotifier_handler_t handler_fn, const lunatik_class_t *class)
 {
+	lunatik_checkpercpu(L);
 	luaL_checktype(L, 1, LUA_TFUNCTION); /* callback */
 
 	lunatik_object_t *object = lunatik_newobject(L, class, sizeof(luanotifier_t), LUNATIK_OPT_NONE);

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -161,7 +161,7 @@ static int luaprobe_new(lua_State *L);
 * @tparam table handlers table with optional `pre` and `post` callback functions;
 *   each receives the symbol (string or lightuserdata) and a `dump` closure
 * @treturn probe
-* @raise if registration fails
+* @raise if registration fails, or if called from a percpu runtime
 */
 static const luaL_Reg luaprobe_lib[] = {
 	{"new", luaprobe_new},
@@ -186,6 +186,7 @@ static const lunatik_class_t luaprobe_class = {
 
 static int luaprobe_new(lua_State *L)
 {
+	lunatik_checkpercpu(L);
 	lunatik_object_t *object = lunatik_newobject(L, &luaprobe_class, sizeof(luaprobe_t), LUNATIK_OPT_NONE);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
 	struct kprobe *kp = &probe->kp;

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -53,9 +53,9 @@ function percpu.name(script)
 	return string.match(script, "^(.+):0$")
 end
 
-function percpu.run(script, context, ...)
+function percpu.run(script, context)
 	for cpu = 0, linux.numcpus() - 1 do
-		local ok, runtime = pcall(lunatik.runtime, script, context, ...)
+		local ok, runtime = pcall(lunatik.runtime, script, context, cpu)
 		if not ok then
 			percpu.stop(script)
 			error(runtime, 0)
@@ -80,15 +80,15 @@ end
 --   once per runtime.
 -- @treturn table created Lunatik runtime object, or `nil` when `percpu` is set.
 -- @raise error if the script is already running.
-function runner.run(script, context, ispercpu, ...)
+function runner.run(script, context, ispercpu)
 	local script = trim(script)
 	if env.runtimes[script] or env.percpu[key(script, 0)] then
 		error(string.format("%s is already running", script))
 	end
 	if ispercpu then
-		return percpu.run(script, context, ...)
+		return percpu.run(script, context)
 	end
-	local runtime = lunatik.runtime(script, context, ...)
+	local runtime = lunatik.runtime(script, context)
 	env.runtimes[script] = runtime
 	return runtime
 end
@@ -100,11 +100,11 @@ end
 -- @tparam string script path or name of the Lua script to spawn.
 -- @treturn userdata kernel thread object.
 -- @raise error if the script is already running or `percpu` is set.
-function runner.spawn(script, context, ispercpu, ...)
+function runner.spawn(script, context, ispercpu)
 	if ispercpu then
 		error("spawn does not support percpu scripts")
 	end
-	local runtime = runner.run(script, context, ispercpu, ...)
+	local runtime = runner.run(script, context)
 	local name = string.match(script, "(%w*/*%w*)$")
 	local t = thread.run(runtime, name)
 	env.threads[script] = t
@@ -159,13 +159,26 @@ function runner.shutdown()
 	end
 end
 
+local function restore(name)
+	local current = env[name]
+	if current == nil then
+		return rcu.table()
+	end
+	if type(current) ~= "userdata" then
+		error(string.format("_ENV.%s is not an rcu table; unload and load the modules", name))
+	end
+	return current
+end
+
 --- Initializes the runner's internal state.
--- Creates RCU-safe tables for storing runtimes and threads.
--- This is typically called during Lunatik's initialization.
+-- Creates RCU-safe tables for storing runtimes and threads, keeping the ones a
+-- previous startup left behind. An entry the core kept across an upgrade may
+-- hold what an older runner stored, which this rejects rather than indexing.
+-- @raise error if a registry survived in a format this runner cannot use.
 function runner.startup()
-	env.runtimes = env.runtimes or rcu.table()
-	env.percpu = env.percpu or rcu.table()
-	env.threads = env.threads or rcu.table()
+	env.runtimes = restore("runtimes")
+	env.percpu = restore("percpu")
+	env.threads = restore("threads")
 end
 
 return runner

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -77,8 +77,8 @@ end
 -- @tparam[opt] string context Execution context: `"process"` (default) or `"softirq"` (for netfilter/XDP hooks).
 -- @tparam[opt] boolean ispercpu create one runtime per CPU id, registered in `env.percpu`
 --   as `<script>:<cpu>`, for scripts dispatched by the eBPF bindings; the script runs
---   once per instance and can read its id with `lunatik.cpu()`. Constructors whose
---   registration is global refuse to run in an instance.
+--   once per instance and can read its id with `lunatik.cpu()`. Netfilter hooks and
+--   constructors whose registration is global refuse to run in an instance.
 -- @treturn table created Lunatik runtime object, or `nil` when `ispercpu` is set.
 -- @raise error if the script is already running.
 function runner.run(script, context, ispercpu)

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -77,8 +77,9 @@ end
 -- @tparam[opt] string context Execution context: `"process"` (default) or `"softirq"` (for netfilter/XDP hooks).
 -- @tparam[opt] boolean ispercpu create one runtime per CPU id, registered in `env.percpu`
 --   as `<script>:<cpu>`, for scripts dispatched by the eBPF bindings; the script runs
---   once per runtime.
--- @treturn table created Lunatik runtime object, or `nil` when `percpu` is set.
+--   once per instance and can read its id with `lunatik.cpu()`. Constructors whose
+--   registration is global refuse to run in an instance.
+-- @treturn table created Lunatik runtime object, or `nil` when `ispercpu` is set.
 -- @raise error if the script is already running.
 function runner.run(script, context, ispercpu)
 	local script = trim(script)
@@ -171,10 +172,10 @@ local function restore(name)
 end
 
 --- Initializes the runner's internal state.
--- Creates RCU-safe tables for storing runtimes and threads, keeping the ones a
--- previous startup left behind. An entry the core kept across an upgrade may
--- hold what an older runner stored, which this rejects rather than indexing.
--- @raise error if a registry survived in a format this runner cannot use.
+-- Creates the RCU-safe tables for runtimes, percpu instances and threads,
+-- reusing the ones a previous startup left in `env`. A table left by an
+-- incompatible runner is rejected: the modules have to be unloaded and loaded.
+-- @raise error if a table in `env` is not an rcu table.
 function runner.startup()
 	env.runtimes = restore("runtimes")
 	env.percpu = restore("percpu")

--- a/lunatik.h
+++ b/lunatik.h
@@ -51,6 +51,9 @@ do {									\
 
 #define lunatik_extra(L)	((lunatik_runtime_t *)lua_getextraspace(L))
 #define lunatik_toruntime(L)	(lunatik_extra(L)->runtime)
+#define LUNATIK_CPU_NONE	(-1)
+#define lunatik_getcpu(L)	(lunatik_extra(L)->cpu)
+#define lunatik_ispercpu(L)	(lunatik_getcpu(L) != LUNATIK_CPU_NONE)
 
 #define lunatik_cannotsleep(L, s)	((s) && lunatik_isirq(lunatik_toruntime(L)->opt))
 

--- a/lunatik.h
+++ b/lunatik.h
@@ -184,8 +184,15 @@ static inline void lunatik_checkfield(lua_State *L, int idx, const char *field, 
 #define LUNATIK_ERR_METATABLE	"metatable not found"
 #define LUNATIK_ERR_CONTEXT	"process-context class in interrupt-context runtime"
 #define LUNATIK_ERR_RUNTIME	"runtime context mismatch"
+#define LUNATIK_ERR_PERCPU	"not allowed in a percpu runtime"
 
 #define lunatik_context(opt)	((opt) & (LUNATIK_OPT_SOFTIRQ | LUNATIK_OPT_HARDIRQ))
+
+static inline void lunatik_checkpercpu(lua_State *L)
+{
+	if (lunatik_ispercpu(L))
+		luaL_error(L, LUNATIK_ERR_PERCPU);
+}
 
 static inline lunatik_object_t *lunatik_checkruntime(lua_State *L, lunatik_opt_t opt)
 {

--- a/lunatik_conf.h
+++ b/lunatik_conf.h
@@ -78,6 +78,7 @@ struct lunatik_object_s;
 typedef struct lunatik_runtime_s {
 	struct lunatik_object_s *runtime;
 	bool ready;
+	int cpu;	/* percpu instance id; LUNATIK_CPU_NONE on a plain runtime */
 } lunatik_runtime_t;
 
 #undef LUA_EXTRASPACE

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -157,12 +157,30 @@ static int lunatik_lresume(lua_State *L)
 	return nresults;
 }
 
+/***
+* Returns the CPU id of a percpu runtime instance.
+* Ranges from `0` to `linux.numcpus() - 1`; see `runner.run`.
+* @function cpu
+* @treturn integer instance CPU id, or `nil` on a plain runtime
+* @within lunatik
+*/
+static int lunatik_cpu(lua_State *L)
+{
+	if (lunatik_ispercpu(L))
+		lua_pushinteger(L, lunatik_getcpu(L));
+	else
+		lua_pushnil(L);
+	return 1;
+}
+
 static const luaL_Reg lunatik_lib[] = {
 	{"runtime", lunatik_lruntime},
+	{"cpu", lunatik_cpu},
 	{NULL, NULL}
 };
 
 static const luaL_Reg lunatik_stub_lib[] = {
+	{"cpu", lunatik_cpu},
 	{NULL, NULL}
 };
 
@@ -225,7 +243,7 @@ static int lunatik_runscript(lua_State *L)
 	return 1; /* callback */
 }
 
-static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt)
+static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt, int cpu)
 {
 	lunatik_object_t *runtime;
 	lua_State *L;
@@ -244,6 +262,7 @@ static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, con
 	lunatik_setobject(runtime, &lunatik_class, opt);
 	lunatik_toruntime(L) = runtime;
 	lunatik_extra(L)->ready = false;
+	lunatik_extra(L)->cpu = cpu;
 
 	runtime->gfp = GFP_KERNEL; /* might use kvmalloc while running in process */
 	lua_setallocf(L, lunatik_alloc, runtime);
@@ -271,7 +290,7 @@ static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, con
 
 int lunatik_runtime(lunatik_object_t **pruntime, const char *script, lunatik_opt_t opt)
 {
-	return lunatik_newruntime(pruntime, NULL, script, opt);
+	return lunatik_newruntime(pruntime, NULL, script, opt, LUNATIK_CPU_NONE);
 }
 EXPORT_SYMBOL(lunatik_runtime);
 
@@ -284,6 +303,9 @@ EXPORT_SYMBOL(lunatik_runtime);
 *   (atomic, GFP\_ATOMIC, spinlock with IRQs disabled).
 *   Use `"softirq"` for hooks that fire in softirq context (netfilter, XDP).
 *   Use `"hardirq"` for hooks that fire in hardirq context (kprobes).
+* @tparam[opt=-1] integer cpu percpu instance CPU id; the runner passes it when
+*   creating `run <script> percpu` instances. A runtime created directly with a
+*   cpu claims to be that instance without being registered for dispatch.
 * @treturn runtime
 * @raise if allocation fails or the script errors on load
 * @within lunatik
@@ -294,10 +316,13 @@ static int lunatik_lruntime(lua_State *L)
 	static const lunatik_opt_t opts[] = {LUNATIK_OPT_NONE, LUNATIK_OPT_SOFTIRQ, LUNATIK_OPT_HARDIRQ};
 	const char *script = luaL_checkstring(L, 1);
 	int context = luaL_checkoption(L, 2, "process", contexts);
+	int cpu = luaL_optinteger(L, 3, LUNATIK_CPU_NONE);
 	lunatik_opt_t opt = opts[context];
 
+	luaL_argcheck(L, cpu >= LUNATIK_CPU_NONE && cpu < (int)nr_cpu_ids, 3, "invalid cpu");
+
 	lunatik_object_t **pruntime = lunatik_newpobject(L, 1);
-	if (lunatik_newruntime(pruntime, L, script, opt) != 0)
+	if (lunatik_newruntime(pruntime, L, script, opt, cpu) != 0)
 		lua_error(L);
 	lunatik_setclass(L, &lunatik_class, true);
 	return 1;

--- a/tests/README.md
+++ b/tests/README.md
@@ -222,6 +222,10 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   stop; and each instance sees its own id via `lunatik.cpu()`, which a
   plain runtime sees as `nil`.
 
+- **percpu_refuse**: a global registration (`device.new`) fails at load
+  in a percpu instance, naming percpu, with a clean rollback; the same
+  script runs as a plain runtime.
+
 ### set
 
 - **set**: `set.new` sorting unsorted input and binary-search membership

--- a/tests/README.md
+++ b/tests/README.md
@@ -222,9 +222,10 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   stop; and each instance sees its own id via `lunatik.cpu()`, which a
   plain runtime sees as `nil`.
 
-- **percpu_refuse**: a global registration (`device.new`) fails at load
-  in a percpu instance, naming percpu, with a clean rollback; the same
-  script runs as a plain runtime.
+- **percpu_refuse**: a registration a percpu instance cannot own fails
+  at load, naming percpu, with a clean rollback, and the same script
+  runs as a plain runtime: `device.new`, whose registration is global,
+  and `netfilter.register`, which has no per-CPU dispatch.
 
 ### set
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -218,8 +218,9 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   up; the script is listed once, by name; `stop` drops every instance
   and lets it run again; `spawn` refuses percpu without creating any
   runtime; a script that fails on one instance rolls back the ones
-  already created; and the instances are not reachable through a
-  generic stop.
+  already created; the instances are not reachable through a generic
+  stop; and each instance sees its own id via `lunatik.cpu()`, which a
+  plain runtime sees as `nil`.
 
 ### set
 

--- a/tests/runtime/percpu.lua
+++ b/tests/runtime/percpu.lua
@@ -4,5 +4,9 @@
 --
 -- Kernel-side script for the percpu runtime test (see percpu.sh).
 
+local lunatik = require("lunatik")
+
+lunatik._ENV["percpu_cpu:" .. lunatik.cpu()] = true
+
 return function() end
 

--- a/tests/runtime/percpu_check.lua
+++ b/tests/runtime/percpu_check.lua
@@ -20,3 +20,11 @@ test("percpu registers one runtime per possible CPU id", function()
 	assert(lunatik._ENV.runtimes[script] == nil, "percpu script leaked into env.runtimes")
 end)
 
+test("each instance sees its own CPU id, a plain runtime sees none", function()
+	assert(lunatik.cpu() == nil, "plain runtime reports a CPU id")
+	for cpu = 0, linux.numcpus() - 1 do
+		assert(lunatik._ENV["percpu_cpu:" .. cpu], "no instance stamped CPU " .. cpu)
+		lunatik._ENV["percpu_cpu:" .. cpu] = nil
+	end
+end)
+

--- a/tests/runtime/percpu_refuse.lua
+++ b/tests/runtime/percpu_refuse.lua
@@ -1,0 +1,17 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu refusal test (see percpu_refuse.sh).
+
+local device = require("device")
+local stat   = require("linux.stat")
+
+local driver = {name = "percpu_refuse", mode = stat.IRUGO}
+
+function driver:read()
+	return ""
+end
+
+device.new(driver)
+

--- a/tests/runtime/percpu_refuse.sh
+++ b/tests/runtime/percpu_refuse.sh
@@ -3,32 +3,47 @@
 # SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
 # SPDX-License-Identifier: MIT OR GPL-2.0-only
 #
-# Regression test for the percpu refusal: a constructor whose registration is
-# global (device.new here) must fail at load in a percpu instance, naming
-# percpu, and the rollback must leave nothing registered; the same script runs
-# fine as a plain runtime.
+# Regression test for the percpu refusal: a registration a percpu instance
+# cannot own must fail at load, naming percpu, and the rollback must leave
+# nothing registered; the same script runs fine as a plain runtime. Covered
+# here by device.new, whose registration is global, and by netfilter.register,
+# which has no per-CPU dispatch.
 #
 # Usage: sudo bash tests/runtime/percpu_refuse.sh
 
 SCRIPT="tests/runtime/percpu_refuse"
+NETFILTER="tests/runtime/percpu_refuse_netfilter"
+MODULE="luanetfilter"
 
 source "$(dirname "$(readlink -f "$0")")/../lib.sh"
 
-cleanup() { lunatik stop "$SCRIPT" > /dev/null 2>&1; }
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+	lunatik stop "$NETFILTER" > /dev/null 2>&1
+}
+
+refuse()
+{
+	local script="$1"
+	shift
+	local output listed
+	output=$(lunatik run "$script" "$@" percpu 2>&1)
+	echo "$output" | grep -q "not allowed in a percpu runtime" || \
+		fail "percpu run did not refuse the registration: $output"
+	listed=$(lunatik list)
+	case "$listed" in
+		*"$script"*) fail "the refused run left instances behind: $listed" ;;
+	esac
+}
 
 trap cleanup EXIT
 cleanup
 
 ktap_header
-ktap_plan 2
+ktap_plan 4
 
-output=$(lunatik run "$SCRIPT" percpu 2>&1)
-echo "$output" | grep -q "not allowed in a percpu runtime" || \
-	fail "percpu run did not refuse the registration: $output"
-listed=$(lunatik list)
-case "$listed" in
-	*"$SCRIPT"*) fail "the refused run left instances behind: $listed" ;;
-esac
+refuse "$SCRIPT"
 [ -e /dev/percpu_refuse ] && fail "the refused run left the device registered"
 ktap_pass "global registration fails at load in a percpu instance"
 
@@ -38,6 +53,23 @@ run_script "$SCRIPT"
 check_dmesg || { ktap_totals; exit 1; }
 lunatik stop "$SCRIPT" > /dev/null 2>&1
 ktap_pass "the same script runs as a plain runtime"
+
+cat /sys/module/$MODULE/refcnt > /dev/null 2>&1 || {
+	echo "# SKIP: $MODULE not loaded"
+	ktap_skip "netfilter registration fails at load in a percpu instance"
+	ktap_skip "the same hook registers in a plain softirq runtime"
+	ktap_totals
+	exit 0
+}
+
+refuse "$NETFILTER" softirq
+ktap_pass "netfilter registration fails at load in a percpu instance"
+
+mark_dmesg
+run_script "$NETFILTER" softirq
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$NETFILTER" > /dev/null 2>&1
+ktap_pass "the same hook registers in a plain softirq runtime"
 
 ktap_totals
 

--- a/tests/runtime/percpu_refuse.sh
+++ b/tests/runtime/percpu_refuse.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for the percpu refusal: a constructor whose registration is
+# global (device.new here) must fail at load in a percpu instance, naming
+# percpu, and the rollback must leave nothing registered; the same script runs
+# fine as a plain runtime.
+#
+# Usage: sudo bash tests/runtime/percpu_refuse.sh
+
+SCRIPT="tests/runtime/percpu_refuse"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() { lunatik stop "$SCRIPT" > /dev/null 2>&1; }
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 2
+
+output=$(lunatik run "$SCRIPT" percpu 2>&1)
+echo "$output" | grep -q "not allowed in a percpu runtime" || \
+	fail "percpu run did not refuse the registration: $output"
+listed=$(lunatik list)
+case "$listed" in
+	*"$SCRIPT"*) fail "the refused run left instances behind: $listed" ;;
+esac
+[ -e /dev/percpu_refuse ] && fail "the refused run left the device registered"
+ktap_pass "global registration fails at load in a percpu instance"
+
+mark_dmesg
+run_script "$SCRIPT"
+[ -e /dev/percpu_refuse ] || fail "plain run did not register the device"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "the same script runs as a plain runtime"
+
+ktap_totals
+

--- a/tests/runtime/percpu_refuse_netfilter.lua
+++ b/tests/runtime/percpu_refuse_netfilter.lua
@@ -1,0 +1,25 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu refusal test (see percpu_refuse.sh).
+
+local netfilter = require("netfilter")
+local nf        = require("linux.nf")
+
+local family   = nf.proto
+local action   = nf.action
+local hooks    = nf.inet
+local priority = nf.ip.pri
+
+local function accept(skb)
+	return action.ACCEPT
+end
+
+netfilter.register{
+	hook     = accept,
+	pf       = family.INET,
+	hooknum  = hooks.LOCAL_IN,
+	priority = priority.FILTER,
+}
+

--- a/tests/runtime/run.sh
+++ b/tests/runtime/run.sh
@@ -19,6 +19,7 @@ TESTS=(
 	opt_skb_single.sh
 	require_cloneobject.sh
 	percpu.sh
+	percpu_refuse.sh
 )
 
 SEP=""


### PR DESCRIPTION
Resolves #675: the registration points now apply the percpu policy, instead of trusting the script.

The runtime carries its instance CPU id in the state's extraspace, stored before the script is loaded so load-time registrations can read it, and `lunatik.cpu()` exposes it to the script (on the stub library as well: percpu scripts are usually softirq). `runner.run` no longer forwards its vararg tail, since a stray extra would silently claim an instance id for a plain runtime.

With the id in place, every registration a percpu instance cannot own is refused at load, with an error naming percpu, through a shared `lunatik_checkpercpu` helper:

- constructors whose registration is global: `device`, `notifier`, `probe`, `hid`;
- `netfilter.register`, which has no per-CPU dispatch: each instance would register its own hook and every packet would be handled once per instance. An earlier version of this branch shipped affinity at dispatch instead, each hook accepting everything not on its CPU, but that is exact only where the hook runs in softirq; on the process-context paths a migration mid-chain can handle a packet twice or not at all, so it was dropped rather than merged as a half measure. The exact form, a single hook per script dispatching to the instance of the current CPU, needs group identity in the core and builds on the percpu groups work (#693).

`syscall` was audited and left alone (address lookup only); the eBPF `attach` and the per-runtime objects need nothing.

Tests, each validated by breaking the code and watching it fail: `lunatik.cpu()` coverage in the percpu suite (every id stamped, a plain runtime sees `nil`), and the refusals for `device.new` and `netfilter.register`, failing at load in a percpu instance with a clean rollback, with the same scripts running plain.

Tested on 6.8.0-136: full suite green with clean dmesg; builds clean against 5.15 and 6.8 headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
