### PR TITLE
docs: add the in-kernel wireless AP authenticator project

### DIFF
--- a/docs/design/wireless-ap/README.md
+++ b/docs/design/wireless-ap/README.md
@@ -1,0 +1,71 @@
+# In-kernel wireless AP authenticator
+
+Working documents for running the Access Point control plane and the WPA
+authenticator (WPA2-PSK first) as Lua **inside the kernel**, over the `nl80211`
+binding — part of what a userspace daemon (`hostapd`) does today, done as a
+hot-loadable kernel script with a programmable association policy.
+
+They exist so that a new contributor, with or without an AI coding assistant, can
+pick the work up without first reverse engineering both `nl80211` and the 802.11
+RSNA authenticator.
+
+| Document | What it is for |
+|----------|----------------|
+| [plan.md](plan.md) | Current state, gap analysis, phases, non goals, risks, definition of done |
+| [api.md](api.md) | Proposed Lua API: the `nl80211` control-plane objects and the `wpa` authenticator, with a worked example |
+| [kernel-notes.md](kernel-notes.md) | Verified kernel reference: nl80211 control plane, the EAPOL control port, the 4-way handshake crypto, and the open questions |
+| [testing.md](testing.md) | Test strategy on `mac80211_hwsim` with `wpa_supplicant` as the client, and the test matrix |
+
+Start with `plan.md`. Read `kernel-notes.md` before writing any module, in
+particular its "Open questions" section — the per-CPU delivery of EAPOL is not
+settled, and one phase exists only to settle it.
+
+## Working on this
+
+The repository conventions that apply to every change here (build, test, style,
+kernel context rules, commit discipline) are in [AGENTS.md](../../../AGENTS.md) at
+the root of the repository. Read it once before the first patch. If you use an AI
+assistant, point it at that file and at `kernel-notes.md`.
+
+Three things decide whether this work goes well:
+
+1. **This is a clean-room design, not a hostapd port.** `hostapd` is a
+   single-process, single-threaded event loop — `grep pthread_create` on its
+   source returns nothing, and its lock-free station tables are correct *only*
+   because nothing runs concurrently. Its structure is the reference for the
+   state machine and the crypto, not for the architecture. The kernel environment
+   offers what a single-threaded daemon does not get for free: per-CPU execution
+   for the per-station handshakes, and association policy evaluated in the packet
+   path and reloadable live. Both have limits — see `plan.md`.
+
+2. **The per-CPU foundation is a prerequisite, and one question inside it is
+   open.** Per-CPU runtimes ([#676], merged) and per-CPU affinity at the
+   registration points ([#678], resolving [#675]) are what make the SMP design
+   possible; this project depends on them. What they do **not** yet answer is
+   whether an EAPOL frame can be delivered to the per-CPU-affine runtime for the
+   CPU it arrives on, or whether it only arrives out-of-band over the control
+   port's single netlink socket. `kernel-notes.md` states both candidates
+   honestly; a phase is dedicated to proving one before any handshake code is
+   written.
+
+3. **Bringing up an AP is bringing up a radio.** Test on `mac80211_hwsim` with a
+   `wpa_supplicant` client, never on hardware whose network you care about — a
+   rogue open AP on a real channel is antisocial at best. Everything here skips,
+   not fails, when `mac80211_hwsim` is absent.
+
+## Status
+
+These documents describe the design; they do not track progress. What is merged,
+what is in flight, and how far along each phase is lives on the project board.
+Each phase is an issue there and lands as its own pull request.
+
+The netlink and nl80211 groundwork this project builds on — the `socket`
+`AF_NETLINK` support, the `netlink` namespace, the rtnetlink `rt` objects, generic
+netlink, the softirq `channel`, and `nl80211.wiphy`/`nl80211.interface` — is
+already on `master`. The AP bring-up itself (`nl80211.ap`, `rt.link:set`) is in
+flight. Nothing of the authenticator exists yet.
+
+[#675]: https://github.com/luainkernel/lunatik/issues/675
+[#676]: https://github.com/luainkernel/lunatik/pull/676
+[#678]: https://github.com/luainkernel/lunatik/pull/678
+

--- a/docs/design/wireless-ap/api.md
+++ b/docs/design/wireless-ap/api.md
@@ -1,0 +1,188 @@
+# Proposed Lua API: the AP control plane and `wpa`
+
+Two layers. The **control plane** extends the existing `nl80211` namespace with
+the objects an AP needs — firm, because each maps to a verified nl80211 command.
+The **authenticator** is a new `wpa` module — proposed, and its frame-delivery
+half is deliberately left open until the phase-2 spike (see `kernel-notes.md`).
+
+Each section is marked **[firm]** (maps to a verified command, shape settled) or
+**[proposed]** (design intent, may change once prototyped).
+
+## Conventions
+
+Objects follow the established `netlink` pattern: a class under the namespace,
+constructed with `()`, closed by `close()` or `<close>`, methods taking an options
+table. `nl80211.ap`/`station`/`key` are `netlink.genl` sessions bound to the
+`"nl80211"` family, exactly like `nl80211.interface`. All block and need a
+sleepable runtime, except where a per-CPU dispatched path is noted.
+
+## Control plane
+
+### `nl80211.ap():start/stop` — [firm, in flight #680]
+
+```lua
+local ap <close> = netlink.nl80211.ap()
+ap:start{ifindex = idx, freq = 2412, beacon_interval = 100, dtim = 2,
+         ssid = "lab", head = beacon_head}   -- raw 802.11 beacon head
+ap:stop{ifindex = idx}
+```
+
+Already proposed and validated in its own PR; listed here for completeness.
+
+### `nl80211.station()` — [firm]
+
+Manage associated stations. `add`/`del`/`set` by MAC; `list` dumps them.
+
+```lua
+local station <close> = netlink.nl80211.station()
+
+station:add{ifindex = idx, mac = mac, aid = 1,
+            listen_interval = 10, supported_rates = rates}
+station:set{ifindex = idx, mac = mac, authorized = true}   -- open the controlled port
+for _, s in ipairs(station:list(idx)) do
+    -- { mac, aid, flags, ... }
+end
+station:del{ifindex = idx, mac = mac}
+```
+
+`set{authorized = true}` is the port-open primitive the handshake calls on
+completion (`NL80211_STA_FLAG_AUTHORIZED`). `add` maps to `NL80211_CMD_NEW_STATION`
+with `MAC`/`STA_AID`/`STA_LISTEN_INTERVAL`/`STA_SUPPORTED_RATES`; `set` to
+`SET_STATION` with a `STA_FLAGS2` set/mask; `del` to `DEL_STATION`.
+
+### `nl80211.key()` — [firm]
+
+Install and remove keys.
+
+```lua
+local key <close> = netlink.nl80211.key()
+
+key:add{ifindex = idx, mac = mac, idx = 0, cipher = cipher.CCMP,
+        data = ptk_tk, seq = seq}            -- pairwise key for one station
+key:add{ifindex = idx, idx = 1, cipher = cipher.CCMP, data = gtk}  -- group key (no mac)
+key:del{ifindex = idx, mac = mac, idx = 0}
+```
+
+`NL80211_CMD_NEW_KEY`/`DEL_KEY` with `KEY_DATA`/`KEY_IDX`/`KEY_CIPHER`/`KEY_SEQ`;
+`MAC` present means pairwise, absent means group.
+
+## The authenticator: `wpa` — [proposed]
+
+A module composing `nl80211` (control plane), `crypto` (handshake primitives) and
+EAPOL delivery. It owns the per-station state and the per-BSS group keys, and
+exposes a small surface: create an authenticator over a running AP, hand it a
+policy, and let it run. The four outward operations it needs (`send_eapol`,
+`set_key`, `get_psk`, `set_port_authorized`) are internal — implemented against
+`key`/`station` and the delivery path — not part of the public API.
+
+### `wpa.authenticator{...}` — [proposed]
+
+```lua
+local wpa = require("wpa")
+
+local auth = wpa.authenticator{
+    ifindex = idx,
+    ssid    = "lab",
+    akm     = wpa.akm.PSK,          -- WPA2-PSK (only PSK and OPEN initially)
+    cipher  = wpa.cipher.CCMP,
+    -- association policy: plain Lua, hot-reloadable, evaluated per station
+    policy  = function(sta)
+        -- sta = { mac, rssi, ies, ... }; return the PSK to admit, or nil to reject
+        if blocked[sta.mac] then return nil end
+        return passphrase           -- get_psk
+    end,
+}
+```
+
+The `policy` callback is `get_psk` and the association decision fused: returning a
+passphrase admits the station and seeds its 4-way handshake; returning `nil`
+rejects it. This is the programmable-policy point — policy in the association
+path, hot-reloadable, with no userspace round trip — and where band-steering or
+per-client parameters would live.
+
+### Per-station state — [proposed]
+
+Kept in a shared `rcu.table` keyed by STA MAC, because delivery is per-CPU by
+arrival, not per-STA (see `kernel-notes.md` §5–6). Each entry is one 4-way FSM:
+`state`, `anonce`/`snonce`, `pmk`/`ptk`, `replay`, and a retransmit deadline. The
+per-BSS group key (GTK) and its rekey are owned by one runtime.
+
+The FSM itself is a direct transcription of `hostapd`'s `WPA_PTK` ladder
+(`kernel-notes.md` §4): a `step(sta, event)` that runs to a fixpoint and calls out
+to `key:add` (install PTK/GTK), `station:set{authorized}` (open the port), and the
+EAPOL sender.
+
+### EAPOL delivery — [open, decided by phase 2]
+
+The one piece intentionally unspecified here. The authenticator needs an inbound
+"an EAPOL frame arrived from MAC X" event and an outbound "send this EAPOL frame to
+MAC X". Both the control-port path (§3a) and the per-CPU packet-path (§3b/A) can
+provide them; which one, and therefore whether the authenticator is a plain
+runtime or a `percpu` script, is the phase-2 result. The `wpa` API above is written
+to not depend on the answer: the handshake logic is the same either way, only the
+transport binding under `send_eapol`/the RX event differs.
+
+## Worked example: a WPA2-PSK AP in Lua
+
+Ties the layers together. Bring up the radio, start beaconing, run the
+authenticator with a policy. (Phases 0–3; the `percpu` form is phase 4.)
+
+```lua
+local netlink = require("netlink")
+local wpa     = require("wpa")
+
+local SSID <const> = "lunatik-lab"
+local PSK  <const> = "correct horse battery staple"
+
+-- 1. create an AP interface on the first radio and bring it up
+local ifindex
+do
+    local wiphy     <close> = netlink.nl80211.wiphy()
+    local interface <close> = netlink.nl80211.interface()
+    ifindex = interface:add{wiphy = wiphy:list()[1].wiphy, name = "ap0",
+                            iftype = require("linux.nl80211").iftype.AP}
+end
+netlink.rt.link():set{ifindex = ifindex, up = true}
+
+-- 2. beacon (minimal open-enough head; RSN IE in the tail advertises WPA2)
+netlink.nl80211.ap():start{ifindex = ifindex, freq = 2412,
+    beacon_interval = 100, dtim = 2, ssid = SSID,
+    head = wpa.beacon_head{ssid = SSID, channel = 1},
+    tail = wpa.beacon_tail{akm = wpa.akm.PSK, cipher = wpa.cipher.CCMP}}
+
+-- 3. the authenticator: admit anyone with the PSK, reject a blocklist
+local auth = wpa.authenticator{
+    ifindex = ifindex, ssid = SSID, akm = wpa.akm.PSK, cipher = wpa.cipher.CCMP,
+    policy = function(sta)
+        return not blocked[sta.mac] and PSK or nil
+    end,
+}
+```
+
+A real client (`wpa_supplicant -c ...`) then associates and completes WPA2-PSK
+against this script. The policy is ordinary Lua: editing `blocked` and reloading
+changes admission with no daemon restart and no userspace round trip on the
+association path — the point of putting the policy in the kernel.
+
+The example shows `ap:start` and `wpa.authenticator` as separate steps. If the
+phase-2 result is the control-port path, START_AP must be sent by the socket that
+then receives EAPOL (`kernel-notes.md` §3a), so the authenticator would own the AP
+bring-up rather than take an already-started interface. Which of the two this
+becomes is, again, the phase-2 result; the split above is the open-AP form.
+
+## Autogen additions
+
+New constants for `linux.nl80211`, added per phase (not all at once — `linux.*` is
+published API, and a table with no consumer freezes a shape too early):
+
+* phase 0: `STA_FLAGS2`, `STA_AID`, `STA_LISTEN_INTERVAL`, `STA_SUPPORTED_RATES`,
+  `KEY_DATA`, `KEY_IDX`, `KEY_CIPHER`, `KEY_SEQ`, `KEY_TYPE` attributes; the
+  `NL80211_STA_FLAG_*` and `WLAN_CIPHER_SUITE_*`/`WLAN_AKM_SUITE_*` values;
+* phase 1: `REGISTER_FRAME`, `FRAME`, `FRAME_TX_STATUS` and the frame-type/auth
+  attributes;
+* phase 2/3: `CONTROL_PORT_FRAME`, `CONTROL_PORT_OVER_NL80211`,
+  `CONTROL_PORT_ETHERTYPE`, `SOCKET_OWNER` — only once the delivery path is chosen.
+
+The `wpa.akm`/`wpa.cipher` tables are thin Lua aliases over the generated
+`WLAN_AKM_SUITE_*`/`WLAN_CIPHER_SUITE_*` values, named for the API's vocabulary.
+

--- a/docs/design/wireless-ap/kernel-notes.md
+++ b/docs/design/wireless-ap/kernel-notes.md
@@ -1,0 +1,251 @@
+# Kernel notes: the AP control plane and the WPA authenticator
+
+Verified reference for the kernel and reference-implementation facts the design
+rests on. Line numbers are `net/wireless/nl80211.c` in the 6.8 HWE tree and
+`src/...` in `hostap.git` (commit `39cd943`) unless noted. **Verify against the
+kernel you build for** before writing code; nl80211 attributes and mac80211
+control-port semantics move.
+
+The two regimes this project spans:
+
+* the **control plane** — creating the AP interface, beaconing, managing stations
+  and keys, answering management frames — is generic netlink (`nl80211`), the same
+  family `nl80211.wiphy`/`nl80211.interface` already use;
+* the **authenticator** — the WPA 4-way handshake — is EAPOL frame I/O plus a
+  per-station state machine and crypto. Its delivery path is the one unsettled
+  piece; see "Open questions".
+
+## 1. START_AP — verified requirements
+
+`nl80211_start_ap` (`~5953`). The interface must already be `NL80211_IFTYPE_AP`
+and administratively **up** (`NL80211_FLAG_NEED_NETDEV_UP` in the command's
+`internal_flags`, `~16847`); otherwise the dispatch fails before the handler runs.
+
+Required attributes — the handler returns `-EINVAL` without all three (`~5975`):
+
+* `NL80211_ATTR_BEACON_INTERVAL` (u32)
+* `NL80211_ATTR_DTIM_PERIOD` (u32)
+* `NL80211_ATTR_BEACON_HEAD` (bytes)
+
+Plus, in practice, `NL80211_ATTR_WIPHY_FREQ` (u32, the channel) parsed by
+`nl80211_parse_chandef`, and optionally `NL80211_ATTR_SSID`, `NL80211_ATTR_BEACON_TAIL`.
+
+**The beacon head is opaque at the netlink layer.** `nl80211_parse_beacon`
+(`~5523`) only takes `nla_data`/`nla_len` and rejects a zero length; the 802.11
+frame is validated deeper, in mac80211. So the binding passes head/tail as raw
+bytes — the 802.11 frame construction is the caller's job, exactly as `hostapd`
+builds `params->head`/`params->tail` and hands them through (`beacon.c:2263`;
+driver at `driver_nl80211.c:5750`). The kernel/firmware inserts the TIM between
+head and tail; the head ends before it. A minimal open-AP head that mac80211 and
+hwsim accept — verified working in the `nl80211.ap` test — is: 802.11 mgmt header
+(FC beacon, broadcast DA, BSSID as SA and addr3), timestamp/beacon-interval/
+capability (ESS), then the SSID, Supported Rates, and DS Parameter Set elements.
+
+`NL80211_CMD_STOP_AP` needs only the up AP interface.
+
+## 2. Station and key commands
+
+For phase 0. The command and attribute names below are verified present in the
+6.8 uapi header (`uapi/linux/nl80211.h`); the exact required-attribute policy of
+each handler is **not** yet verified the way START_AP's is (§1), and must be
+confirmed in `net/wireless/nl80211.c` before writing the phase-0 code.
+
+* `NL80211_CMD_NEW_STATION` / `DEL_STATION` / `SET_STATION` — add/remove/modify a
+  station on the AP interface, keyed by `NL80211_ATTR_MAC`. Flags via
+  `NL80211_ATTR_STA_FLAGS2` (a `nl80211_sta_flag_update` set/mask). The one that
+  opens the controlled data path is `NL80211_STA_FLAG_AUTHORIZED`; `hostapd` sets
+  it through `set_port_authorized` → `NL80211_STA_FLAG_AUTHORIZED`
+  (`driver_nl80211.c:6232`). Association parameters: `STA_AID` (**u16** in the
+  header — not the u32 `message.attrs` packs a number as; pack it explicitly),
+  `STA_LISTEN_INTERVAL`, `STA_SUPPORTED_RATES`.
+* `NL80211_CMD_NEW_KEY` / `DEL_KEY` — install a key on the interface (pairwise) or
+  per-station (`NL80211_ATTR_MAC` present) with `NL80211_ATTR_KEY_DATA`,
+  `KEY_IDX`, `KEY_CIPHER` (e.g. `WLAN_CIPHER_SUITE_CCMP` = `SUITE(0x000FAC, 4)` =
+  `0x000fac04`, verified in `linux/ieee80211.h`), `KEY_SEQ`, `KEY_TYPE`.
+
+These reuse the same genl-session `call` the existing `nl80211` objects use; the
+target interface is `NL80211_ATTR_IFINDEX`.
+
+## 3. The EAPOL control port
+
+The 4-way handshake exchanges EAPOL-Key frames (EtherType `ETH_P_PAE` = `0x888E`).
+The AP has two ways to carry them; `hostapd` implements both and prefers the
+first on modern kernels.
+
+### 3a. Control-port-over-nl80211 (the modern path)
+
+Enabled at START_AP by setting `NL80211_ATTR_CONTROL_PORT_OVER_NL80211` (and
+usually `NL80211_ATTR_SOCKET_OWNER`). Verified in `nl80211_start_ap`: on success,
+`if (info->attrs[NL80211_ATTR_SOCKET_OWNER]) wdev->conn_owner_nlportid = info->snd_portid;`
+— the kernel records the port id of the socket that sent START_AP.
+
+* **RX.** A received EAPOL frame becomes an `NL80211_CMD_CONTROL_PORT_FRAME`
+  message carrying `NL80211_ATTR_FRAME` (the raw frame), `NL80211_ATTR_MAC` (the
+  source STA), `IFINDEX`, and `CONTROL_PORT_ETHERTYPE`, delivered by
+  **`genlmsg_unicast(..., wdev->conn_owner_nlportid)`** (`__nl80211_rx_control_port`,
+  `~19090`). That is: **unicast to the exact socket that started the AP**, not a
+  multicast group. So the owning session receives EAPOL with an ordinary
+  `receive()`.
+* **TX.** Send `NL80211_CMD_CONTROL_PORT_FRAME` with the frame, dest MAC and
+  ethertype (`nl80211_tx_control_port` on the hostapd side, `driver_nl80211.c:7054`).
+
+The consequence for lunatik: the control-port EAPOL path reuses the `nl80211.ap`
+session's socket. There is no new socket type and no multicast subscription. But
+it places two concrete requirements the in-flight `nl80211.ap` does not yet meet —
+neither a bug in it (its scope is start/stop), but both needed before this path
+works:
+
+* `ap:start` must **also** send `CONTROL_PORT_OVER_NL80211` and `SOCKET_OWNER`; the
+  current call sends neither. This is an additive option on `ap:start` (e.g.
+  `control_port = true`), not a breaking change.
+* the START_AP socket must **stay open** to be the `conn_owner_nlportid` — the RX
+  path returns `-ENOENT` when that port id is gone. The current `ap()` is
+  transactional (open, `start`, close), so the authenticator cannot use a
+  throwaway `ap():start(); ap():close()`; it holds a **long-lived** `ap` session
+  and receives on it.
+
+And it is, in any case, **one socket** — see the open question about per-CPU
+delivery.
+
+### 3b. AF_PACKET (the legacy path)
+
+`hostapd`'s driver opens `socket(PF_PACKET, SOCK_DGRAM, htons(ETH_P_PAE))` bound to
+the AP ifindex (`driver_nl80211.c:9595`; the generic `l2_packet_linux.c:271`) and
+`sendto`/`recvfrom`s EAPOL directly. When control-port RX is available it does not
+even open this socket. lunatik's `socket` already supports `AF_PACKET` (sockaddr_ll
+with protocol+ifindex), so this path is reachable — and, unlike the single
+control-port socket, `AF_PACKET` supports `PACKET_FANOUT` for per-CPU load
+spreading. Whether the fanout hash gives useful per-STA distribution for L2 EAPOL
+frames is unverified (see open questions).
+
+## 4. The 4-way handshake (from hostapd, for phase 3)
+
+The authenticator is `src/ap/wpa_auth.c`. It is a variable-driven Mealy machine:
+boolean event variables (`EAPOLKeyReceived`, `MICVerified`, `TimeoutEvt`, …) drive
+`SM_STEP(WPA_PTK)` (`wpa_auth.c:5547`) to a fixpoint (`wpa_sm_step`, guarded
+against reentrancy by `in_step_loop`).
+
+Pairwise state ladder and wire messages:
+
+| State | Action | Advances on |
+|-------|--------|-------------|
+| `PTKSTART` | send msg 1/4 (ANonce, no MIC) | RX msg 2/4 → `PTKCALCNEGOTIATING`; timeout → resend, capped by `wpa_pairwise_update_count` (4) then `DISCONNECT` |
+| `PTKCALCNEGOTIATING` | derive PTK from SNonce, verify msg-2 MIC | `MICVerified` |
+| `PTKINITNEGOTIATING` | send msg 3/4 (GTK, MIC, key data AES-wrapped) | RX msg 4/4 (MIC ok) → `PTKINITDONE` |
+| `PTKINITDONE` | install PTK, open controlled port | terminal until rekey/disconnect |
+
+RX classifier `wpa_receive` (`wpa_auth.c:1700`) validates the replay counter and
+(once `PTK_valid`) the MIC, copies SNonce on msg 2, sets the event variables, and
+steps. Retransmit is a per-SM timer (`wpa_send_eapol`/`_timeout`, `~2366/2419`).
+
+Crypto (all in `src/common/wpa_common.c` + `src/crypto/`), mapped to lunatik's
+`crypto`:
+
+* **PMK** (PSK): `PBKDF2-HMAC-SHA1(passphrase, ssid, 4096, 256)`. No PBKDF2 in
+  `crypto`; compute it as iterated HMAC-SHA1 via `shash`. **[to verify: cost of
+  4096 iterations in-kernel]**
+* **PTK**: `wpa_pmk_to_ptk` → `sha1_prf` / `sha256_prf` / `sha384_prf` selected by
+  AKM. Via `shash`.
+* **EAPOL-Key MIC**: `hmac_sha1` (truncated, WPA2 default) / `omac1_aes_128`
+  (AES-128-CMAC for SHA256 AKMs) / `hmac_sha256`/`_384`. `shash` covers HMAC;
+  AES-CMAC needs checking in `crypto`. **[to verify: AES-CMAC availability]**
+* **Key data encryption in msg 3**: NIST AES key wrap (`aes_wrap`/`aes_unwrap`).
+  **[to verify: AES key wrap exposed via `crypto`/`skcipher`]**
+* Nonces: kernel RNG (`crypto.rng` / `linux.random`).
+
+The three `[to verify]` items are crypto-availability checks to do in phase 3
+before committing to the handshake; each has a fallback (compute in Lua over a
+lower primitive) but at a cost worth measuring.
+
+## 5. Per-STA vs per-BSS state (the SMP split)
+
+From `hostapd`'s structures (`src/ap/wpa_auth_i.h`), the split that decides the
+sharded design:
+
+| State | Scope | Parallelizable |
+|-------|-------|----------------|
+| 4-way FSM: ANonce/SNonce, PMK, **PTK**, `key_replay[]`, retransmit timer (`wpa_state_machine`) | **per-STA** | **yes — the shard unit**, per-STA serialization only |
+| 802.1X port (`eapol_state_machine`) | per-STA | yes |
+| station table / hash / AID bitmap | per-BSS | no — shared aggregate, atomic AID allocator |
+| protection counters (non-ERP, …) | per-BSS | no — mutated on assoc, drives beacon |
+| group keys GMK/**GTK**/IGTK, `GKeyDoneStations` (`wpa_group`) | per-BSS | no — single owner; GTK rekey is a cross-STA barrier |
+| prebuilt RSN IE, PMKSA cache, stats | per-BSS | RCU reads; serialized writes / per-CPU counters |
+
+The important asymmetry: **the handshakes parallelize, the shared aggregates do
+not.** A sharded design gives the station table + AID allocator + group keys a
+single owner (or concurrent structures) and lets the FSMs run on any CPU. In
+lunatik terms, the per-STA state is an `rcu.table` entry keyed by MAC; the group
+keys are owned by one runtime; GTK rekey is serialized.
+
+## 6. The per-CPU infrastructure ([#676], [#678])
+
+What the merged/in-flight foundation provides:
+
+* `linux.numcpus()` → `nr_cpu_ids` (`lualinux.c`).
+* `lunatik run <script> percpu` creates one runtime per CPU id, registered as
+  `<script>:<cpu>` in `env.percpu`; the body runs once per runtime.
+* The eBPF dispatch (`bpf_luaxdp_run`) resolves `<key>:<raw_smp_processor_id()>` —
+  it runs on the runtime of the CPU the hook fired on.
+* [#678]: `lunatik.cpu()` returns an instance's CPU id (nil for a plain runtime),
+  and `netfilter.register` from a percpu instance is **affine at dispatch** — the
+  hook acts only on packets processed on its CPU, `NF_ACCEPT`s the rest, so each
+  packet is handled by exactly one instance with no locking. Global-registration
+  constructors (`device`, `notifier`, `probe`, `hid`) refuse at load in a percpu
+  instance.
+* `spawn` does **not** support percpu (no per-CPU kthread). A percpu authenticator
+  is therefore event-dispatched (a hook per CPU), not a receive-loop kthread.
+
+This is exactly the model for a per-CPU authenticator **if** EAPOL arrives through
+a per-CPU-affine hook. Which is the open question.
+
+## Open questions
+
+Documented as open, not resolved. Each is a phase-2 spike deliverable.
+
+1. **Per-CPU EAPOL delivery, and the eBPF path.** Control-port-over-nl80211
+   delivers EAPOL by unicast to one socket (§3a) — not per-CPU, not through the
+   affine packet path (§6). The per-CPU alternative (path A) is an **eBPF path**:
+   the [#676] per-CPU runtime resolution is wired only in `bpf_luaxdp_run`, so an
+   **XDP or TC-BPF program** on the AP netdev filtering EtherType `0x888E`, calling
+   `bpf_luaxdp_run`, is the existing mechanism that lands EAPOL on the runtime of
+   the CPU it arrived on. The open part is **visibility**: does mac80211 expose
+   control-port frames to an XDP/TC hook on the netdev, or consume them first? And
+   is XDP even attachable on the wireless interface / hwsim? eBPF does not answer
+   these — if mac80211 eats the frame first, path A never sees it. If not, is a
+   software MAC-hash dispatch from the single control-port socket (path B)
+   acceptable, and where does its dispatcher live? **This gates the sharded design.**
+2. **The atomic-context split path A forces.** XDP and `netfilter` hooks run in
+   **softirq** — `GFP_ATOMIC`, no sleeping. But the handshake's key steps sleep: a
+   `NEW_KEY`/`SET_STATION` netlink round trip, and PBKDF2's 4096 HMAC iterations
+   are too heavy for softirq. So a per-CPU packet-path authenticator cannot run
+   inline; path A is a **two-tier** structure — a softirq XDP/TC front-end that
+   receives and dispatches, and a process-context worker that does the keying and
+   crypto. Path B (control-port over netlink, process context) does the whole
+   handshake inline but on one socket. Whether the two-tier per-CPU structure earns
+   its complexity over an inline process-context authenticator (single runtime, or
+   a software per-CPU dispatch) is the spike's real tradeoff, not "XDP yes/no". A
+   `bpf.map` ([#633], Lua↔BPF map) is a candidate for the per-STA state shared
+   between the two tiers, versus a plain `rcu.table`.
+3. **AF_PACKET fanout for L2.** If path A uses `AF_PACKET` + `PACKET_FANOUT` instead
+   of XDP/TC, does the fanout hash distribute EtherType-`0x888E` frames usefully
+   across CPUs, with stable per-STA affinity or not? (Determines whether per-STA
+   state can be CPU-local or must stay shared.)
+4. **Software MLME vs offload on hwsim.** Does hwsim require the AP to answer
+   auth/assoc in software (`REGISTER_FRAME`/`FRAME`), or does it offload them?
+   Phase 1 settles this; it changes where association policy is evaluated.
+5. **Crypto availability** (the three `[to verify]` in §4): AES-CMAC, AES key wrap,
+   and the cost of in-kernel PBKDF2. Phase 3, before the handshake.
+
+## Version drift to watch
+
+* nl80211 station/key attributes and `STA_FLAGS2` semantics; MLO adds
+  `NL80211_ATTR_MLO_LINK_ID` to several commands (6.x).
+* Control-port attributes (`CONTROL_PORT_OVER_NL80211`, `_NO_PREAUTH`,
+  `_TX_STATUS`) are extended-feature-gated; check `NL80211_EXT_FEATURE_*`.
+* `NL80211_ATTR_IFACE_SOCKET_OWNER` (auto-delete the interface when the owning
+  socket closes) is a clean lifecycle idiom worth mirroring for the AP.
+
+[#675]: https://github.com/luainkernel/lunatik/issues/675
+[#676]: https://github.com/luainkernel/lunatik/pull/676
+[#678]: https://github.com/luainkernel/lunatik/pull/678
+

--- a/docs/design/wireless-ap/plan.md
+++ b/docs/design/wireless-ap/plan.md
@@ -1,0 +1,236 @@
+# Plan: in-kernel wireless AP authenticator
+
+Execution plan for running the 802.11 Access Point control plane and the WPA
+authenticator as a Lua kernel script, over the `nl80211` binding. The long-term
+target is a hot-loadable, policy-programmable AP authenticator that uses two
+things the kernel environment offers and a userspace daemon has to build for
+itself: per-CPU execution for the per-station handshakes, and policy evaluated in
+the packet path.
+
+## Where we are today
+
+The netlink groundwork is done and merged. On `master`:
+
+* `socket` speaks `AF_NETLINK`, and the `netlink` namespace groups request/response
+  sessions (`netlink.rt`, `netlink.genl`) and the softirq-safe `netlink.channel`;
+* `netlink.rt` exposes rtnetlink as per-object classes: `route`, `link`, `addr`,
+  `rule`, each `add`/`del`/`list` over a `NETLINK_ROUTE` session;
+* `netlink.nl80211` is a genl subclass bound to the `"nl80211"` family, with
+  `wiphy():list()` (radios) and `interface():add/del/list` (create/destroy a
+  virtual interface in a given mode);
+* per-CPU runtimes exist ([#676]): a `percpu` script gets one runtime per CPU id,
+  and the eBPF dispatch resolves to the runtime of the CPU a hook runs on;
+* `crypto` provides `shash` (HMAC-SHA1/256/384), `skcipher`, `aead`, `rng`, `hkdf`
+  — the primitives the 4-way handshake needs.
+
+In flight (open pull requests, prerequisites for this project):
+
+* `nl80211.ap():start/stop` — begin/stop beaconing with a raw beacon head;
+* `rt.link():set{up}` — bring an interface administratively up over `RTM_SETLINK`;
+* per-CPU **affinity** at the registration points ([#678], resolving [#675]):
+  `lunatik.cpu()` exposes an instance's CPU id, and `netfilter.register` from a
+  percpu instance only acts on packets processed on that instance's CPU.
+
+So "we can bring up an open AP from the kernel" is nearly true. What does not exist
+at all is the authenticator: no station management, no key installation, no EAPOL,
+no 4-way handshake, no policy.
+
+## What is missing
+
+| Outcome | Gap |
+|---------|-----|
+| Manage associated stations | No `station` object. No add/del/set/list, no per-STA flags, no `AUTHORIZED` port control. |
+| Install keys | No `key` object. No `NEW_KEY`/`DEL_KEY`, no PTK/GTK installation. |
+| Receive and send EAPOL | Never done. EAPOL delivery to an in-kernel script is unproven — see "The open question" below. |
+| Run the 4-way handshake | No authenticator. No per-STA state machine, no PMK/PTK derivation, no MIC, no key wrap, no replay protection, no GTK rekey. |
+| Programmable association policy | The point of the project; nothing yet. |
+
+Supporting gaps: the nl80211 `station`/`key`/`AKM`/cipher/auth-type constants are
+not in the autogen allowlist; there is no representation for an 802.11 element
+(IE) in Lua beyond hand-packing bytes; and the WPA crypto (PRF, AES key wrap,
+AES-CMAC MIC) has not been exercised through the `crypto` module.
+
+## The idea that shapes the design
+
+Two facts, one merged and one from reading `hostapd`, set the architecture.
+
+**hostapd runs its authenticator on one thread.** It is a single event loop
+(`src/utils/eloop.c`, one process-global `struct eloop_data`, no threads), so
+every station's 4-way handshake — nonce generation, `PBKDF2`, the `PRF`, AES key
+wrap — is serviced on that one loop, on one CPU. This is not an oversight to
+optimize away: its lock-free station tables and non-reentrant state machines are
+correct *because* nothing runs concurrently, so using more than one CPU would
+mean rearchitecting that core, not setting a flag. The consequence is that when
+many stations authenticate at once, their crypto serializes on a single core.
+
+**The per-station handshake is independent.** From `hostapd`'s own structures, the
+`wpa_state_machine` (per-STA: ANonce/SNonce, PMK, PTK, replay counters, retransmit
+timer) shares nothing on the write side with another station's, except reads of
+the group key and the PSK. The per-BSS shared state is small and identifiable: the
+group keys (`wpa_group`: GMK/GTK/IGTK, and the GTK rekey fan-out), the station
+table and AID allocator, the protection counters, and the prebuilt RSN IE. See
+`kernel-notes.md` §"Per-STA vs per-BSS state" for the full split.
+
+So the design aims at a **`percpu` authenticator**: one runtime per CPU, each
+handling the handshakes for the stations whose frames land on its CPU — subject to
+"The open question" below, which decides whether that delivery is even available.
+The per-station handshake state lives in a shared `rcu.table` (read-mostly, keyed
+by STA MAC), because — and this is the honest limit of the merged infrastructure —
+[#676] shards by the CPU a frame *arrives on*, not by station. A station's frames
+are not guaranteed to land on one CPU, so its state cannot be CPU-local; it is
+shared, with per-STA serialization. The parallelism is real (N CPUs deriving PTKs
+concurrently), but it is shared-state parallelism, not share-nothing. The per-BSS
+group-key subsystem has a single owner and RCU readers; GTK rekey is the one
+inherently cross-CPU operation (a barrier over all stations).
+
+The authenticator's only outward dependencies are the four `hostapd` uses:
+`send_eapol`, `set_key`, `get_psk`, `set_port_authorized`. Those map to the
+control port (or packet path), the `key` object, a Lua policy callback, and the
+`station` object's `AUTHORIZED` flag. That small seam is the module boundary.
+
+### The open question
+
+**Can an EAPOL frame reach the per-CPU-affine runtime for the CPU it arrives on?**
+The merged affinity ([#678]) is for the packet path — a `netfilter`/XDP hook fires
+on the CPU processing the packet. But an AP receives EAPOL over the 802.11
+**control port**, which the modern kernel delivers as an `NL80211_CMD_CONTROL_PORT_FRAME`
+event, **unicast to the single socket that started the AP** (`conn_owner_nlportid`)
+— not through the packet path, and not per-CPU. The two ways out:
+
+* **A — packet-path delivery.** Catch EAPOL (EtherType `0x888E`) with a per-CPU
+  `netfilter`/XDP/TC hook on the AP netdev, so [#678]'s affinity applies directly.
+  Open: whether mac80211 exposes control-port frames to that hook at all, and
+  whether frame steering gives useful per-CPU distribution.
+* **B — control-port delivery + software dispatch.** Receive over the one
+  control-port socket and route each frame to a per-CPU runtime by hashing the STA
+  MAC. Gives stable STA→CPU affinity (CPU-local state becomes possible) but the
+  dispatcher does not exist and the single socket is a serialization point at
+  ingress.
+
+This is not settled and must not be pretended settled. Phase 2 exists only to
+answer it with a prototype. Until it is answered, the handshake phases assume the
+model that does not depend on it: a shared per-STA `rcu.table` reachable from any
+runtime, with per-STA serialization.
+
+## Phases
+
+Each phase is one or more self-contained pull requests, sized to what fits in one
+reviewable diff. The order keeps the project useful at every cut: an open AP that
+accepts clients (end of phase 2) is already a demonstrable result, and every later
+phase is additive.
+
+### Phase 0: finish the control plane
+
+`nl80211.station():add/del/set/list` and `nl80211.key():add/del`. The station
+object carries the AID, capabilities and flags; `set{authorized=true}` opens the
+controlled port (`NL80211_STA_FLAG_AUTHORIZED`). The key object installs a PTK or
+GTK (`NEW_KEY` with cipher/key-index/key-data). Add the `station`/`key`/AKM/cipher
+constants to the autogen allowlist. Validate against `mac80211_hwsim`: add a
+station, set it authorized, install a key, see it in a dump.
+
+Depends on `nl80211.ap` and `rt.link:set` landing first.
+
+### Phase 1: associate an open client
+
+Register for management frames (`REGISTER_FRAME`), receive auth/assoc requests,
+and answer them (`FRAME` TX) — the software-MLME path. Add the station on assoc,
+open its port. Milestone: a `wpa_supplicant` client associates to the open AP and
+`iw dev` shows it. This is the first time something a user can see works, and it is
+the whole of "open AP" — no crypto yet.
+
+Whether hwsim/mac80211 requires software MLME or offloads auth/assoc is settled
+here with a prototype, not an assumption.
+
+### Phase 2: the EAPOL I/O spike (the gate)
+
+Prove, on hwsim with a real `wpa_supplicant` client, that the kernel script can
+**receive and send** an EAPOL-Key frame — both candidate paths from "The open
+question" tried, the winner chosen with data. Path A is specifically the
+**eBPF path**: an XDP/TC-BPF program catching EtherType `0x888E` and dispatching
+per-CPU via `bpf_luaxdp_run` (the mechanism [#676] already wires). The spike must
+answer not just "does a frame arrive" but two things that decide the whole shape:
+whether mac80211 even exposes EAPOL to that hook, and — since XDP/`netfilter` run
+in softirq — that path A forces a **two-tier** design (a softirq front-end plus a
+process-context worker, because the keying and PBKDF2 sleep), which path B
+(control-port over netlink, all in process context) does not. See
+`kernel-notes.md` "Open questions" 1–2. No handshake logic, no PR of a public API
+until RX and TX are demonstrated; the phase produces a throwaway prototype and a
+findings note.
+
+If neither path works cleanly, that is a finding too: it caps the project at "open
+AP + external authenticator" and is worth knowing before writing crypto.
+
+### Phase 3: one 4-way handshake, single runtime
+
+The WPA2-PSK authenticator for a single station, in one runtime (no percpu yet):
+the `WPA_PTK` state machine (msg 1–4), PMK from the passphrase (`PBKDF2` via
+`shash`), PTK via the `PRF`, the msg-2/4 MIC, AES key wrap of the GTK in msg 3,
+replay counters, retransmit timeout. Install the PTK/GTK via phase 0's `key`, open
+the port. Milestone: `wpa_supplicant` completes WPA2-PSK against the kernel AP and
+passes encrypted traffic on hwsim.
+
+### Phase 4: shard across CPUs
+
+Move the authenticator to a `percpu` script with per-STA state in a shared
+`rcu.table`, using the phase-2 delivery path and [#678]'s affinity. The per-BSS
+group-key subsystem gets a single owner. Prove correctness under concurrent
+associations (many clients at once) and measure the speedup against phase 3's
+single runtime. GTK rekey stays serialized (the cross-CPU barrier).
+
+### Phase 5: programmable policy and the demo
+
+The user-facing payoff: an association-policy callback (accept / reject /
+per-client parameters / band-steer) that is plain Lua, hot-reloadable, evaluated in
+the association path with no userspace round trip. Plus an `examples/` AP and a
+documentation pass. WPA3-SAE and enterprise (EAP/RADIUS) are explicitly out of the
+initial scope; see non goals.
+
+## Non goals
+
+Stated so they do not creep in:
+
+* **WPA3-SAE and enterprise (EAP/RADIUS/TLS).** The initial target is WPA2-PSK and
+  open. SAE adds a dragonfly handshake in management frames; enterprise adds an
+  EAP state machine and a RADIUS client. Both are natural sequels and both are out
+  of scope until WPA2-PSK works end to end.
+* **Multi-BSS / multiple radios in one script.** One BSS on one radio. The per-BSS
+  shared state is designed as if there could be more, but managing several is a
+  later concern.
+* **Replacing the whole of hostapd.** No config-file compatibility, no ACL/MAC
+  filtering beyond what the policy callback expresses, no WPS, no 802.11r/k/v.
+* **Beacon/IE construction as a library.** Phase-1 builds the minimal beacon by
+  hand (as `nl80211.ap` already does in its test). A general 802.11 element
+  builder is a possible follow-up, not a dependency.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| EAPOL cannot be delivered per-CPU (the open question) | Phase 2 is a gate: prove RX/TX before any handshake code. A negative result caps scope but is found early. |
+| Shared per-STA `rcu.table` becomes a contention or correctness problem under load | Phase 4 measures it against phase 3; per-STA serialization keeps cross-STA contention out. Only optimize (STA→CPU affinity, path B) if the numbers demand it. |
+| GTK rekey (cross-CPU fan-out over all stations) races the per-CPU handshakes | Single-owner group-key subsystem; rekey is a serialized barrier, not sharded. Designed in from phase 4, not retrofitted. |
+| nl80211/mac80211 version drift (attributes, control-port semantics, MLO link ids) | Verify every command against the target kernel's `uapi/linux/nl80211.h` and `net/wireless/nl80211.c` before writing it, as `kernel-notes.md` does. |
+| Software MLME vs offload differs between hwsim and real drivers | Phase 1 prototypes the auth/assoc path on hwsim; the design notes where a real driver would diverge. |
+| WPA crypto details (PRF selection by AKM, key-wrap IV, MIC truncation) are easy to get subtly wrong | `kernel-notes.md` pins each primitive to its `hostapd` reference; the phase-3 test is a real `wpa_supplicant`, which rejects a wrong MIC. |
+
+## Definition of done, per phase
+
+A phase is done when all of the following hold. This is the review checklist.
+
+1. builds clean on the target kernel, no new warnings;
+2. LDoc on every new function and object type; the module in `config.ld` in
+   alphabetical order and a row in the README module table;
+3. a test in the right suite, wired into its `run.sh`, described in
+   `tests/README.md`, that **skips** (not fails) without `mac80211_hwsim`;
+4. coverage is the matrix of operation by outcome, the success paths included, not
+   only the error paths;
+5. the full suite still passes: `sudo lunatik test`;
+6. error paths audited: for every raise, whatever was acquired is released;
+7. commits are small and each one stands alone;
+8. any design question the phase was meant to answer is answered in the docs with a
+   result, not left implied.
+
+[#675]: https://github.com/luainkernel/lunatik/issues/675
+[#676]: https://github.com/luainkernel/lunatik/pull/676
+[#678]: https://github.com/luainkernel/lunatik/pull/678
+

--- a/docs/design/wireless-ap/testing.md
+++ b/docs/design/wireless-ap/testing.md
@@ -1,0 +1,93 @@
+# Testing the AP authenticator
+
+The whole stack is testable without hardware on `mac80211_hwsim`, driving a real
+`wpa_supplicant` client against the kernel AP. Every test **skips** (not fails)
+when `mac80211_hwsim` or `wpa_supplicant` is absent, mirroring the existing
+`nl80211`/`nl80211_iface` tests.
+
+## What the harness already gives, and what is missing
+
+The `nl80211` and `nl80211_iface` tests establish the pattern: `modprobe
+mac80211_hwsim radios=2`, resolve the wiphy by dumping (indices are not `0`/`1`),
+create/keep an AP interface, assert via a dump, clean up in a `trap`. Reuse it.
+
+Missing, to build as the phases need it:
+
+* **a client.** The authenticator tests need a station that actually associates and
+  runs the handshake. `wpa_supplicant` on the *second* hwsim radio is the client:
+  a scratch config (`network={ ssid=... psk=... }` or `key_mgmt=NONE` for open),
+  `wpa_supplicant -i wlanN -c scratch.conf`, then poll `wpa_cli status` for
+  `wpa_state=COMPLETED`. Skip if `wpa_supplicant` is not installed.
+* **a clean radio between tests.** Manual `iw`/`ip` fiddling leaves interfaces in
+  the wrong mode and wedges later runs (a documented gotcha — see AGENTS.md). Each
+  `.sh` does its own `modprobe`/`rmmod` and creates the AP through lunatik, not by
+  hand; the formal `.sh` is the authoritative validation, never a manual scratch.
+
+## Test matrix
+
+Per phase, the operation-by-outcome matrix (successes included, not only errors).
+
+### `tests/nl80211/` (phase 0, extends the existing suite)
+
+* **station_adddel** — `station:add` a fake STA on an AP interface, see it in a
+  dump with its AID; `set{authorized=true}`, confirm the flag; a second add of the
+  same MAC raises; `del`, confirm gone.
+* **key_adddel** — `key:add` a pairwise key for a station and a group key, confirm
+  no error; `del`; adding with a bad cipher raises.
+
+### `tests/wireless/` (new suite, phases 1–4)
+
+* **associate** (phase 1) — bring up an open AP; a `wpa_supplicant` client on the
+  second radio reaches `COMPLETED`; the STA appears in `station:list` and `iw dev`
+  shows it associated. The negative: a policy that rejects the MAC keeps it out.
+* **eapol_spike** (phase 2) — not a public-API test but a gate: the chosen
+  delivery path receives an EAPOL frame the client sent and the script can send one
+  back. Asserts the raw RX/TX, from `dmesg` markers, before any handshake exists.
+* **wpa2_psk** (phase 3) — a `wpa_supplicant` client with the right PSK reaches
+  `COMPLETED` **and passes encrypted traffic** (a ping over the associated link);
+  a client with the wrong PSK fails the 4-way (MIC rejected) and does not
+  associate. This is the real end-to-end check — `wpa_supplicant` verifies the
+  MIC, so a wrong handshake does not pass.
+* **wpa2_psk_percpu** (phase 4) — several clients associate concurrently and all
+  reach `COMPLETED`; per-CPU instance counters show the handshakes actually ran on
+  more than one CPU (the same shape as the [#678] affinity test, where per-instance
+  counters must sum to the packet count, not N times it); a correctness check that
+  the shared per-STA `rcu.table` served concurrent associations without loss.
+
+### `tests/wireless/` (phase 5)
+
+* **policy** — the association callback is hot-reloaded between two client
+  attempts (rejected, then admitted) with no AP restart, proving live policy.
+
+## Conventions to follow
+
+Per AGENTS.md and the existing tests:
+
+* skip, do not fail, without `mac80211_hwsim` / `wpa_supplicant`;
+* `mark_dmesg` before `run_script`, `check_dmesg` after; assert on the kernel
+  script's `print`s via `dmesg`, since `lunatik run` exits 0 on a script error;
+* clean up in a `trap` (kill `wpa_supplicant`, delete the AP interface, `rmmod
+  hwsim`) and run the cleanup once up front;
+* resolve the wiphy by dumping — never hardcode a phy index;
+* one `lunatik` operation at a time; the authenticator's percpu form is loaded with
+  `lunatik run <script> percpu`.
+
+## Manual smoke test
+
+Before trusting a phase, drive it by hand once on hwsim:
+
+```sh
+sudo modprobe mac80211_hwsim radios=2
+# bring up the AP via the kernel script (phase under test), then:
+sudo wpa_supplicant -i wlan1 -c /tmp/sta.conf -d          # the client
+sudo wpa_cli -i wlan1 status | grep wpa_state             # COMPLETED?
+sudo iw dev ap0 station dump                              # the client, authorized?
+# for WPA2: ping across the link to prove the pairwise key works
+sudo rmmod mac80211_hwsim
+```
+
+Never run this against a radio on a network you care about: it stands up a rogue
+AP on a real channel.
+
+[#678]: https://github.com/luainkernel/lunatik/pull/678
+


### PR DESCRIPTION
Design notes for the next big piece of the nl80211 work: running the 802.11 AP control plane and the WPA authenticator as a Lua kernel script — what `hostapd` does, in the kernel, with a programmable association policy. Same `docs/design/<theme>/` format as conntrack-nat, lsm-ebpf and fsnotify (README / plan / api / kernel-notes / testing).

The design is deliberately **clean-room, not a hostapd port**. `hostapd` is single-threaded by construction; the reason to do this in the kernel is SMP — per-CPU authenticators over the `percpu` runtimes (#676) and the affinity work (#678). The per-station 4-way handshake is the shard unit; the per-BSS group keys / station table are the serialization points.

Everything is grounded in verified sources: the nl80211 control-plane commands (against `net/wireless/nl80211.c` 6.8), the EAPOL control port (unicast to the AP-owning socket), and the 4-way handshake state machine and crypto (against `hostap.git`). The one genuinely open question — whether EAPOL can be delivered to a per-CPU-affine runtime, or only over the single control-port socket — is documented **as open**, with a phase (the EAPOL spike) dedicated to settling it before any handshake code is written.

No code; these are working documents so the phased implementation can proceed as its own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)