### PR TITLE
lunatik: spawn percpu as per-CPU pinned worker threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [
 * `status`: show which Lunatik kernel modules are currently loaded
 * `test [suite]`: run installed test suites (see [Testing](#testing))
 * `list`: show which runtime environments are currently running
-* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime instance per CPU id, for scripts dispatched by the eBPF bindings, which resolve to the instance of the CPU the hook runs on. The script runs once per instance
+* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime instance per CPU id, for scripts dispatched by the eBPF bindings, which resolve to the instance of the CPU the hook runs on. The script runs once per instance and can read its id with `lunatik.cpu()`; a netfilter hook registered by an instance only acts on packets of its own CPU, and constructors whose registration is global (`device`, `notifier`, `probe`, `hid`) fail at load in a percpu instance
 * `spawn`: create a new runtime environment and spawn a thread to run the script `/lib/modules/lua/<script>.lua`
 * `stop`: stop the runtime environment created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [
 * `test [suite]`: run installed test suites (see [Testing](#testing))
 * `list`: show which runtime environments are currently running
 * `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime instance per CPU id, for scripts dispatched by the eBPF bindings, which resolve to the instance of the CPU the hook runs on. The script runs once per instance and can read its id with `lunatik.cpu()`; a netfilter hook registered by an instance only acts on packets of its own CPU, and constructors whose registration is global (`device`, `notifier`, `probe`, `hid`) fail at load in a percpu instance
-* `spawn`: create a new runtime environment and spawn a thread to run the script `/lib/modules/lua/<script>.lua`
+* `spawn`: create a new runtime environment and spawn a thread to run the script `/lib/modules/lua/<script>.lua`; optionally pass `percpu` to spawn one thread per CPU id, each bound to its own CPU and running its own runtime
 * `stop`: stop the runtime environment created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_
 

--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -353,6 +353,7 @@ static int luadevice_new(lua_State *L)
 	const char *name;
 	int ret;
 
+	lunatik_checknotpercpu(L);
 	luaL_checktype(L, 1, LUA_TTABLE); /* driver */
 
 	lunatik_checkfield(L, 1, "name", LUA_TSTRING);

--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -285,6 +285,7 @@ static int luahid_raw_event(struct hid_device *hdev, struct hid_report *report, 
 */
 static int luahid_register(lua_State *L)
 {
+	lunatik_checknotpercpu(L);
 	luaL_checktype(L, 1, LUA_TTABLE);
 
 	lunatik_object_t *object = lunatik_newobject(L, &luahid_class, sizeof(luahid_t), LUNATIK_OPT_NONE);

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -23,6 +23,7 @@ typedef struct luanetfilter_s {
 	lunatik_object_t *runtime;
 	lunatik_object_t *skb;
 	u32 mark;
+	int cpu;
 	struct nf_hook_ops nfops;
 } luanetfilter_t;
 
@@ -92,6 +93,11 @@ static inline unsigned int luanetfilter_docall(luanetfilter_t *luanf, struct sk_
 		goto out;
 	}
 
+	/* foreign percpu instances must stay transparent to the chain,
+	 * whatever the policy becomes */
+	if (luanf->cpu >= 0 && luanf->cpu != raw_smp_processor_id())
+		return NF_ACCEPT;
+
 	if (likely(luanf->mark != skb->mark))
 		goto out;
 
@@ -123,6 +129,9 @@ static const lunatik_class_t luanetfilter_class = {
 
 /***
 * Registers a Netfilter hook.
+* Registered from a percpu runtime instance, the hook only acts on packets
+* being processed on its instance's CPU and accepts everything else, so each
+* packet is handled by exactly one instance.
 * @function register
 * @tparam table opts Hook options: `hook` (function), `pf`, `hooknum`, `priority` (integers),
 *   and optionally `mark` (integer, default 0).
@@ -146,6 +155,7 @@ static int luanetfilter_register(lua_State *L)
 	lunatik_setinteger(L, 1, nfops, hooknum);
 	lunatik_setinteger(L, 1, nfops, priority);
 	lunatik_optinteger(L, 1, nf, mark, 0);
+	nf->cpu = lunatik_getcpu(L);
 
 	if (nf_register_net_hook(&init_net, nfops) != 0)
 		luaL_error(L, "failed to register netfilter hook");

--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -222,6 +222,7 @@ static const lunatik_class_t luanotifier_hardirq_class = {
 static int luanotifier_new(lua_State *L, luanotifier_register_t register_fn, luanotifier_register_t unregister_fn,
 	luanotifier_handler_t handler_fn, const lunatik_class_t *class)
 {
+	lunatik_checknotpercpu(L);
 	luaL_checktype(L, 1, LUA_TFUNCTION); /* callback */
 
 	lunatik_object_t *object = lunatik_newobject(L, class, sizeof(luanotifier_t), LUNATIK_OPT_NONE);

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -186,6 +186,7 @@ static const lunatik_class_t luaprobe_class = {
 
 static int luaprobe_new(lua_State *L)
 {
+	lunatik_checknotpercpu(L);
 	lunatik_object_t *object = lunatik_newobject(L, &luaprobe_class, sizeof(luaprobe_t), LUNATIK_OPT_NONE);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
 	struct kprobe *kp = &probe->kp;

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -177,6 +177,8 @@ static const lunatik_class_t luathread_class = {
 * @function run
 * @tparam runtime runtime A sleepable Lunatik runtime whose script returns a function.
 * @tparam string name A descriptive name for the kernel thread.
+* @tparam[opt] integer cpu CPU id to bind the thread to; it then runs there and
+*   nowhere else, and stays parked while that CPU is offline.
 * @treturn thread A new thread object.
 * @raise Error if the runtime is not sleepable or if thread creation fails.
 * @see lunatik.runtime
@@ -187,6 +189,8 @@ static int luathread_run(lua_State *L)
 	lunatik_object_t *runtime = lunatik_checkobject(L, 1);
 	luaL_argcheck(L, !lunatik_isirq(runtime->opt), 1, "IRQ runtime cannot spawn threads");
 	const char *name = luaL_checkstring(L, 2);
+	int cpu = luaL_optinteger(L, 3, -1);
+	luaL_argcheck(L, cpu >= -1 && cpu < (int)nr_cpu_ids, 3, "invalid cpu");
 	lunatik_object_t *object = luathread_new(L);
 	luathread_t *thread = object->private;
 
@@ -194,9 +198,13 @@ static int luathread_run(lua_State *L)
 	lunatik_getobject(runtime);
 	thread->runtime = runtime;
 
-	thread->task = kthread_run(luathread_func, object, name);
+	thread->task = kthread_create(luathread_func, object, name);
 	if (IS_ERR(thread->task))
 		luaL_error(L, "failed to create a new thread");
+
+	if (cpu >= 0)
+		kthread_bind(thread->task, cpu); /* must precede the first wake up */
+	wake_up_process(thread->task);
 
 	return 1; /* object */
 }

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -116,7 +116,8 @@ static int luathread_stop(lua_State *L)
 * Retrieves information about the kernel task associated with the thread.
 * @function task
 * @tparam thread self thread object.
-* @treturn table A table with fields: `cpu` (SMP only), `command`, `pid`, `tgid`.
+* @treturn table A table with fields: `cpu` (SMP only, the CPU the task last ran on),
+*   `command`, `pid`, `tgid`.
 * @usage
 * local info = my_thread:task()
 */
@@ -130,7 +131,7 @@ static int luathread_task(lua_State *L)
 	int table = lua_gettop(L);
 
 #ifdef CONFIG_SMP
-	lua_pushinteger(L, task->on_cpu);
+	lua_pushinteger(L, task_cpu(task));
 	lua_setfield(L, table, "cpu");
 #endif
 

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -64,9 +64,23 @@ function percpu.run(script, context)
 	end
 end
 
+function percpu.attach(script, name)
+	for cpu = 0, linux.numcpus() - 1 do
+		local instance = key(script, cpu)
+		local ok, t = pcall(thread.run, env.percpu[instance], name, cpu)
+		if not ok then
+			percpu.stop(script)
+			error(t, 0)
+		end
+		env.threads[instance] = t
+	end
+end
+
 function percpu.stop(script)
 	for cpu = 0, linux.numcpus() - 1 do
-		stop(env.percpu, key(script, cpu))
+		local instance = key(script, cpu)
+		stop(env.threads, instance)
+		stop(env.percpu, instance)
 	end
 end
 
@@ -100,14 +114,19 @@ end
 -- to execute the runtime. The thread is named based on the script's filename.
 -- The spawned script is expected to return a function, which will then be executed in the new thread.
 -- @tparam string script path or name of the Lua script to spawn.
--- @treturn userdata kernel thread object.
--- @raise error if the script is already running or `percpu` is set.
+-- @tparam[opt] string context Execution context; `spawn` is always sleepable.
+-- @tparam[opt] boolean ispercpu spawn one thread per CPU id, each bound to its own
+--   CPU and running its own runtime; see `runner.run`.
+-- @treturn userdata kernel thread object, or `nil` when `ispercpu` is set.
+-- @raise error if the script is already running.
 function runner.spawn(script, context, ispercpu)
+	local script = trim(script)
+	local name = string.match(script, "(%w*/*%w*)$")
 	if ispercpu then
-		error("spawn does not support percpu scripts")
+		runner.run(script, context, true)
+		return percpu.attach(script, name)
 	end
 	local runtime = runner.run(script, context)
-	local name = string.match(script, "(%w*/*%w*)$")
 	local t = thread.run(runtime, name)
 	env.threads[script] = t
 	return t

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -77,7 +77,9 @@ end
 -- @tparam[opt] string context Execution context: `"process"` (default) or `"softirq"` (for netfilter/XDP hooks).
 -- @tparam[opt] boolean ispercpu create one runtime per CPU id, registered in `env.percpu`
 --   as `<script>:<cpu>`, for scripts dispatched by the eBPF bindings; the script runs
---   once per runtime.
+--   once per runtime and can read its id with `lunatik.cpu()`. Netfilter hooks act
+--   only on their instance's CPU; global registrations (`device`, `notifier`,
+--   `probe`, `hid`) fail at load.
 -- @treturn table created Lunatik runtime object, or `nil` when `percpu` is set.
 -- @raise error if the script is already running.
 function runner.run(script, context, ispercpu)

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -53,9 +53,9 @@ function percpu.name(script)
 	return string.match(script, "^(.+):0$")
 end
 
-function percpu.run(script, context, ...)
+function percpu.run(script, context)
 	for cpu = 0, linux.numcpus() - 1 do
-		local ok, runtime = pcall(lunatik.runtime, script, context, ...)
+		local ok, runtime = pcall(lunatik.runtime, script, context, cpu)
 		if not ok then
 			percpu.stop(script)
 			error(runtime, 0)
@@ -80,15 +80,15 @@ end
 --   once per runtime.
 -- @treturn table created Lunatik runtime object, or `nil` when `percpu` is set.
 -- @raise error if the script is already running.
-function runner.run(script, context, ispercpu, ...)
+function runner.run(script, context, ispercpu)
 	local script = trim(script)
 	if env.runtimes[script] or env.percpu[key(script, 0)] then
 		error(string.format("%s is already running", script))
 	end
 	if ispercpu then
-		return percpu.run(script, context, ...)
+		return percpu.run(script, context)
 	end
-	local runtime = lunatik.runtime(script, context, ...)
+	local runtime = lunatik.runtime(script, context)
 	env.runtimes[script] = runtime
 	return runtime
 end
@@ -100,11 +100,11 @@ end
 -- @tparam string script path or name of the Lua script to spawn.
 -- @treturn userdata kernel thread object.
 -- @raise error if the script is already running or `percpu` is set.
-function runner.spawn(script, context, ispercpu, ...)
+function runner.spawn(script, context, ispercpu)
 	if ispercpu then
 		error("spawn does not support percpu scripts")
 	end
-	local runtime = runner.run(script, context, ispercpu, ...)
+	local runtime = runner.run(script, context)
 	local name = string.match(script, "(%w*/*%w*)$")
 	local t = thread.run(runtime, name)
 	env.threads[script] = t
@@ -159,13 +159,26 @@ function runner.shutdown()
 	end
 end
 
+local function registry(name)
+	local current = env[name]
+	if current == nil then
+		return rcu.table()
+	end
+	if type(current) ~= "userdata" then
+		error(string.format("_ENV.%s outlived an incompatible runner; unload and load the modules", name))
+	end
+	return current
+end
+
 --- Initializes the runner's internal state.
--- Creates RCU-safe tables for storing runtimes and threads.
--- This is typically called during Lunatik's initialization.
+-- Creates RCU-safe tables for storing runtimes and threads, keeping the ones a
+-- previous startup left behind. An entry the core kept across an upgrade may
+-- hold what an older runner stored, which this rejects rather than indexing.
+-- @raise error if a registry survived in a format this runner cannot use.
 function runner.startup()
-	env.runtimes = env.runtimes or rcu.table()
-	env.percpu = env.percpu or rcu.table()
-	env.threads = env.threads or rcu.table()
+	env.runtimes = registry("runtimes")
+	env.percpu = registry("percpu")
+	env.threads = registry("threads")
 end
 
 return runner

--- a/lunatik.h
+++ b/lunatik.h
@@ -51,6 +51,8 @@ do {									\
 
 #define lunatik_extra(L)	((lunatik_runtime_t *)lua_getextraspace(L))
 #define lunatik_toruntime(L)	(lunatik_extra(L)->runtime)
+#define lunatik_getcpu(L)	(lunatik_extra(L)->cpu)
+#define lunatik_ispercpu(L)	(lunatik_getcpu(L) >= 0)
 
 #define lunatik_cannotsleep(L, s)	((s) && lunatik_isirq(lunatik_toruntime(L)->opt))
 

--- a/lunatik.h
+++ b/lunatik.h
@@ -56,6 +56,11 @@ do {									\
 
 #define lunatik_cannotsleep(L, s)	((s) && lunatik_isirq(lunatik_toruntime(L)->opt))
 
+/* for constructors whose registration is global: a percpu script would
+ * register it once per instance */
+#define lunatik_checknotpercpu(L)	\
+	luaL_argcheck((L), !lunatik_ispercpu(L), 1, "not allowed in a percpu runtime")
+
 #define lunatik_getstate(runtime)	((lua_State *)(runtime)->private)
 #define lunatik_isready(runtime)	\
 	((runtime)->private && lunatik_extra(lunatik_getstate(runtime))->ready)

--- a/lunatik_conf.h
+++ b/lunatik_conf.h
@@ -78,6 +78,7 @@ struct lunatik_object_s;
 typedef struct lunatik_runtime_s {
 	struct lunatik_object_s *runtime;
 	bool ready;
+	int cpu;	/* percpu instance id; -1 on a plain runtime */
 } lunatik_runtime_t;
 
 #undef LUA_EXTRASPACE

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -157,12 +157,30 @@ static int lunatik_lresume(lua_State *L)
 	return nresults;
 }
 
+/***
+* Returns the CPU id of a percpu runtime instance.
+* Ranges from `0` to `linux.numcpus() - 1`; see `runner.run`.
+* @function cpu
+* @treturn integer instance CPU id, or `nil` on a plain runtime
+* @within lunatik
+*/
+static int lunatik_lcpu(lua_State *L)
+{
+	if (lunatik_ispercpu(L))
+		lua_pushinteger(L, lunatik_getcpu(L));
+	else
+		lua_pushnil(L);
+	return 1;
+}
+
 static const luaL_Reg lunatik_lib[] = {
 	{"runtime", lunatik_lruntime},
+	{"cpu", lunatik_lcpu},
 	{NULL, NULL}
 };
 
 static const luaL_Reg lunatik_stub_lib[] = {
+	{"cpu", lunatik_lcpu},
 	{NULL, NULL}
 };
 
@@ -225,7 +243,7 @@ static int lunatik_runscript(lua_State *L)
 	return 1; /* callback */
 }
 
-static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt)
+static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt, int cpu)
 {
 	lunatik_object_t *runtime;
 	lua_State *L;
@@ -244,6 +262,7 @@ static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, con
 	lunatik_setobject(runtime, &lunatik_class, opt);
 	lunatik_toruntime(L) = runtime;
 	lunatik_extra(L)->ready = false;
+	lunatik_extra(L)->cpu = cpu;
 
 	runtime->gfp = GFP_KERNEL; /* might use kvmalloc while running in process */
 	lua_setallocf(L, lunatik_alloc, runtime);
@@ -271,7 +290,7 @@ static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, con
 
 int lunatik_runtime(lunatik_object_t **pruntime, const char *script, lunatik_opt_t opt)
 {
-	return lunatik_newruntime(pruntime, NULL, script, opt);
+	return lunatik_newruntime(pruntime, NULL, script, opt, -1);
 }
 EXPORT_SYMBOL(lunatik_runtime);
 
@@ -284,6 +303,9 @@ EXPORT_SYMBOL(lunatik_runtime);
 *   (atomic, GFP\_ATOMIC, spinlock with IRQs disabled).
 *   Use `"softirq"` for hooks that fire in softirq context (netfilter, XDP).
 *   Use `"hardirq"` for hooks that fire in hardirq context (kprobes).
+* @tparam[opt=-1] integer cpu percpu instance CPU id; the runner passes it when
+*   creating `run <script> percpu` instances. A runtime created directly with a
+*   cpu claims to be that instance without being registered for dispatch.
 * @treturn runtime
 * @raise if allocation fails or the script errors on load
 * @within lunatik
@@ -294,10 +316,13 @@ static int lunatik_lruntime(lua_State *L)
 	static const lunatik_opt_t opts[] = {LUNATIK_OPT_NONE, LUNATIK_OPT_SOFTIRQ, LUNATIK_OPT_HARDIRQ};
 	const char *script = luaL_checkstring(L, 1);
 	int context = luaL_checkoption(L, 2, "process", contexts);
+	int cpu = luaL_optinteger(L, 3, -1);
 	lunatik_opt_t opt = opts[context];
 
+	luaL_argcheck(L, cpu >= -1 && cpu < (int)nr_cpu_ids, 3, "invalid cpu");
+
 	lunatik_object_t **pruntime = lunatik_newpobject(L, 1);
-	if (lunatik_newruntime(pruntime, L, script, opt) != 0)
+	if (lunatik_newruntime(pruntime, L, script, opt, cpu) != 0)
 		lua_error(L);
 	lunatik_setclass(L, &lunatik_class, true);
 	return 1;

--- a/tests/README.md
+++ b/tests/README.md
@@ -204,8 +204,8 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
 - **percpu**: `run <script> percpu` registers one runtime per possible
   CPU id, as `<script>:<cpu>`, which is the key the eBPF bindings look
   up; the script is listed once, by name; `stop` drops every instance
-  and lets it run again; `spawn` refuses percpu without creating any
-  runtime; a script that fails on one instance rolls back the ones
+  and lets it run again; a running script is neither run nor spawned
+  twice; a script that fails on one instance rolls back the ones
   already created; the instances are not reachable through a generic
   stop; and each instance sees its own id via `lunatik.cpu()`, which a
   plain runtime sees as `nil`.
@@ -217,6 +217,11 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
 - **percpu_refuse**: a global registration (`device.new`) fails at load
   in a percpu instance, naming percpu, with a clean rollback; the same
   script runs as a plain runtime.
+
+- **percpu_spawn**: `spawn <script> percpu` starts one thread per
+  possible CPU id, each bound to its CPU: every thread records whether
+  it runs where its instance claims, and the check asserts all did;
+  stopping by name drops every thread and lets the script spawn again.
 
 ### set
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -210,6 +210,14 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   stop; and each instance sees its own id via `lunatik.cpu()`, which a
   plain runtime sees as `nil`.
 
+- **percpu_affinity**: a netfilter hook registered by a percpu instance
+  only acts on packets processed on its instance's CPU: after K pings
+  the per-instance counters add up to exactly K, not N*K.
+
+- **percpu_refuse**: a global registration (`device.new`) fails at load
+  in a percpu instance, naming percpu, with a clean rollback; the same
+  script runs as a plain runtime.
+
 ### set
 
 - **set**: `set.new` sorting unsorted input and binary-search membership

--- a/tests/README.md
+++ b/tests/README.md
@@ -206,8 +206,9 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   up; the script is listed once, by name; `stop` drops every instance
   and lets it run again; `spawn` refuses percpu without creating any
   runtime; a script that fails on one instance rolls back the ones
-  already created; and the instances are not reachable through a
-  generic stop.
+  already created; the instances are not reachable through a generic
+  stop; and each instance sees its own id via `lunatik.cpu()`, which a
+  plain runtime sees as `nil`.
 
 ### set
 

--- a/tests/runtime/percpu.lua
+++ b/tests/runtime/percpu.lua
@@ -4,5 +4,9 @@
 --
 -- Kernel-side script for the percpu runtime test (see percpu.sh).
 
+local lunatik = require("lunatik")
+
+lunatik._ENV["percpu_cpu:" .. lunatik.cpu()] = true
+
 return function() end
 

--- a/tests/runtime/percpu.sh
+++ b/tests/runtime/percpu.sh
@@ -6,8 +6,8 @@
 # Regression test for percpu runtimes: `run <script> percpu` registers one
 # runtime per possible CPU id as `<script>:<cpu>`, which is what the eBPF
 # bindings look up; the script is listed once, by name; stopping it drops every
-# instance and lets it run again; `spawn` refuses percpu without creating any
-# runtime; a script that fails on one instance rolls back the ones already
+# instance and lets it run again; a running script is neither run nor spawned
+# twice; a script that fails on one instance rolls back the ones already
 # created; and the instances are not reachable through a generic stop.
 #
 # Usage: sudo bash tests/runtime/percpu.sh
@@ -58,14 +58,15 @@ run_script "$SCRIPT" percpu
 lunatik stop "$SCRIPT" > /dev/null 2>&1
 ktap_pass "stop drops every instance and lets the script run again"
 
+run_script "$SCRIPT" percpu
+output=$(lunatik run "$SCRIPT" percpu 2>&1)
+echo "$output" | grep -q "is already running" || \
+	fail "a second percpu run was accepted: $output"
 output=$(lunatik spawn "$SCRIPT" percpu 2>&1)
-echo "$output" | grep -q "spawn does not support percpu" || \
-	fail "spawn accepted percpu: $output"
-listed=$(lunatik list)
-case "$listed" in
-	*"$SCRIPT"*) fail "the refused spawn left runtimes behind: $listed" ;;
-esac
-ktap_pass "spawn refuses percpu without creating runtimes"
+echo "$output" | grep -q "is already running" || \
+	fail "a percpu spawn over a running script was accepted: $output"
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "a running percpu script is not run or spawned twice"
 
 output=$(lunatik run "$FAIL_SCRIPT" percpu 2>&1)
 echo "$output" | grep -q "intentional error on the second instance" || \

--- a/tests/runtime/percpu_affinity.lua
+++ b/tests/runtime/percpu_affinity.lua
@@ -1,0 +1,37 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu affinity test (see percpu_affinity.sh).
+
+local netfilter = require("netfilter")
+local nf        = require("linux.nf")
+local byteorder = require("byteorder")
+local net       = require("net")
+local lunatik   = require("lunatik")
+
+local family    = nf.proto
+local action    = nf.action
+local hooks     = nf.inet
+local priority  = nf.ip.pri
+
+local IP_DADDR <const> = 16
+local TARGET   <const> = byteorder.hton32(net.aton("127.0.0.9"))
+
+local counter <const> = "percpu_nf:" .. lunatik.cpu()
+local env = lunatik._ENV
+
+local function hook(skb)
+	if skb:data():getuint32(IP_DADDR) == TARGET then
+		env[counter] = (env[counter] or 0) + 1
+	end
+	return action.ACCEPT
+end
+
+netfilter.register{
+	hook     = hook,
+	pf       = family.INET,
+	hooknum  = hooks.LOCAL_OUT,
+	priority = priority.FILTER,
+}
+

--- a/tests/runtime/percpu_affinity.sh
+++ b/tests/runtime/percpu_affinity.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for percpu netfilter affinity: a hook registered by a percpu
+# instance only acts on packets processed on its instance's CPU and accepts
+# everything else. Each instance counts the LOCAL_OUT packets to 127.0.0.9 it
+# handled; after K pings the counts must add up to exactly K -- without the
+# affinity every packet would fire all N hooks and the sum would be N*K.
+#
+# Usage: sudo bash tests/runtime/percpu_affinity.sh
+
+SCRIPT="tests/runtime/percpu_affinity"
+CHECK="tests/runtime/percpu_affinity_check"
+PACKETS=7  # must match percpu_affinity_check.lua
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+	lunatik stop "$CHECK" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+cat /sys/module/luanetfilter/refcnt > /dev/null 2>&1 || {
+	echo "# SKIP: luanetfilter not loaded"
+	ktap_totals
+	exit 0
+}
+
+mark_dmesg
+
+run_script "$SCRIPT" softirq percpu
+
+ping -c $PACKETS -i 0.1 -W 1 127.0.0.9 > /dev/null 2>&1 || true
+
+run_script "$CHECK"
+check_dmesg || { ktap_totals; exit 1; }
+ktap_pass "each packet is handled by exactly one percpu instance"
+
+ktap_totals
+

--- a/tests/runtime/percpu_affinity_check.lua
+++ b/tests/runtime/percpu_affinity_check.lua
@@ -1,0 +1,23 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu affinity test (see percpu_affinity.sh).
+
+local lunatik = require("lunatik")
+local linux   = require("linux")
+local test    = require("util").test
+
+local PACKETS <const> = 7  -- must match percpu_affinity.sh
+
+test("each packet is handled by exactly one percpu instance", function()
+	local total = 0
+	for cpu = 0, linux.numcpus() - 1 do
+		local count = lunatik._ENV["percpu_nf:" .. cpu] or 0
+		total = total + count
+		lunatik._ENV["percpu_nf:" .. cpu] = nil
+	end
+	assert(total == PACKETS,
+		string.format("expected %d handled packets, got %d", PACKETS, total))
+end)
+

--- a/tests/runtime/percpu_check.lua
+++ b/tests/runtime/percpu_check.lua
@@ -20,3 +20,11 @@ test("percpu registers one runtime per possible CPU id", function()
 	assert(lunatik._ENV.runtimes[script] == nil, "percpu script leaked into env.runtimes")
 end)
 
+test("each instance sees its own CPU id, a plain runtime sees none", function()
+	assert(lunatik.cpu() == nil, "plain runtime reports a CPU id")
+	for cpu = 0, linux.numcpus() - 1 do
+		assert(lunatik._ENV["percpu_cpu:" .. cpu], "no instance stamped CPU " .. cpu)
+		lunatik._ENV["percpu_cpu:" .. cpu] = nil
+	end
+end)
+

--- a/tests/runtime/percpu_refuse.lua
+++ b/tests/runtime/percpu_refuse.lua
@@ -1,0 +1,17 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu refusal test (see percpu_refuse.sh).
+
+local device = require("device")
+local stat   = require("linux.stat")
+
+local driver = {name = "percpu_refuse", mode = stat.IRUGO}
+
+function driver:read()
+	return ""
+end
+
+device.new(driver)
+

--- a/tests/runtime/percpu_refuse.sh
+++ b/tests/runtime/percpu_refuse.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for the percpu refusal: a constructor whose registration is
+# global (device.new here) must fail at load in a percpu instance, naming
+# percpu, and the rollback must leave nothing registered; the same script runs
+# fine as a plain runtime.
+#
+# Usage: sudo bash tests/runtime/percpu_refuse.sh
+
+SCRIPT="tests/runtime/percpu_refuse"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() { lunatik stop "$SCRIPT" > /dev/null 2>&1; }
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 2
+
+output=$(lunatik run "$SCRIPT" percpu 2>&1)
+echo "$output" | grep -q "not allowed in a percpu runtime" || \
+	fail "percpu run did not refuse the registration: $output"
+listed=$(lunatik list)
+case "$listed" in
+	*"$SCRIPT"*) fail "the refused run left instances behind: $listed" ;;
+esac
+[ -e /dev/percpu_refuse ] && fail "the refused run left the device registered"
+ktap_pass "global registration fails at load in a percpu instance"
+
+mark_dmesg
+run_script "$SCRIPT"
+[ -e /dev/percpu_refuse ] || fail "plain run did not register the device"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "the same script runs as a plain runtime"
+
+ktap_totals
+

--- a/tests/runtime/percpu_spawn.lua
+++ b/tests/runtime/percpu_spawn.lua
@@ -1,0 +1,20 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu spawn test (see percpu_spawn.sh).
+
+local thread  = require("thread")
+local linux   = require("linux")
+local lunatik = require("lunatik")
+
+local bound <const> = "percpu_spawn:" .. lunatik.cpu()
+local env = lunatik._ENV
+
+return function()
+	while not thread.shouldstop() do
+		env[bound] = thread.current():task().cpu == lunatik.cpu()
+		linux.schedule(100)
+	end
+end
+

--- a/tests/runtime/percpu_spawn.sh
+++ b/tests/runtime/percpu_spawn.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for percpu spawn: `spawn <script> percpu` starts one kernel
+# thread per possible CPU id, each bound to its own CPU and running its own
+# runtime. Every thread records whether it is executing on the CPU its instance
+# claims; the check asserts all of them did. Stopping by name drops every
+# thread and runtime, and lets the script spawn again.
+#
+# Usage: sudo bash tests/runtime/percpu_spawn.sh
+
+SCRIPT="tests/runtime/percpu_spawn"
+CHECK="tests/runtime/percpu_spawn_check"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+	lunatik stop "$CHECK" > /dev/null 2>&1
+}
+
+spawn_percpu()
+{
+	local output
+	output=$(lunatik spawn "$SCRIPT" percpu 2>&1)
+	[ -z "$output" ] || fail "spawn percpu failed: $output"
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 2
+
+mark_dmesg
+
+spawn_percpu
+sleep 1
+run_script "$CHECK"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$CHECK" > /dev/null 2>&1
+ktap_pass "each spawned thread runs on the CPU it is bound to"
+
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+listed=$(lunatik list)
+case "$listed" in
+	*"$SCRIPT"*) fail "stop left the script running: $listed" ;;
+esac
+spawn_percpu
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "stop drops every thread and lets the script spawn again"
+
+ktap_totals
+

--- a/tests/runtime/percpu_spawn_check.lua
+++ b/tests/runtime/percpu_spawn_check.lua
@@ -1,0 +1,22 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu spawn test (see percpu_spawn.sh).
+
+local lunatik = require("lunatik")
+local linux   = require("linux")
+local test    = require("util").test
+
+local prefix <const> = "percpu_spawn:"
+
+test("each spawned thread runs on the CPU it is bound to", function()
+	local env = lunatik._ENV
+	for cpu = 0, linux.numcpus() - 1 do
+		local ran = env[prefix .. cpu]
+		env[prefix .. cpu] = nil
+		assert(ran ~= nil, "no thread ran for CPU " .. cpu)
+		assert(ran, "the thread of CPU " .. cpu .. " ran on another CPU")
+	end
+end)
+

--- a/tests/runtime/run.sh
+++ b/tests/runtime/run.sh
@@ -19,6 +19,7 @@ TESTS=(
 	opt_skb_single.sh
 	require_cloneobject.sh
 	percpu.sh
+	percpu_affinity.sh
 )
 
 SEP=""

--- a/tests/runtime/run.sh
+++ b/tests/runtime/run.sh
@@ -21,6 +21,7 @@ TESTS=(
 	percpu.sh
 	percpu_affinity.sh
 	percpu_refuse.sh
+	percpu_spawn.sh
 )
 
 SEP=""

--- a/tests/runtime/run.sh
+++ b/tests/runtime/run.sh
@@ -20,6 +20,7 @@ TESTS=(
 	require_cloneobject.sh
 	percpu.sh
 	percpu_affinity.sh
+	percpu_refuse.sh
 )
 
 SEP=""


### PR DESCRIPTION
Resolves #681, stacked on #678. `spawn <script> percpu` now starts one runtime and one kernel thread per CPU id, each thread bound to the CPU of its instance, so a worker sees a stable `lunatik.cpu()` and owns per-CPU state without locking — the ksoftirqd shape, in Lua. The refusal #676 added was the placeholder for this.

Two bugs surfaced on the way and are fixed first, each on its own commit:

`thread:task()` reported `task->on_cpu`, which tells whether the task is executing, not where: it answered 1 on every call. With `task_cpu()` it reports the CPU, which is also what lets the test prove the binding.

`runner.spawn` keyed `env.threads` by the untrimmed script name while `runner.stop` looked it up trimmed, so spawning `<script>.lua` left the thread behind. Fixed as part of making the keys consistent for percpu.

`kthread_bind` must run between creation and the first wake up, so `thread.run` splits `kthread_run` into `kthread_create` + bind + `wake_up_process`. The cpu argument is optional and a plain spawn takes the old path.

Test: each thread records whether it is executing on the CPU its instance claims; the check asserts all of them did. Removing the bind makes it fail with "the thread of CPU 0 ran on another CPU". The percpu suite's refusal assertion became "a running percpu script is neither run nor spawned twice".

Tested on 6.8.0-136: full suite twice, `pass:94 fail:0`, clean dmesg; builds clean against 5.15 and 6.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
