### PR TITLE
lunatik: check the class of foreign object arguments

### DIFF
--- a/lib/luarcu.c
+++ b/lib/luarcu.c
@@ -1,5 +1,5 @@
 /*
-* SPDX-FileCopyrightText: (c) 2023-2025 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-FileCopyrightText: (c) 2023-2026 Ring Zero Desenvolvimento de Software LTDA
 * SPDX-License-Identifier: MIT OR GPL-2.0-only
 */
 
@@ -97,7 +97,11 @@ static inline void luarcu_free(luarcu_entry_t *entry)
 	kfree_rcu(entry, rcu);
 }
 
-LUNATIK_OBJECTCHECKER(luarcu_checktable, luarcu_table_t *);
+static const lunatik_class_t luarcu_class;
+
+LUNATIK_PRIVATECHECKER(luarcu_checktable, luarcu_table_t *,
+	lunatik_argcheckclass(L, ix, &luarcu_class, "rcu.table");
+);
 
 void luarcu_getvalue(lunatik_object_t *table, const char *key, size_t keylen, lunatik_value_t *value)
 {

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -184,6 +184,7 @@ static int luathread_run(lua_State *L)
 {
 	luaL_argcheck(L, lunatik_isready(lunatik_toruntime(L)), 1, "not allowed during module load");
 	lunatik_object_t *runtime = lunatik_checkobject(L, 1);
+	lunatik_argcheckclass(L, 1, &lunatik_class, "runtime");
 	luaL_argcheck(L, !lunatik_isirq(runtime->opt), 1, "IRQ runtime cannot spawn threads");
 	const char *name = luaL_checkstring(L, 2);
 	lunatik_object_t *object = luathread_new(L);

--- a/lunatik.h
+++ b/lunatik.h
@@ -101,6 +101,7 @@ typedef struct lunatik_object_s {
 } lunatik_object_t;
 
 extern lunatik_object_t *lunatik_env;
+extern const lunatik_class_t lunatik_class;
 
 static inline int lunatik_trylock(lunatik_object_t *object)
 {
@@ -242,6 +243,8 @@ void lunatik_monitorobject(lua_State *L, const lunatik_class_t *class);
 
 #define lunatik_newpobject(L, n)	(lunatik_object_t **)lua_newuserdatauv((L), sizeof(lunatik_object_t *), (n))
 #define lunatik_argchecknull(L, o, i)	luaL_argcheck((L), (o) != NULL, (i), LUNATIK_ERR_NULLPTR)
+#define lunatik_argcheckclass(L, ix, cls, tname)	\
+	luaL_argexpected((L), lunatik_toobject((L), (ix))->class == (cls), (ix), (tname))
 #define lunatik_checkobject(L, i)	(*lunatik_checkpobject((L), (i)))
 #define lunatik_toobject(L, i)		(*(lunatik_object_t **)lua_touserdata((L), (i)))
 #define lunatik_getobject(o)		kref_get(&(o)->kref)

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -198,13 +198,14 @@ static const luaL_Reg lunatik_mt[] = {
 
 LUNATIK_OPENER(lunatik);
 LUNATIK_OPENER(lunatik_stub);
-static const lunatik_class_t lunatik_class = {
+const lunatik_class_t lunatik_class = {
 	.name = "lunatik",
 	.methods = lunatik_mt,
 	.release = lunatik_releaseruntime,
 	.opener = luaopen_lunatik,
 	.opt = LUNATIK_OPT_MONITOR | LUNATIK_OPT_EXTERNAL,
 };
+EXPORT_SYMBOL(lunatik_class);
 
 static inline void lunatik_setready(lunatik_object_t *runtime)
 {

--- a/tests/README.md
+++ b/tests/README.md
@@ -276,5 +276,8 @@ Regression tests for `luathread`.
   (non-kthread) context without crashing, and `true` in a `spawn`
   (kthread) context when stop is requested.
 
+- **foreign_object**: `thread.run()` refuses an object of another class
+  instead of using its private data as a Lua state.
+
 - **run_during_load**: `runner.spawn()` called from a script's top-level
   code must error instead of hanging the kernel.

--- a/tests/README.md
+++ b/tests/README.md
@@ -171,6 +171,9 @@ higher-level `netlink.*` modules built on top of it.
 - **map_values**: `rcu.map()` iterates booleans, integers, userdata,
   mixed types, and skips nil (deleted) entries.
 
+- **map_foreign**: `rcu.map()` refuses an object of another class
+  instead of walking its private data as a table.
+
 - **map_sync**: `rcu.map()` remains safe when called while another
   kthread is modifying the table.
 

--- a/tests/rcu/map_foreign.lua
+++ b/tests/rcu/map_foreign.lua
@@ -1,0 +1,16 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the rcu.map class check test (see run.sh).
+
+local rcu  = require("rcu")
+local data = require("data")
+local test = require("util").test
+
+test("rcu.map refuses an object of another class", function()
+	local ok, err = pcall(rcu.map, data.new(8), function() end)
+	assert(not ok, "rcu.map accepted a data object")
+	assert(err:match("rcu.table expected"), "unexpected error: " .. tostring(err))
+end)
+

--- a/tests/rcu/run.sh
+++ b/tests/rcu/run.sh
@@ -11,7 +11,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 
 source "$DIR/../lib.sh"
 
-TESTS="map_values"
+TESTS="map_values map_foreign"
 TOTAL=$(echo $TESTS | wc -w)
 
 ktap_header

--- a/tests/thread/foreign_object.lua
+++ b/tests/thread/foreign_object.lua
@@ -1,0 +1,21 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the thread.run class check test (see foreign_object.sh).
+
+local thread  = require("thread")
+local linux   = require("linux")
+local data    = require("data")
+local lunatik = require("lunatik")
+
+local env = lunatik._ENV
+
+return function()
+	local ok, err = pcall(thread.run, data.new(8), "foreign_object")
+	env.foreign_object = not ok and err:match("runtime expected") ~= nil
+	while not thread.shouldstop() do
+		linux.schedule(100)
+	end
+end
+

--- a/tests/thread/foreign_object.sh
+++ b/tests/thread/foreign_object.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for the thread.run class check: an object of another class
+# (a data buffer here) must be refused as the runtime argument, instead of
+# having its private data used as a Lua state. The call runs in a spawned
+# thread body because thread.run is not allowed during module load.
+#
+# Usage: sudo bash tests/thread/foreign_object.sh
+
+SCRIPT="tests/thread/foreign_object"
+CHECK="tests/thread/foreign_object_check"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+	lunatik stop "$CHECK" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+mark_dmesg
+
+output=$(lunatik spawn "$SCRIPT" 2>&1)
+[ -n "$output" ] && fail "spawn failed: $output"
+sleep 1
+
+run_script "$CHECK"
+check_dmesg || { ktap_totals; exit 1; }
+ktap_pass "thread.run refuses an object of another class"
+
+ktap_totals
+

--- a/tests/thread/foreign_object_check.lua
+++ b/tests/thread/foreign_object_check.lua
@@ -1,0 +1,18 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the thread.run class check test (see foreign_object.sh).
+
+local lunatik = require("lunatik")
+local test    = require("util").test
+
+local env = lunatik._ENV
+
+test("thread.run refuses an object of another class", function()
+	local result = env.foreign_object
+	env.foreign_object = nil
+	assert(result ~= nil, "the spawned body did not report")
+	assert(result == true, "thread.run did not refuse with 'runtime expected'")
+end)
+

--- a/tests/thread/run.sh
+++ b/tests/thread/run.sh
@@ -11,7 +11,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
 SEP=""
-for t in "$DIR"/shouldstop.sh "$DIR"/run_during_load.sh; do
+for t in "$DIR"/shouldstop.sh "$DIR"/run_during_load.sh "$DIR"/foreign_object.sh; do
 	echo "${SEP}# --- $(basename "$t") ---"
 	SEP=$'\n'
 	bash "$t" || FAILED=$((FAILED+1))


### PR DESCRIPTION
`thread.run` and `rcu.map` take a lunatik object as an argument and cast its private data to what their class stores: a well-formed script passing a data buffer or a fifo has it used as a Lua state, or walked as an rcu table. Both now refuse an object of another class with `bad argument #1 (... expected)`. Methods are not exposed, since they dispatch through the class metatable.

The tests assert the refusal message; the negative A/B (removing the check) is deliberately not run, since the unchecked path is a memory-corrupting crash.