### PR TITLE
docs: update the wireless-ap percpu analysis for #686

### DIFF
--- a/docs/design/wireless-ap/README.md
+++ b/docs/design/wireless-ap/README.md
@@ -39,14 +39,15 @@ Three things decide whether this work goes well:
    path and reloadable live. Both have limits — see `plan.md`.
 
 2. **The per-CPU foundation is a prerequisite, and one question inside it is
-   open.** Per-CPU runtimes ([#676], merged) and per-CPU affinity at the
-   registration points ([#678], resolving [#675]) are what make the SMP design
-   possible; this project depends on them. What they do **not** yet answer is
-   whether an EAPOL frame can be delivered to the per-CPU-affine runtime for the
-   CPU it arrives on, or whether it only arrives out-of-band over the control
-   port's single netlink socket. `kernel-notes.md` states both candidates
-   honestly; a phase is dedicated to proving one before any handshake code is
-   written.
+   open.** Per-CPU runtimes ([#676], merged), per-CPU affinity at the registration
+   points ([#678], resolving [#675]), and per-CPU CPU-pinned kthreads for `spawn`
+   ([#686], sleepable — so a worker can do the keying and PBKDF2 inline) are what
+   make the SMP design possible; this project depends on them. What they do
+   **not** yet answer is whether an EAPOL frame can be delivered to a per-CPU
+   worker for the CPU it arrives on, or whether it only arrives out-of-band over
+   the control port's single netlink socket. `kernel-notes.md` states the
+   candidates honestly; a phase is dedicated to proving one before any handshake
+   code is written.
 
 3. **Bringing up an AP is bringing up a radio.** Test on `mac80211_hwsim` with a
    `wpa_supplicant` client, never on hardware whose network you care about — a
@@ -68,4 +69,5 @@ flight. Nothing of the authenticator exists yet.
 [#675]: https://github.com/luainkernel/lunatik/issues/675
 [#676]: https://github.com/luainkernel/lunatik/pull/676
 [#678]: https://github.com/luainkernel/lunatik/pull/678
+[#686]: https://github.com/luainkernel/lunatik/pull/686
 

--- a/docs/design/wireless-ap/kernel-notes.md
+++ b/docs/design/wireless-ap/kernel-notes.md
@@ -192,48 +192,50 @@ What the merged/in-flight foundation provides:
   packet is handled by exactly one instance with no locking. Global-registration
   constructors (`device`, `notifier`, `probe`, `hid`) refuse at load in a percpu
   instance.
-* `spawn` does **not** support percpu (no per-CPU kthread). A percpu authenticator
-  is therefore event-dispatched (a hook per CPU), not a receive-loop kthread.
+* `spawn <script> percpu` ([#686], stacked on [#678]) starts one runtime **and one
+  CPU-pinned kernel thread** per CPU id — process context, so it may sleep, with
+  per-CPU state and no locking (the ksoftirqd shape, in Lua).
 
-This is exactly the model for a per-CPU authenticator **if** EAPOL arrives through
-a per-CPU-affine hook. Which is the open question.
+So there are two shapes for a per-CPU authenticator. A **spawned per-CPU worker**
+([#686]): a CPU-pinned kthread that receives EAPOL in a bounded loop and runs the
+whole handshake inline — it may sleep, so the keying (`NEW_KEY`/`SET_STATION`) and
+the PBKDF2 happen in place. Or a **softirq per-CPU hook** (`netfilter`/XDP): fast
+and affine at dispatch, but atomic, so the sleeping steps must be deferred to a
+worker — two tiers. The worker shape is the cleaner one; what is still open is how
+EAPOL reaches the right CPU's worker. That is the open question.
 
 ## Open questions
 
 Documented as open, not resolved. Each is a phase-2 spike deliverable.
 
-1. **Per-CPU EAPOL delivery, and the eBPF path.** Control-port-over-nl80211
-   delivers EAPOL by unicast to one socket (§3a) — not per-CPU, not through the
-   affine packet path (§6). The per-CPU alternative (path A) is an **eBPF path**:
-   the [#676] per-CPU runtime resolution is wired only in `bpf_luaxdp_run`, so an
-   **XDP or TC-BPF program** on the AP netdev filtering EtherType `0x888E`, calling
-   `bpf_luaxdp_run`, is the existing mechanism that lands EAPOL on the runtime of
-   the CPU it arrived on. The open part is **visibility**: does mac80211 expose
-   control-port frames to an XDP/TC hook on the netdev, or consume them first? And
-   is XDP even attachable on the wireless interface / hwsim? eBPF does not answer
-   these — if mac80211 eats the frame first, path A never sees it. If not, is a
-   software MAC-hash dispatch from the single control-port socket (path B)
-   acceptable, and where does its dispatcher live? **This gates the sharded design.**
-2. **The atomic-context split path A forces.** XDP and `netfilter` hooks run in
-   **softirq** — `GFP_ATOMIC`, no sleeping. But the handshake's key steps sleep: a
-   `NEW_KEY`/`SET_STATION` netlink round trip, and PBKDF2's 4096 HMAC iterations
-   are too heavy for softirq. So a per-CPU packet-path authenticator cannot run
-   inline; path A is a **two-tier** structure — a softirq XDP/TC front-end that
-   receives and dispatches, and a process-context worker that does the keying and
-   crypto. Path B (control-port over netlink, process context) does the whole
-   handshake inline but on one socket. Whether the two-tier per-CPU structure earns
-   its complexity over an inline process-context authenticator (single runtime, or
-   a software per-CPU dispatch) is the spike's real tradeoff, not "XDP yes/no". A
-   `bpf.map` ([#633], Lua↔BPF map) is a candidate for the per-STA state shared
-   between the two tiers, versus a plain `rcu.table`.
-3. **AF_PACKET fanout for L2.** If path A uses `AF_PACKET` + `PACKET_FANOUT` instead
-   of XDP/TC, does the fanout hash distribute EtherType-`0x888E` frames usefully
-   across CPUs, with stable per-STA affinity or not? (Determines whether per-STA
-   state can be CPU-local or must stay shared.)
-4. **Software MLME vs offload on hwsim.** Does hwsim require the AP to answer
+1. **Where EAPOL enters, and how it reaches a per-CPU worker.** With [#686]'s
+   per-CPU workers (§6), the sleeping-context problem is solved; delivery is what
+   is left. Candidates:
+   * a per-CPU **`AF_PACKET`** socket (EtherType `0x888E`) on the AP netdev with
+     `PACKET_FANOUT` — the kernel shards received EAPOL across the sockets, each
+     worker reads its share and runs the handshake inline. The cleanest fit, **if**
+     mac80211 exposes EAPOL to `AF_PACKET` on an AP netdev rather than consuming it
+     into the control port first;
+   * the **control port** (§3a) — one socket, unicast to the AP owner; fits a
+     single worker, and going per-CPU needs a software MAC-hash dispatch;
+   * a softirq **XDP/TC-BPF** hook via `bpf_luaxdp_run` — per-CPU by arrival, but
+     atomic, so the keying and PBKDF2 defer to a worker (two tiers).
+
+   The open, spike-answered part is **visibility**: does mac80211 let EAPOL reach
+   `AF_PACKET`/a packet hook on an AP netdev, or does the control port take it
+   first? If the control port is the only way in, the per-CPU story needs the
+   software dispatch. **This gates the sharded design.**
+2. **STA affinity, or shared state.** `PACKET_FANOUT_CPU` (and the XDP arrival CPU)
+   shards by the CPU a frame lands on, not by station, so a station's frames may
+   cross CPUs during its handshake — its state then must be shared (`rcu.table`,
+   per-STA lock), not CPU-local. `PACKET_FANOUT_HASH` on the source MAC would give
+   stable STA→CPU affinity and CPU-local state, **if** the hash keys on the L2
+   source for a non-IP frame (unverified). This decides whether the per-STA state
+   is shared or owned.
+3. **Software MLME vs offload on hwsim.** Does hwsim require the AP to answer
    auth/assoc in software (`REGISTER_FRAME`/`FRAME`), or does it offload them?
    Phase 1 settles this; it changes where association policy is evaluated.
-5. **Crypto availability** (the three `[to verify]` in §4): AES-CMAC, AES key wrap,
+4. **Crypto availability** (the three `[to verify]` in §4): AES-CMAC, AES key wrap,
    and the cost of in-kernel PBKDF2. Phase 3, before the handshake.
 
 ## Version drift to watch
@@ -248,4 +250,5 @@ Documented as open, not resolved. Each is a phase-2 spike deliverable.
 [#675]: https://github.com/luainkernel/lunatik/issues/675
 [#676]: https://github.com/luainkernel/lunatik/pull/676
 [#678]: https://github.com/luainkernel/lunatik/pull/678
+[#686]: https://github.com/luainkernel/lunatik/pull/686
 

--- a/docs/design/wireless-ap/plan.md
+++ b/docs/design/wireless-ap/plan.md
@@ -71,17 +71,19 @@ group keys (`wpa_group`: GMK/GTK/IGTK, and the GTK rekey fan-out), the station
 table and AID allocator, the protection counters, and the prebuilt RSN IE. See
 `kernel-notes.md` §"Per-STA vs per-BSS state" for the full split.
 
-So the design aims at a **`percpu` authenticator**: one runtime per CPU, each
-handling the handshakes for the stations whose frames land on its CPU — subject to
-"The open question" below, which decides whether that delivery is even available.
-The per-station handshake state lives in a shared `rcu.table` (read-mostly, keyed
-by STA MAC), because — and this is the honest limit of the merged infrastructure —
-[#676] shards by the CPU a frame *arrives on*, not by station. A station's frames
-are not guaranteed to land on one CPU, so its state cannot be CPU-local; it is
-shared, with per-STA serialization. The parallelism is real (N CPUs deriving PTKs
-concurrently), but it is shared-state parallelism, not share-nothing. The per-BSS
-group-key subsystem has a single owner and RCU readers; GTK rekey is the one
-inherently cross-CPU operation (a barrier over all stations).
+So the design aims at a **per-CPU authenticator**: with [#686], a `spawn ... percpu`
+worker is a CPU-pinned kernel thread per CPU — process context, so it may sleep,
+which the handshake's keying and PBKDF2 need — each handling the handshakes for the
+stations whose frames land on its CPU. This is subject to "The open question"
+below, which decides whether EAPOL can reach a per-CPU worker at all. The
+per-station handshake state lives in a shared `rcu.table` (read-mostly, keyed by
+STA MAC), because per-CPU delivery shards by the CPU a frame *arrives on*, not by
+station: a station's frames are not guaranteed to land on one CPU, so its state
+cannot be CPU-local unless the delivery is made STA-affine (see the open questions).
+The parallelism is real (N CPUs deriving PTKs concurrently), but it is shared-state
+parallelism, not share-nothing. The per-BSS group-key subsystem has a single owner
+and RCU readers; GTK rekey is the one inherently cross-CPU operation (a barrier
+over all stations).
 
 The authenticator's only outward dependencies are the four `hostapd` uses:
 `send_eapol`, `set_key`, `get_psk`, `set_port_authorized`. Those map to the
@@ -144,18 +146,15 @@ here with a prototype, not an assumption.
 ### Phase 2: the EAPOL I/O spike (the gate)
 
 Prove, on hwsim with a real `wpa_supplicant` client, that the kernel script can
-**receive and send** an EAPOL-Key frame — both candidate paths from "The open
-question" tried, the winner chosen with data. Path A is specifically the
-**eBPF path**: an XDP/TC-BPF program catching EtherType `0x888E` and dispatching
-per-CPU via `bpf_luaxdp_run` (the mechanism [#676] already wires). The spike must
-answer not just "does a frame arrive" but two things that decide the whole shape:
-whether mac80211 even exposes EAPOL to that hook, and — since XDP/`netfilter` run
-in softirq — that path A forces a **two-tier** design (a softirq front-end plus a
-process-context worker, because the keying and PBKDF2 sleep), which path B
-(control-port over netlink, all in process context) does not. See
-`kernel-notes.md` "Open questions" 1–2. No handshake logic, no PR of a public API
-until RX and TX are demonstrated; the phase produces a throwaway prototype and a
-findings note.
+**receive and send** an EAPOL-Key frame. The question the spike settles is where
+EAPOL enters and how it reaches a per-CPU worker (`kernel-notes.md` "Open
+questions" 1). The leading candidate, now that [#686] gives per-CPU sleepable
+workers, is a per-CPU `AF_PACKET` socket (`0x888E`) with `PACKET_FANOUT` feeding a
+`spawn ... percpu` worker that handles the handshake inline — clean if mac80211
+exposes EAPOL to `AF_PACKET` on an AP netdev rather than taking it into the control
+port first. The control-port socket (one owner) and a softirq XDP/TC hook (atomic,
+two-tier) are the fallbacks. No handshake logic, no PR of a public API until RX and
+TX are demonstrated; the phase produces a throwaway prototype and a findings note.
 
 If neither path works cleanly, that is a finding too: it caps the project at "open
 AP + external authenticator" and is worth knowing before writing crypto.
@@ -171,11 +170,12 @@ passes encrypted traffic on hwsim.
 
 ### Phase 4: shard across CPUs
 
-Move the authenticator to a `percpu` script with per-STA state in a shared
-`rcu.table`, using the phase-2 delivery path and [#678]'s affinity. The per-BSS
-group-key subsystem gets a single owner. Prove correctness under concurrent
-associations (many clients at once) and measure the speedup against phase 3's
-single runtime. GTK rekey stays serialized (the cross-CPU barrier).
+Move the authenticator to a `spawn ... percpu` worker ([#686]) — a CPU-pinned
+kernel thread per CPU — with per-STA state in a shared `rcu.table`, using the
+phase-2 delivery path. The per-BSS group-key subsystem gets a single owner. Prove
+correctness under concurrent associations (many clients at once) and measure the
+speedup against phase 3's single runtime. GTK rekey stays serialized (the
+cross-CPU barrier).
 
 ### Phase 5: programmable policy and the demo
 
@@ -233,4 +233,5 @@ A phase is done when all of the following hold. This is the review checklist.
 [#675]: https://github.com/luainkernel/lunatik/issues/675
 [#676]: https://github.com/luainkernel/lunatik/pull/676
 [#678]: https://github.com/luainkernel/lunatik/pull/678
+[#686]: https://github.com/luainkernel/lunatik/pull/686
 


### PR DESCRIPTION
[#686] (per-CPU CPU-pinned kthreads for `spawn`, sleepable) reshapes the per-CPU authenticator in the wireless-ap design: the handshake's keying and PBKDF2 can now run inline in a per-CPU worker, so the softirq two-tier split becomes a fallback rather than the premise.

This updates the design docs (`README.md`, `plan.md`, `kernel-notes.md`) to:
- describe `spawn ... percpu` ([#686]) as a CPU-pinned kthread per CPU (process context, sleepable) and its two authenticator shapes (spawned worker vs softirq hook);
- lead phase 2 / the open questions with the spawned-worker + `AF_PACKET` `PACKET_FANOUT` candidate;
- keep the honest open questions: EAPOL visibility to `AF_PACKET` on an AP netdev, and STA affinity vs shared state.

Docs only; no code change.

[#686]: https://github.com/luainkernel/lunatik/pull/686

🤖 Generated with [Claude Code](https://claude.com/claude-code)