### PR TITLE
lunatik: fix the maintainer email domain

### DIFF
--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -429,5 +429,5 @@ static void __exit luadevice_exit(void)
 module_init(luadevice_init);
 module_exit(luadevice_exit);
 MODULE_LICENSE("Dual MIT/GPL");
-MODULE_AUTHOR("Lourival Vieira Neto <lourival.neto@ring-0.io>");
+MODULE_AUTHOR("Lourival Vieira Neto <lourival.neto@ringzero.com.br>");
 

--- a/lib/luafifo.c
+++ b/lib/luafifo.c
@@ -154,5 +154,5 @@ static void __exit luafifo_exit(void)
 module_init(luafifo_init);
 module_exit(luafifo_exit);
 MODULE_LICENSE("Dual MIT/GPL");
-MODULE_AUTHOR("Lourival Vieira Neto <lourival.neto@ring-0.io>");
+MODULE_AUTHOR("Lourival Vieira Neto <lourival.neto@ringzero.com.br>");
 

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -264,5 +264,5 @@ static void __exit luaxdp_exit(void)
 module_init(luaxdp_init);
 module_exit(luaxdp_exit);
 MODULE_LICENSE("Dual MIT/GPL");
-MODULE_AUTHOR("Lourival Vieira Neto <lourival.neto@ring-0.io>");
+MODULE_AUTHOR("Lourival Vieira Neto <lourival.neto@ringzero.com.br>");
 

--- a/lunatik_run.c
+++ b/lunatik_run.c
@@ -38,5 +38,5 @@ static void __exit lunatik_run_exit(void)
 module_init(lunatik_run_init);
 module_exit(lunatik_run_exit);
 MODULE_LICENSE("Dual MIT/GPL");
-MODULE_AUTHOR("Lourival Vieira Neto <lourival.neto@ring-0.io>");
+MODULE_AUTHOR("Lourival Vieira Neto <lourival.neto@ringzero.com.br>");
 


### PR DESCRIPTION
`MODULE_AUTHOR` in `lunatik_run.c`, `luaxdp.c`, `luadevice.c` and `luafifo.c` carries `ring-0.io`; the maintainer's domain is `ringzero.com.br`, as everywhere else in the tree.