### PR TITLE
docs: reviews enforce conventions, not preferences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,6 +304,10 @@ On the comments themselves:
 * A request for changes is not a place for praise. Padding buries the change being asked for.
 * Missing tests are a finding of their own, written as such, not a remark appended to another
   comment.
+* A review holds new code to the conventions this file records; it does not impose preferences
+  beyond them. Where the tree itself is inconsistent and a style seems worth settling, that is an
+  exclusive pull request — one that fixes the whole tree and records the convention here — never a
+  finding on someone's feature work.
 * The checklist above is the reviewer's too. A pull request that fails it is not ready, whatever the
   code looks like.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,8 @@ the body.
 * Change only what the task requires. Do not reformat untouched lines, do not move code, do not
   rename variables in passing. Compare `git diff` against `git diff -w` before committing to catch
   stray whitespace.
+* No dead or unnecessary code. A branch that cannot execute — a nil check on a call that raises
+  instead of returning nil — is noise that misstates the API's contract.
 * No cosmetic changes inside a feature or fix commit, not even a blank line.
 * Never remove an existing comment unless the change made it factually wrong.
 * Restoring something that was removed puts it back exactly where and how it was.


### PR DESCRIPTION
One rule for the review workflow, from the second round on #685: a reviewer holds new code to the conventions AGENTS.md records, and nothing beyond them. A style the tree itself is inconsistent about is not a finding on someone's feature work; if it seems worth settling, it becomes an exclusive pull request that fixes the whole tree and records the convention.