### PR TITLE
tests: stop the one-shot script after each nl80211 test

### DIFF
--- a/tests/netlink/nl80211.sh
+++ b/tests/netlink/nl80211.sh
@@ -17,8 +17,9 @@ MODULE="luasocket"
 source "$(dirname "$(readlink -f "$0")")/../lib.sh"
 
 HWSIM_LOADED=0
-cleanup() { [ "$HWSIM_LOADED" = 1 ] && rmmod mac80211_hwsim 2>/dev/null; }
+cleanup() { lunatik stop "$SCRIPT" 2>/dev/null; [ "$HWSIM_LOADED" = 1 ] && rmmod mac80211_hwsim 2>/dev/null; }
 trap cleanup EXIT
+cleanup
 
 ktap_header
 ktap_plan 3

--- a/tests/netlink/nl80211_ap.sh
+++ b/tests/netlink/nl80211_ap.sh
@@ -18,10 +18,12 @@ source "$(dirname "$(readlink -f "$0")")/../lib.sh"
 
 HWSIM_LOADED=0
 cleanup() {
+	lunatik stop "$SCRIPT" 2>/dev/null
 	ip link del "$IFNAME" 2>/dev/null
 	[ "$HWSIM_LOADED" = 1 ] && rmmod mac80211_hwsim 2>/dev/null
 }
 trap cleanup EXIT
+cleanup
 
 ktap_header
 ktap_plan 3

--- a/tests/netlink/nl80211_iface.sh
+++ b/tests/netlink/nl80211_iface.sh
@@ -18,10 +18,12 @@ source "$(dirname "$(readlink -f "$0")")/../lib.sh"
 
 HWSIM_LOADED=0
 cleanup() {
+	lunatik stop "$SCRIPT" 2>/dev/null
 	ip link del "$IFNAME" 2>/dev/null
 	[ "$HWSIM_LOADED" = 1 ] && rmmod mac80211_hwsim 2>/dev/null
 }
 trap cleanup EXIT
+cleanup
 
 ktap_header
 ktap_plan 3

--- a/tests/netlink/nl80211_station.lua
+++ b/tests/netlink/nl80211_station.lua
@@ -61,7 +61,3 @@ station:del{ifindex = ifindex, mac = STA}
 assert(not present(), "station still listed after del")
 print("netlink nl80211_station: deleted")
 
-ap:stop{ifindex = ifindex}
-netlink.rt.link():set{ifindex = ifindex, up = false}
-netlink.nl80211.interface():del{ifindex = ifindex}
-

--- a/tests/netlink/nl80211_station.sh
+++ b/tests/netlink/nl80211_station.sh
@@ -18,10 +18,12 @@ source "$(dirname "$(readlink -f "$0")")/../lib.sh"
 
 HWSIM_LOADED=0
 cleanup() {
+	lunatik stop "$SCRIPT" 2>/dev/null
 	ip link del "$IFNAME" 2>/dev/null
 	[ "$HWSIM_LOADED" = 1 ] && rmmod mac80211_hwsim 2>/dev/null
 }
 trap cleanup EXIT
+cleanup
 
 ktap_header
 ktap_plan 4


### PR DESCRIPTION
## Problem

Running the netlink suite (`tests/netlink/run.sh`), a later nl80211 test would fail: `ENFILE` from accumulated resources, and an intermittent `ENETDOWN`.

## Two causes, two commits

**1. Leaked one-shot runtimes (`ENFILE`).** `run_script` runs a one-shot script with `lunatik run`, which leaves the runtime registered (it shows up in `lunatik list` until stopped); the caller must stop it, as `percpu.sh` already does. The nl80211 tests' `cleanup()` only tore down the interface and hwsim, never the script, so each left its runtime and ~5-6 netlink sockets registered. Across a suite run they accumulated until a later test hit `ENFILE`. Fix: `lunatik stop "$SCRIPT"` in each nl80211 `cleanup()`, and call `cleanup` up front to clear any leftover from an aborted run. The shared `run_script` helper is left unchanged so the persistent-runtime tests (softirq hooks in `channel`/`connmark`, `kprobe_concurrent`, `percpu`) keep their runtime alive.

**2. A racy teardown tail (`ENETDOWN`).** `nl80211_station.lua` ended by stopping the AP and deleting the interface -- redundant with its `.sh` `cleanup()`. That trailing `STOP_AP` failed about one run in six: its `NL80211_FLAG_NEED_NETDEV_UP` gate found the netdev not running. Cause (ftrace stack trace): whatever manages interfaces on the host claims the freshly created AP netdev and administratively brings it down, clearing the running state the stop requires -- observed here as **NetworkManager** (`RTM_NEWLINK` -> `__dev_close_many` -> `ieee80211_do_stop`). That down lands after the assertions, where the teardown was; dropping the redundant stop removes the exposed operation and the `.sh` cleanup covers the rest.

## Evidence

- ftrace on `ieee80211_do_stop` catches the host manager (NetworkManager here) bringing the interface down via `__dev_change_flags` -> `__dev_close_many` on the failing run.
- With the teardown removed (this PR) and the manager active: 40/40 via the `.sh` (plus an earlier 0/20 and a reload-paced 0/12) -- ~70 runs, no failures.

## Scope

The fix is portable: it keeps the test independent of whatever manages interfaces on the host, by removing the operation such a manager's asynchronous down lands on -- it does not matter which manager it is. Tying the test to a specific one (e.g. NetworkManager's `unmanaged-devices`) is deliberately avoided; that would not carry to other distros or to CI. `nl80211_ap.lua`'s asserted `ap:stop` shares the same exposure (a smaller window, before the manager reacts), never observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
