### PR TITLE
docs: add the LPeg binding project plan

### DIFF
--- a/docs/design/lpeg/README.md
+++ b/docs/design/lpeg/README.md
@@ -1,0 +1,45 @@
+# LPeg binding
+
+Working documents for `lpeg`: bringing Roberto Ierusalimschy's
+[LPeg](https://www.inf.puc-rio.br/~roberto/lpeg/) — Parsing Expression Grammars for Lua — into the
+kernel Lua state, so kernel scripts can parse and match structured input (protocol headers, HTTP
+request lines, config, byte formats) with a real grammar engine and captures, instead of hand-rolled
+byte walking or the limited Lua pattern library.
+
+This is the parsing/matching **primitive**, not an application. It is the first of a small family of
+matching-layer projects; the Aho-Corasick multi-pattern module and the radix router are separate. An
+HTTP parser ships here only as the *demonstration* of the engine, not as a gateway.
+
+| Document | What it is for |
+|----------|----------------|
+| [plan.md](plan.md) | Current state, gap analysis, phases, non goals, risks, definition of done |
+| [api.md](api.md) | The Lua API (`lpeg` combinators, the `re` grammar-string module), matching a `data` object, the compile/match discipline, worked examples |
+| [kernel-notes.md](kernel-notes.md) | Verified facts: Lua 5.5 API compatibility, the C-stack budget, allocation context, lazy compilation, licensing, what to drop/stub, packaging |
+| [testing.md](testing.md) | Test strategy and the coverage matrix |
+
+Start with `plan.md`. Read `kernel-notes.md` before writing or vendoring any C.
+
+## Working on this
+
+The repository conventions that apply to every change here (build, test, style, kernel context rules,
+commit discipline) are in [AGENTS.md](../../../AGENTS.md) at the root of the repository. Read it once
+before the first patch. If you use an AI assistant, point it at that file and at `kernel-notes.md`.
+
+What is unusual about this project, and what to keep in mind:
+
+1. **This vendors third-party C.** Unlike every other Lunatik module, most of the code is upstream
+   LPeg, copied in verbatim. Keep the upstream files diffable against their origin (upstream names,
+   upstream copyright headers — do not stamp them with the Lunatik header), so the vendored copy can be
+   updated later. Only the thin glue file is Lunatik's.
+2. **The risk is the kernel C stack, not the matcher.** LPeg is already kernel-shaped — every
+   allocation goes through the Lua allocator and the matching VM is an explicit stack machine, not C
+   recursion. The one real hazard is that it puts ~9.6 KB of arrays on the C stack per match, against a
+   16 KB kernel stack, and that patterns compile lazily on first match. `kernel-notes.md` is mostly
+   about taming those two facts.
+3. **Compile in process context, match anywhere (carefully).** Pattern compilation allocates and
+   recurses over the pattern tree; do it from a process runtime, never per-packet in softirq.
+
+## Status
+
+Tracked in the epic issue in this repository. Each phase lands as its own pull request.
+

--- a/docs/design/lpeg/api.md
+++ b/docs/design/lpeg/api.md
@@ -1,0 +1,147 @@
+# Proposed Lua API: `lpeg` and `re`
+
+This is a design proposal, not a specification. The `lpeg` and `re` surfaces are **upstream LPeg's**
+and are not open for redesign — vendoring them faithfully is a project goal. What *is* proposed here is
+the thin Lunatik-specific surface: how a pattern matches a `data` object, the compile/match
+discipline for kernel contexts, and how the modules are exposed. Anything that conflicts with a kernel
+constraint (`kernel-notes.md`) loses.
+
+Two modules:
+
+* `lpeg` — the C library, exposed exactly as upstream `luaopen_lpeg` builds it (`luaL_newlib` over
+  `pattreg`: `match`, `P`, `R`, `S`, `C`, `Ct`, `Cg`, `Cc`, `Cp`, `Cmt`, `B`, `V`, grammars, …);
+* `re` — the pure-Lua grammar-string front end (`lib/re.lua`, installed verbatim), which `require`s
+  `lpeg`.
+
+## Conventions
+
+* A **pattern** is a userdata whose uservalue holds its `ktable` (subpattern references and capture
+  constants); it is ordinary GC-managed Lua state. Nothing to free by hand.
+* Compilation happens in a **process** runtime; matching happens wherever the pattern is used, subject
+  to the softirq rules below.
+* The subject of a match is a Lua string **or** a `data` object; captures come back as Lua values.
+
+## Using it — combinators
+
+    local lpeg = require("lpeg")
+
+    local digit  = lpeg.R("09")
+    local number = lpeg.C(digit^1) / tonumber      -- capture, converted
+    local ws     = lpeg.S(" \t")^0
+    local pair   = lpeg.Ct(number * ws * number)   -- table capture
+
+    local t = lpeg.match(pair, "12   34")          -- {12, 34}
+
+## Using it — the `re` grammar syntax
+
+    local re = require("re")
+
+    local ip = re.compile[[
+      ip     <- octet "." octet "." octet "." octet
+      octet  <- %d %d? %d?
+    ]]
+
+    print(lpeg.match(ip, "192.168.0.1"))           -- end position, or nil
+
+`re.match(subject, patt)` and `re.compile(grammar)` behave as upstream. `re` is Lua only; it adds no
+kernel surface of its own beyond needing `lpeg` loaded.
+
+## Matching a `data` object
+
+The one genuinely new entry point. Upstream `lp_match` takes the subject via `luaL_checklstring`; a
+kernel hook holds packet bytes as a `data` object, not a Lua string, and copying a packet to a string
+per match is exactly the cost this binding exists to avoid.
+
+Proposal: `lpeg.match` accepts a `data` object as the subject and reads its buffer `(ptr, len)`
+directly, with no copy.
+
+    local function hook(skb)
+        local payload = skb:data()                 -- a data object, no copy
+        local m = lpeg.match(http_request, payload)
+        ...
+    end
+
+Lifetime rule: the `data` buffer must stay valid for the duration of the match. Inside a hook it does
+(the `skb` is live for the callback). A pattern must not stash the subject and match it later against a
+buffer that has been freed — matching is synchronous and does not retain the buffer.
+
+Open question: whether this is a `data`-aware branch inside the existing `lpeg.match` (preferred — one
+function, subject is string-or-data) or a separate `lpeg.matchdata`. The single-function form reads
+better and mirrors how `skb:data()` already returns something the rest of the API consumes.
+
+## The compile / match discipline
+
+This is the part that is Lunatik's, not LPeg's, and it exists because of the kernel stack and context
+rules in `kernel-notes.md`.
+
+LPeg compiles a pattern **lazily**, on its first match (`prepcompile` inside `lp_match`). In userspace
+that is invisible. In the kernel it means the first match decides *where compilation runs* — and
+compilation allocates and recurses over the pattern tree, which must not happen in softirq.
+
+Proposal: an explicit compile step, so a pattern that will be used from a softirq hook is compiled
+ahead of time in the process runtime that builds it.
+
+    -- process context (script body, runs once at runtime creation):
+    local http_request = lpeg.compile(grammar)     -- forces prepcompile now
+
+    -- softirq hook (later): matches an already-compiled pattern, never compiles
+    lpeg.match(http_request, payload)
+
+`lpeg.compile(patt)` returns the same pattern, compiled. If the maintainer prefers not to add API, the
+alternative is a documented rule ("match once in process context to warm the pattern"), but an explicit
+`compile` is harder to get wrong and self-documenting. Either way, **a softirq runtime that reaches an
+uncompiled pattern raises** rather than compiling in atomic context.
+
+Matching itself from softirq is allowed once the pattern is compiled, the on-stack arrays are shrunk
+(build-time, `kernel-notes.md`), and the pattern is linear by construction. If phase 3 finds softirq
+matching cannot be made safe, `lpeg.match` from a non-sleepable runtime raises via the
+`lunatik_cannotsleep` path, and matching is process-only — a documented restriction, not a crash.
+
+## Match-time captures (`Cmt`)
+
+`Cmt(patt, f)` calls the Lua function `f` *during* the match. That is legal and useful (a rule can run
+code as it parses), but the callback runs in the matching runtime's context: in a softirq runtime it
+must not sleep, the same rule every Lunatik softirq callback already follows. Documented, and covered
+by a test.
+
+## Worked example: HTTP request line and Host
+
+The demonstration of the engine — a grammar, not a gateway. It parses one buffer; it does not
+reassemble TCP (that is the `stream` project), and the example says so.
+
+    local lpeg = require("lpeg")
+    local C, Ct, P, R, S = lpeg.C, lpeg.Ct, lpeg.P, lpeg.R, lpeg.S
+
+    local crlf   = P"\r\n"
+    local sp     = P" "
+    local token  = C((R("!~") - sp)^1)                    -- non-space run
+    local method = token
+    local target = token
+    local version= C(P"HTTP/" * R"09" * P"." * R"09")
+
+    local reqline = Ct(method * sp * target * sp * version * crlf)
+
+    local hdr_host = P"Host:" * S" \t"^0 * C((1 - crlf)^1)
+    local host     = (crlf^-1 * (hdr_host + (1 - crlf)^0 * crlf))^0
+
+    local request  = lpeg.compile(Ct(reqline * (host + P(1))))   -- compiled in process
+
+    -- in a hook (softirq), against packet bytes with no copy:
+    local function classify(payload)
+        local r = lpeg.match(request, payload)
+        -- r[1] = {method, target, version}; capture Host as needed
+        return r
+    end
+
+The grammar produces structured fields; a routing decision on top of them belongs to the router
+project, not here.
+
+## Open questions for review
+
+1. `lpeg.match` accepting a `data` subject (one function) versus a separate `lpeg.matchdata`.
+2. Adding `lpeg.compile` versus documenting a warm-up match. (Proposal: add it.)
+3. Whether `re` should be installed unconditionally or only when `lpeg` is present (it `require`s
+   `lpeg`, so it is inert without it — installing both together is simplest).
+4. Whether to expose `lpeg.setmaxstack` (it exists upstream, sets the per-state backtrack cap stored
+   in the registry) so a script can tune the heap-spill threshold, or fix it at a kernel-safe value.
+

--- a/docs/design/lpeg/kernel-notes.md
+++ b/docs/design/lpeg/kernel-notes.md
@@ -1,0 +1,167 @@
+# Kernel notes: LPeg binding
+
+Reference sheet for the `lpeg` binding. Everything below was checked firsthand against the vendored
+Lua in this repository (`lua/`, version 5.5.0) and LPeg 1.1.0 source (upstream
+`roberto-ieru/LPeg`). Re-check on the LPeg version you actually vendor and the kernel you build for.
+
+Unlike the other project notes, most of the "kernel API" here is not the Linux kernel — it is the Lua
+C API and LPeg's own internals, because the work is porting a userspace C library into the kernel Lua
+state rather than calling kernel subsystems. LPeg touches no Linux kernel API directly; it allocates
+only through the Lua allocator and computes.
+
+## Licensing
+
+LPeg is **MIT** ("Copyright 2007-2023, Lua.org & PUC-Rio", `lptypes.h:3`, license in `lpeg.html`) —
+the same license as Lua, GPL-compatible, and compatible with Lunatik's `MIT OR GPL-2.0-only`. No
+licensing blocker.
+
+Vendoring rule: the upstream `.c`/`.h` files keep their **own** copyright header, unchanged. Do not
+stamp them with the Lunatik/Ring Zero header — they are third-party code, and the header is how a
+reviewer and a future updater tell vendored code from ours. Only `lib/lualpeg.c` (the glue) carries the
+Lunatik header. Record the imported LPeg version somewhere durable (a line in the glue file or a
+`lib/lpeg/VERSION`), so the copy can be refreshed against upstream later.
+
+## Lua 5.5 compatibility — verified present
+
+The vendored Lua is 5.5.0 (`LUA_VERSION_NUM == 505`, `lua/lua.h`). LPeg 1.1.0 advertises Lua 5.1–5.4,
+but its Lua 5.1-only code is behind `#if LUA_VERSION_NUM == 501` (`lptypes.h:28`) — `lua_getfenv`,
+`lua_setfenv`, `lua_objlen`, `lua_equal`, `luaL_register` are never reached on the 5.5 path. The
+symbols LPeg uses on its modern path were each checked against `lua/lua.h` and `lua/lauxlib.h` and are
+all present:
+
+    lua_newuserdata      -> #define lua_newuserdata(L,s) lua_newuserdatauv(L,s,1)   (lua.h:455)
+    lua_getuservalue     -> #define over lua_getiuservalue
+    lua_setuservalue     -> #define over lua_setiuservalue
+    lua_rawgeti, lua_geti, lua_rawlen, lua_compare                                  (present)
+    luaL_newlib, luaL_setfuncs, luaL_testudata, luaL_buffinit, luaL_addchar,
+    luaL_pushresult, luaL_checkinteger, luaL_optinteger, luaL_checklstring          (present)
+
+So the C API surface is satisfied. What inspection cannot rule out is 5.4→5.5 **semantic** drift.
+Therefore phase 0's real deliverable is a **clean compile plus a trivial passing match**, not a
+reading — treat any build error as expected work, not a surprise. `LUA_COMPAT_GLOBAL` is on in the
+vendored `luaconf.h`; the deprecated math-lib compat is off (irrelevant to LPeg).
+
+## The library entry point already fits Lunatik
+
+Upstream `luaopen_lpeg` (`lptree.c:1361`) builds the module with `luaL_newlib(L, pattreg)` over the
+`pattreg` table (`lptree.c:1320`: `match`, `P`, `S`, `R`, `C`, `Ct`, …) and sets the backtrack-stack
+cap in the registry (`lua_setfield(L, LUA_REGISTRYINDEX, MAXSTACKIDX)`, `lptree.c:1364`). That is
+exactly the shape a Lunatik opener wraps; the glue is `LUNATIK_NEWLIB`-thin.
+
+## The C-stack budget — the load-bearing constraint
+
+LPeg's matcher puts fixed arrays on the C stack, in one frame:
+
+* `Stack stackbase[INITBACK]` at `lpvm.c:232`, with `INITBACK = MAXBACK` (`lpvm.c:17`) and
+  `MAXBACK = 400` (`lptypes.h:53`). `struct Stack` is `{const char *s; const Instruction *p; int
+  caplevel}` = 24 bytes on 64-bit → **9,600 bytes**.
+* `Capture capture[INITCAPSIZE]` with `INITCAPSIZE = 32` (`lptypes.h:65`), 8 bytes each → 256 bytes.
+
+≈ 9.9 KB in a single frame, before callees, on a kernel stack that is **16 KB** total (`THREAD_SIZE`)
+and shared with whatever called into Lua. In softirq that is dangerous.
+
+Both limits are `#if !defined(...)` overridable (`lptypes.h:52`, `lpvm.c:16`). Build with small values:
+
+    ccflags-y += -DMAXBACK=32 -DINITBACK=32 -DMAXRECLEVEL=40
+
+The excess backtrack depth then spills to a **Lua-allocated** stack — `doublestack` (`lpvm.c:133`)
+uses `lua_newuserdata`, and the depth is capped at the registry `MAXSTACKIDX` value, raising
+`"backtrack stack overflow"` (`lpvm.c:129`) rather than smashing the kernel stack. So shrinking the
+on-stack array trades a few hundred bytes of frame for a heap allocation on deep patterns, which is the
+correct trade in the kernel. Pick the exact numbers in phase 0 and validate the spill in phase 3.
+
+## Allocation — all through the Lua allocator
+
+There is no raw `malloc`/`free`/`realloc` in LPeg. Every allocation goes through the Lua allocator or
+`lua_newuserdata`:
+
+* bytecode: `realloccode`/`freecode` fetch `lua_getallocf` and call it (`lpcode.c:420-431, 457`);
+* backtrack-stack growth: `doublestack` → `lua_newuserdata` (`lpvm.c:133`);
+* capture-list growth: `growcap` → `lua_newuserdata` (`lpvm.c:109`);
+* trees/charsets/patterns: `lua_newuserdata` (`lptree.c`).
+
+Consequence: LPeg inherits the `GFP_` context of the Lunatik runtime automatically. In a process
+runtime that is `GFP_KERNEL`; in a softirq runtime it is `GFP_ATOMIC`. This is exactly the property we
+want — no allocator to port — but it means a pattern whose match needs to grow the backtrack/capture
+stack in softirq is doing a `GFP_ATOMIC` allocation, which can fail under pressure and must be handled
+as a clean match error, not a crash. Keeping patterns shallow (so they never grow past the on-stack
+arrays) avoids it entirely.
+
+## Lazy compilation — why an explicit compile step
+
+`lp_match` compiles on demand: `code = (p->code != NULL) ? p->code : prepcompile(L, p, 1)`
+(`lptree.c:1229`). Compilation (`lpcode.c` `codegen` and the analysis passes) is **C-recursive over the
+pattern tree**, bounded only by tree size (`MAXPATTSIZE ≈ 32k`, `lptypes.h`), and allocates. It must
+run in a process runtime.
+
+Because compilation is lazy, "where the first match runs" decides "where compilation runs". If a
+softirq hook matches an uncompiled pattern, it compiles in softirq — recursion and `GFP_ATOMIC`
+allocation in atomic context. The binding must prevent that: expose `lpeg.compile(patt)` (calls
+`prepcompile` now, in process context) — see `api.md` — and make a softirq match of an uncompiled
+pattern raise rather than compile.
+
+## Matching VM — not C-recursive
+
+`match()` (`lpvm.c:241`) is a single `for (;;)` over opcodes with `goto fail`, pushing calls and
+choices onto the explicit `Stack` array (`ICall`/`IChoice`/`IRet`). It does not recurse in C, so match
+depth is bounded by the (now heap-backed) stack, not the C stack. Good — the only C recursion in the
+whole match path is capture extraction.
+
+## Capture extraction — bounded C recursion
+
+`pushcapture`/`pushnestedvalues` recurse, bounded by `MAXRECLEVEL = 200` (`lpcap.c:498`, checked at
+`:510`). 200-deep C frames on top of the match frame is a kernel-stack risk; reduce it with
+`-DMAXRECLEVEL` (40 is generous for the parsing this binding targets) and avoid pathologically nested
+captures. This runs only when a match with captures succeeds, not on the scanning hot path.
+
+## Backtracking cost — a CPU-DoS note, not a stack note
+
+PEG matching with `*`/`+` and ordered choice has no memoization and can be super-linear (quadratic, and
+constructed-case exponential) in subject length. Both target use cases take attacker-controlled input,
+so a badly written pattern is a softirq-time CPU DoS. The stack cap protects the stack, **not** CPU
+time. Mitigation is authorship, not a knob: patterns must be linear by construction, and LPeg's own
+optimizer helps (`getfirst`/`ITestChar`/`ISpan` turn many idioms into non-backtracking scans). Say
+this in the docs; it is the one hazard a build flag does not fix.
+
+## What to drop or stub
+
+* **`lpprint.c`** — debug printers (`printtree`, `printcode`), all `stdio.h`/`printf`. Drop it from the
+  Kbuild objects entirely and stub its two callable exports (`lp_print*`) if anything references them;
+  the VM's own `printf` calls are behind `#if defined(DEBUG)` (`lpvm.c:242-248`) and never compiled.
+* **`lp_locale`** in `lptree.c:1305` — the only `ctype.h` user (`isalnum`/`isalpha`/…), implementing
+  `lpeg.locale()`. Drop the entry from `pattreg` (`lptree.c:1338`), or back it with the kernel's own
+  `_ctype[]` table if the feature is wanted. Not a match-path dependency.
+
+After those two, the remaining libc surface is `string.h` (memcpy/memset/memcmp — in kernel),
+`limits.h` (in kernel), and `assert.h` (compiles out with `-DNDEBUG`). No FPU: LPeg is integer-only
+save one comment, matching Lunatik's integers-only invariant.
+
+## Packaging
+
+Mirror `luacrypto` (multi-`.c` module). Vendored sources under `lib/lpeg/`, glue in `lib/lualpeg.c`:
+
+    obj-$(CONFIG_LUNATIK_LPEG) += lualpeg.o
+    lualpeg-objs := lualpeg.o lpeg/lpvm.o lpeg/lpcap.o lpeg/lpcode.o \
+                    lpeg/lpcset.o lpeg/lptree.o
+
+Confirm in phase 0 that Kbuild resolves objects in a subdirectory (it does for out-of-tree modules
+with the relative path as above); if it fights, fall back to flat `lib/lp_*.c` names, but prefer the
+subdir so the vendored files keep their upstream names and stay diffable. `re.lua` installs like any
+`lib/*.lua` to `/lib/modules/lua/`.
+
+`ccflags-y` for the module carries the `-D` limits above plus `-DNDEBUG`, and the include path for the
+vendored headers.
+
+## Summary of the verified facts
+
+| Fact | Where | Consequence |
+|------|-------|-------------|
+| Lua 5.5 exports LPeg's ≥5.2 API surface | `lua/lua.h`, `lua/lauxlib.h` | build is plausible; confirm by compiling |
+| 9.6 KB `Stack` array on the C stack per match | `lpvm.c:232`, `lptypes.h:53` | `-DMAXBACK`/`-DINITBACK` small; validate spill |
+| all heap via Lua allocator | `lpcode.c:420`, `lpvm.c:109,133` | inherits `GFP_`; atomic-safe if shallow |
+| lazy compile on first match | `lptree.c:1229` | need `lpeg.compile`; softirq must not compile |
+| match VM is a stack machine, not C recursion | `lpvm.c:241` | match depth bounded by heap stack |
+| capture recursion bounded at 200 | `lpcap.c:498` | `-DMAXRECLEVEL` small |
+| MIT license, upstream copyright | `lptypes.h:3` | vendor verbatim; keep headers |
+| `stdio.h` only in `lpprint.c`; `ctype.h` only in `lp_locale` | grep | drop/stub both |
+

--- a/docs/design/lpeg/plan.md
+++ b/docs/design/lpeg/plan.md
@@ -1,0 +1,187 @@
+# Plan: LPeg binding
+
+Execution plan for the `lpeg` binding.
+
+## Expected results
+
+1. A kernel Lua script can build LPeg patterns with the full combinator API (`P`, `R`, `S`, `C`,
+   `Ct`, grammars, …) and match them against a Lua string, with captures.
+2. The `re` module is available, so patterns can be written in LPeg's grammar-string syntax
+   (`re.compile`, `re.match`), not only combinators.
+3. Patterns match against a `data` object (packet payload / arbitrary buffer) with no copy, not only
+   Lua strings, so hooks can parse packet bytes directly.
+4. A pattern compiled in a process runtime can be matched from a non-sleepable (softirq) runtime
+   safely — bounded C stack, atomic-context allocation — or, if that proves unsafe, matching is
+   cleanly restricted to process context with a documented reason.
+5. An example plus a KTAP suite: an HTTP request-line and `Host` parser written as an LPeg grammar,
+   proving structured field extraction in kernel Lua.
+
+## Where we are today
+
+The kernel Lua state ships the standard string library (`lua/lstrlib.c`), so `string.match` and Lua
+patterns are available — enough for a single anchored capture (`string.match(payload, "\r\nHost:
+([^\r\n]+)")`, as the conntrack L7 example does), but not for a real grammar: no ordered choice, no
+recursion, no composable rules, no typed captures. There is no PEG engine.
+
+A sweep of every local and remote branch, and of the closed issues and pull requests, found no LPeg
+code anywhere in the tree; LPeg appears only in old GSoC idea pages under `lablua`. This is a clean
+slate.
+
+What the base *does* give this project, verified:
+
+* the vendored Lua is **5.5.0** (`lua/lua.h`), and it already exports every C API symbol LPeg uses on
+  its Lua ≥ 5.2 path (see `kernel-notes.md` for the checked list);
+* `luacrypto` is a multi-`.c` module (`luacrypto-objs := …` in `lib/Kbuild`), so a multi-file
+  vendored library packages the same way;
+* `lib/*.lua` files install to `/lib/modules/lua/`, so `re.lua` ships as-is with no porting.
+
+## What is missing
+
+| Expected result | Gap |
+|-----------------|-----|
+| Combinator API in kernel Lua | LPeg's C is not built or loadable; no `lpeg` module. |
+| `re` grammar syntax | `re.lua` not installed, and it depends on `lpeg` being loadable first. |
+| Match a `data` object | `lp_match` takes a Lua string via `luaL_checklstring`; it has no path for a `data` object's buffer. |
+| Softirq matching | Untested; LPeg's on-C-stack arrays and lazy first-match compilation are unsafe in softirq as shipped. |
+| Example and tests | No suite, and no HTTP-parse example. |
+
+Supporting gaps:
+
+* the vendored sources include a debug printer (`lpprint.c`, `stdio.h`) and a locale feature
+  (`lp_locale` in `lptree.c`, `ctype.h`) that do not belong in the kernel;
+* the default `MAXBACK`/`INITBACK`/`MAXRECLEVEL` are sized for userspace, not a 16 KB kernel stack;
+* compilation is lazy (on first match), which would put pattern compilation in whatever context the
+  first match runs in — softirq, if a hook matches first.
+
+## Shape of the work
+
+One new kernel module, `lpeg` (`lib/lualpeg.c` glue plus the vendored LPeg C under `lib/lpeg/`), and
+one installed Lua file (`re.lua`). The module registers the `lpeg` library exactly as upstream's
+`luaopen_lpeg` already does (`luaL_newlib` over `pattreg`), wrapped in Lunatik's opener.
+
+The full API proposal is in `api.md`; the constraints that drive it are in `kernel-notes.md`. The one
+fact that shapes the whole project:
+
+> LPeg's matcher is not the risk — its C-stack use and its lazy compilation are. It puts ~9.6 KB of
+> arrays in a single stack frame per match (`Stack stackbase[INITBACK]`, `INITBACK = MAXBACK = 400`),
+> against a 16 KB kernel stack shared with the caller, and it compiles a pattern lazily on the first
+> match. So the project is not "port a regex engine"; it is "run an already-kernel-shaped engine
+> safely within the kernel's stack and atomic-context limits", which means shrinking the on-stack
+> arrays (`-DMAXBACK`/`-DINITBACK`), bounding capture recursion (`-DMAXRECLEVEL`), and forcing
+> compilation into process context so softirq only ever *matches* a pre-compiled pattern.
+
+The second fact worth stating up front: this vendors third-party C. The upstream files stay verbatim
+and diffable (upstream names and copyright), so the copy can be refreshed; only `lib/lualpeg.c` is
+Lunatik's. See `kernel-notes.md`.
+
+## Phases
+
+Each phase is one or more self-contained pull requests.
+
+### Phase 0: vendor and build
+
+Bring the LPeg C sources into `lib/lpeg/`, add the glue file and the Kbuild/Kconfig entries, and get
+`require("lpeg")` to load in a **process** runtime with a trivial match working
+(`lpeg.match(lpeg.P"a", "a")`). This phase carries the two things that de-risk everything else:
+
+* **prove Lua 5.5 compatibility by compiling** — the API surface is present (`kernel-notes.md`), but
+  5.4→5.5 semantic drift is only settled by a clean build and a passing trivial match, not by
+  inspection;
+* **apply the port changes**: drop `lpprint.c` from the build and stub its two callable exports; drop
+  or neutralize `lp_locale` (the `ctype.h` user); compile with small `-DMAXBACK`/`-DINITBACK` and a
+  reduced `-DMAXRECLEVEL`.
+
+Deliverables: `lib/lpeg/*` (vendored, upstream headers intact), `lib/lualpeg.c`, `lib/Kbuild` +
+`Kconfig` entries, `config.ld` and README module-table rows, a minimal `tests/lpeg/`.
+
+### Phase 1: the API surface and the `re` module
+
+Confirm the full combinator API behaves in-kernel — constructors, ordered choice, repetition,
+grammars, and every capture kind (`C`, `Ct`, `Cg`, `Cc`, `Cp`, back-references, `Cmt` match-time
+captures). Install `re.lua` and confirm the grammar-string front end. This is where the coverage
+matrix in `testing.md` gets filled for string subjects.
+
+Match-time captures (`Cmt`) call a Lua function *during* the match; document and test that this is
+fine in a process runtime and must be non-sleeping in softirq.
+
+### Phase 2: matching a `data` object
+
+Let the subject of a match be a `data` object, read as `(ptr, len)` with no copy, so a hook can parse
+packet bytes. `lp_match` currently insists on a Lua string; add a `data`-aware path (a Lunatik-side
+`lpeg.match` wrapper, or acceptance of a `data` argument in the C entry) that feeds LPeg the buffer
+directly. Decide and document the lifetime rule: the `data` must stay valid for the duration of the
+match (it is, inside a hook).
+
+### Phase 3: softirq safety
+
+Make "compile in process, match in softirq" real and proven:
+
+* add an explicit `lpeg.compile(patt)` (or document that a first match in process context compiles),
+  so a pattern reaching a softirq hook is already compiled and softirq never runs `prepcompile`;
+* validate matching from a `softirq` runtime with the shrunk stacks and atomic-context allocation,
+  under real backtracking, and confirm a deep backtrack spills to the heap or errors cleanly rather
+  than overflowing the kernel stack;
+* if any of that cannot be made safe, restrict matching to process runtimes with a
+  `lunatik_cannotsleep`-style guard and document why — an honest gate beats a machine check.
+
+This is the risk phase; it lands after the engine is otherwise proven, so a stack overflow here is
+found against a working baseline.
+
+### Phase 4: example and documentation
+
+An HTTP request-line + `Host` parser written as an LPeg grammar (the demonstration of expected result
+5), a documentation pass, and whatever API cleanup the example exposes. The example parses a single
+buffer; it explicitly does **not** reassemble TCP (that is the `stream` project) and says so, the way
+the conntrack L7 example is honest about its limits.
+
+## Sizing
+
+Sized by what fits in a reviewable pull request.
+
+| Scope | Phases |
+|-------|--------|
+| Minimum useful | 0 to 1. LPeg and `re` usable in a process runtime against Lua strings. |
+| Complete | 0 to 4. Adds `data` matching, softirq safety, and the worked example. |
+
+Phase 0 is the real gate: if the vendored code does not build cleanly against Lua 5.5, everything
+after it waits on fixing that, so it is worth doing first and carefully.
+
+## Non goals
+
+* **Being the router.** The radix/hash routing table (L2 in the architecture) is a separate,
+  pure-Lua project. This binding parses; it does not route.
+* **Being the byte source.** TCP reassembly and the stream view (L0) are a separate project. The
+  example matches one buffer and misses patterns spanning segment boundaries, by design.
+* **Being the IDS matcher.** LPeg is a single-grammar, ordered-choice, anchored matcher; it is not a
+  simultaneous multi-pattern scanner. Aho-Corasick (the next project) owns that. Do not force
+  thousands of signatures into an ordered choice here.
+* **Modifying LPeg's language or semantics.** Vendor it faithfully. The only edits are the kernel
+  port (drop `lpprint`, neutralize `lp_locale`, size the `-D` limits, the `data` subject path). Any
+  behavioural change to matching is out of scope and would break diffability against upstream.
+* **JIT or SIMD.** LPeg is a portable scalar bytecode VM; that is the point. Nothing here needs FPU.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Lua 5.5 semantic drift breaks a clean 5.4-era build | Phase 0 compiles against the vendored tree and runs a trivial match before anything else; treat a build failure as the phase's real content, not a surprise. |
+| ~9.6 KB on-C-stack arrays overflow the kernel stack in softirq | Shrink with `-DMAXBACK`/`-DINITBACK`; the overflow path already spills to the Lua-allocated stack. Prove it in phase 3 with a deep-backtrack test, not by argument. |
+| Lazy compilation runs `prepcompile` in softirq on first match | Force compilation in process context (`lpeg.compile` or a warm-up match); phase 3 owns this. |
+| Backtracking is super-linear on adversarial input → softirq CPU DoS | Patterns must be linear by construction; document it, and lean on LPeg's own `ITestChar`/`ISpan` optimizations. The stack cap protects the stack, not CPU time — say so. |
+| Vendored copy drifts from upstream and becomes unmaintainable | Keep upstream files verbatim (names, copyright); confine all Lunatik code to `lib/lualpeg.c`; record the imported LPeg version. |
+| `Cmt` match-time captures call Lua mid-match | Fine in process; in softirq the callback must not sleep. Documented and tested. |
+
+## Definition of done, per phase
+
+1. builds clean on the target kernel, no new warnings;
+2. LDoc on the Lunatik-authored surface (the glue module and any added functions); the vendored files
+   keep their upstream docs; `lpeg`/`re` listed in `config.ld` in alphabetical order;
+3. a row in the README module table;
+4. a test in `tests/lpeg/`, wired into that suite's `run.sh`, and described in `tests/README.md`;
+5. the test skips (not fails) when a needed config is absent;
+6. the full suite still passes: `sudo lunatik test`;
+7. error paths audited: for every raise, whatever was acquired is released (patterns are GC-managed
+   userdata, so this is mostly the glue's argument checking);
+8. commits are small and each one stands alone; vendored imports are one reviewable commit, distinct
+   from the Lunatik glue.
+

--- a/docs/design/lpeg/testing.md
+++ b/docs/design/lpeg/testing.md
@@ -1,0 +1,94 @@
+# Testing the LPeg binding
+
+Lunatik's tests are shell scripts emitting KTAP, driving a kernel Lua script and asserting on what it
+prints to `dmesg`. `tests/crypto/` and `tests/set/` are the closest models — a C-backed library
+exercised from a kernel Lua script over a matrix of inputs, no packets or namespaces needed. Read
+`tests/lib.sh` (`run_test`, `mark_dmesg`, `dmesg_since`, `check_dmesg`, `ktap_skip`) first.
+
+Run everything with `sudo lunatik test`, one suite with `sudo lunatik test lpeg`.
+
+## What this suite needs that others do not
+
+Two things, both cheap:
+
+**A vendored-behaviour baseline.** Because most of the code is upstream LPeg, a chunk of the value is
+proving the *port* did not change LPeg's behaviour. The most economical way is to lift a subset of
+LPeg's own `test.lua` assertions (the parts that do not need `io`/`os`/coroutines) and run them in the
+kernel state. A divergence there means the port broke something; a plain pass means the vendored engine
+behaves in-kernel as upstream. Keep this a small, curated subset, not the whole upstream test file.
+
+**A stack-safety test that must not crash the machine.** Phase 3's deep-backtrack test deliberately
+drives the matcher past the shrunk on-stack arrays to prove the heap spill and the clean
+`"backtrack stack overflow"` error, rather than a silent kernel-stack overflow. Run it in a process
+runtime first (where a bug is a clean error), and only then in softirq. If it can wedge a machine, it
+is written wrong.
+
+## Test matrix
+
+Coverage means the matrix of construct × subject × context, including the successes and the clean
+failures, not a list of features.
+
+### Phase 0: it builds and loads
+
+| Test | Proves |
+|------|--------|
+| `load.sh` | `require("lpeg")` loads in a process runtime; `lpeg.match(lpeg.P"a","a")` returns 2, `lpeg.match(lpeg.P"a","b")` returns nil |
+| `version.sh` | the imported LPeg version is what the vendored tree records (guards against an accidental partial import) |
+
+### Phase 1: the API surface (string subjects)
+
+| Test | Proves |
+|------|--------|
+| `basic.sh` | `P`, `R`, `S`, literals, ordered choice `+`, sequence `*`, repetition `^`, `-` (difference), `#` (lookahead) each match and fail as specified |
+| `captures.sh` | `C`, `Ct`, `Cg`/back-reference, `Cc`, `Cp`, `Cs` each return the right Lua values; a `/` function/string/table capture transforms correctly |
+| `grammar.sh` | a recursive grammar (balanced parens, a small arithmetic grammar) matches nested input and rejects malformed input |
+| `re.sh` | `re.compile`/`re.match` parse the grammar-string syntax and agree with the equivalent combinators |
+| `cmt.sh` | a `Cmt` match-time capture calls its Lua function during the match and its return steers the match |
+| `nomatch.sh` | failed matches return nil (not an error) at the right position; a partial match reports the right end position |
+
+### Phase 2: `data` subjects
+
+| Test | Proves |
+|------|--------|
+| `data_match.sh` | the same pattern matches a `data` object and a Lua string with identical results, no copy |
+| `data_offset.sh` | matching from an init position into a `data` buffer works; out-of-range init is handled |
+| `data_lifetime.sh` | a match consumes the `data` synchronously; the documented "do not stash and match later" rule holds (the buffer is not retained) |
+
+### Phase 3: contexts and stack safety
+
+| Test | Proves |
+|------|--------|
+| `compile_context.sh` | `lpeg.compile` in a process runtime produces a pattern that a softirq runtime matches without compiling; a softirq match of an *uncompiled* pattern raises rather than compiling |
+| `softirq_match.sh` | a compiled, linear pattern matches packet bytes from a `softirq` runtime (driven through a netfilter/XDP hook) and returns the right captures |
+| `deep_backtrack.sh` | a pattern that exceeds the shrunk on-stack backtrack array spills to the heap and either matches or raises `"backtrack stack overflow"` cleanly — the machine survives; run in process first, then softirq |
+| `atomic_alloc.sh` | a softirq match that must grow the capture/backtrack stack under `GFP_ATOMIC` either succeeds or fails as a clean match error, never oopses |
+| `cmt_softirq.sh` | a `Cmt` callback in a softirq runtime that does not sleep works; documentation states a sleeping callback is illegal there |
+
+`compile_context.sh` and `deep_backtrack.sh` are the two that justify the whole phase; write them
+before declaring softirq support done. If phase 3 concludes softirq matching cannot be made safe,
+these become the tests that a non-sleepable `lpeg.match` raises cleanly, and `softirq_match.sh` is
+removed with the reason recorded.
+
+### Phase 4: the example
+
+| Test | Proves |
+|------|--------|
+| `example_http.sh` | the HTTP request-line + `Host` grammar extracts method, target, version and host from a well-formed request buffer, and rejects a malformed one |
+| `example_partial.sh` | the example behaves as documented on a buffer that ends mid-request (no crash, a clean no-match) — the honest single-buffer limitation |
+
+## Conventions to follow
+
+* skip, do not fail, when a needed config is absent;
+* mark `dmesg` before the run, read only what came after, and `check_dmesg` at the end;
+* `lunatik run` exits 0 even when the script fails to load — assert on output, never on exit status;
+* the `.sh` carries the description; the `.lua` gets one line pointing back at it;
+* one `.sh` per row above, wired into `tests/lpeg/run.sh` and described in `tests/README.md`, in the
+  same commit as the code it tests.
+
+## A note on where these run
+
+Everything except the phase-3 softirq rows runs in a plain process runtime and needs nothing special.
+The softirq rows need a netfilter or XDP hook to carry the match into softirq context; model them on
+the existing `tests/` that drive loopback traffic, and confine any packet matching to a scratch
+port/interface so a matcher bug cannot disturb the machine's real traffic.
+


### PR DESCRIPTION
Execution material for the LPeg epic (#698), in the same shape as the other
`docs/design/<theme>/` sets: plan, proposed API, verified kernel/Lua reference, test strategy.

`docs/design/lpeg/` covers bringing [LPeg](https://www.inf.puc-rio.br/~roberto/lpeg/) — Parsing
Expression Grammars for Lua — into the kernel Lua state, so scripts can parse structured input
(protocol headers, HTTP request lines, byte formats) with a grammar engine and captures instead of
hand-rolled byte walking or the limited Lua pattern library. It is the parsing/matching primitive from
`reports/matching_architecture.md`, not an application: an HTTP parser ships only as the demonstration.

The design turns on one fact, and the notes exist so a contributor does not learn it the hard way:

> LPeg is already kernel-shaped — every allocation goes through the Lua allocator and the matching VM
> is an explicit stack machine, not C recursion. The risk is that it puts ~9.6 KB of arrays in one
> C-stack frame per match against a 16 KB kernel stack, and compiles a pattern lazily on first match.
> So the work is running an already-kernel-shaped engine within the kernel's stack and atomic-context
> limits — shrinking the on-stack arrays (`-DMAXBACK`/`-DINITBACK`), bounding capture recursion, and
> forcing compilation into process context so a softirq hook only ever matches a pre-compiled pattern.

Two enabling facts were verified firsthand against the tree: the vendored Lua is 5.5.0 and already
exports every C API symbol LPeg uses on its Lua ≥ 5.2 path (the 5.1-only calls are behind
`#if LUA_VERSION_NUM == 501`), and LPeg is MIT (dual-compatible with Lunatik). The residual risk is
5.4→5.5 semantic drift, which only a clean compile settles — that is phase 0's real content.


