### PR TITLE
docs: sweep by role and re-read the pull request after a rewrite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,11 @@ the body.
   first.
 * After squashing, re read the comments and commit bodies so they describe the final state rather than
   the path taken.
+* Naming an existing literal is done by visiting every call site of what carries it: sweep for the
+  function's callers or the field's users, not for the literal, which misses positional arguments.
+* A force-push that restructures a branch is not done until the pull request title and body are
+  re-read against it. They describe the branch; a rewrite that drops or replaces a mechanism turns
+  them into fiction the reviewer reads first.
 * Do not commit directly to `master`.
 * Copyright years: a new file carries the current year; a modified file extends its range to include
   it.


### PR DESCRIPTION
Two rules from the #678 round, one per miss.

A literal that gains a name was swept by grepping for the literal next to a keyword, which missed the one call site passing it positionally; the sweep that cannot miss is by the callers of the function that carries the value.

A branch restructure dropped a mechanism the pull request body still described; nothing in the tree points at the body, so no in-repo discipline catches it. Re-reading the title and body is now part of finishing a force-push.