### PR TITLE
examples/filter: fix vmlinux.h dependency for https.o

### DIFF
--- a/examples/filter/Makefile
+++ b/examples/filter/Makefile
@@ -1,12 +1,12 @@
-# SPDX-FileCopyrightText: (c) 2023-2024 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-FileCopyrightText: (c) 2023-2026 Ring Zero Desenvolvimento de Software LTDA
 # SPDX-License-Identifier: MIT OR GPL-2.0-only
 
-all: vmlinux https.o
+all: https.o
 
-vmlinux:
-	bpftool btf dump file /sys/kernel/btf/vmlinux format c > vmlinux.h
+vmlinux.h:
+	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $@
 
-https.o: https.c
+https.o: https.c vmlinux.h
 	clang -target bpf -Wall -O2 -c -g $<
 
 clean:


### PR DESCRIPTION
Rename the vmlinux target to vmlinux.h and make https.o depend on it, so bpftool regenerates the header only when needed instead of running unconditionally on every build.