### PR TITLE
xdp: reject a zero-sized kfunc key

### DIFF
--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -8,6 +8,16 @@
 
 #include "lib/luarcu.h"
 
+/* a zero size is allowed by the verifier and would underflow the length */
+static inline int lunatik_ebpf_checkkey(char *key, size_t key_sz, size_t *keylen)
+{
+	if (unlikely(key_sz == 0))
+		return -1;
+	*keylen = key_sz - 1;
+	key[*keylen] = '\0';
+	return 0;
+}
+
 static inline int lunatik_ebpf_checkruntimes(lunatik_object_t **runtimes, lunatik_object_t **percpu)
 {
 	static const char runtimes_key[] = "runtimes";
@@ -23,8 +33,10 @@ static inline lunatik_object_t *lunatik_ebpf_lookupruntime(lunatik_object_t **ru
 		lunatik_object_t **percpu, char *key, size_t key_sz, int cpuid)
 {
 	lunatik_object_t *runtime = NULL;
-	size_t keylen = key_sz - 1;
-	key[keylen] = '\0';
+	size_t keylen;
+
+	if (lunatik_ebpf_checkkey(key, key_sz, &keylen) != 0)
+		return NULL;
 	if (unlikely(lunatik_ebpf_checkruntimes(runtimes, percpu) != 0)) {
 		pr_err_ratelimited("couldn't find _ENV.runtimes or _ENV.percpu\n");
 		return NULL;

--- a/tests/README.md
+++ b/tests/README.md
@@ -308,3 +308,9 @@ BTF, or `bpftool` or `clang` is unavailable.
 - **xdp attach**: `xdp.attach` refuses a sleepable runtime with "runtime
   context mismatch".
 
+- **xdp zero-key**: an eBPF program calling `bpf_luaxdp_run` with a
+  zero-sized key (which the verifier accepts) is rejected in the kfunc
+  instead of underflowing the length into an out-of-bounds access. The program
+  drops on rejection, so a working guard blocks the ping, proving the
+  kfunc ran and returned without crashing.
+

--- a/tests/xdp/Makefile
+++ b/tests/xdp/Makefile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: (c) 2026 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
 # SPDX-License-Identifier: MIT OR GPL-2.0-only
 
-all: xdp_pass.bpf.o xdp_drop.bpf.o xdp_detach.bpf.o
+all: xdp_pass.bpf.o xdp_drop.bpf.o xdp_detach.bpf.o xdp_zerokey.bpf.o
 
 vmlinux.h:
 	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $@
@@ -15,6 +15,9 @@ xdp_drop.bpf.o: xdp_drop.bpf.c vmlinux.h
 xdp_detach.bpf.o: xdp_detach.bpf.c vmlinux.h
 	clang -target bpf -Wall -O2 -c -g $<
 
+xdp_zerokey.bpf.o: xdp_zerokey.bpf.c vmlinux.h
+	clang -target bpf -Wall -O2 -c -g $<
+
 clean:
-	rm -f vmlinux.h xdp_pass.bpf.o xdp_drop.bpf.o xdp_detach.bpf.o
+	rm -f vmlinux.h xdp_pass.bpf.o xdp_drop.bpf.o xdp_detach.bpf.o xdp_zerokey.bpf.o
 

--- a/tests/xdp/test_xdp.sh
+++ b/tests/xdp/test_xdp.sh
@@ -21,7 +21,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 source "$DIR/../lib.sh"
 
 ktap_header
-ktap_plan 4
+ktap_plan 5
 
 skip_all()
 {
@@ -30,6 +30,7 @@ skip_all()
 	ktap_skip "xdp drop: verdict enforced correctly"
 	ktap_skip "xdp detach: callback stops firing and traffic resumes"
 	ktap_skip "xdp attach: refuses a sleepable runtime"
+	ktap_skip "xdp zero-key: a zero-sized key is rejected without a crash"
 	ktap_totals
 	exit 0
 }
@@ -42,7 +43,7 @@ command -v clang > /dev/null 2>&1 || skip_all "clang not available"
 cleanup()
 {
 	bpftool net detach xdp dev "$IFACE" 2>/dev/null
-	rm -f "${PIN}_pass" "${PIN}_drop" "${PIN}_detach"
+	rm -f "${PIN}_pass" "${PIN}_drop" "${PIN}_detach" "${PIN}_zerokey"
 	lunatik stop tests/xdp/pass > /dev/null 2>&1
 	lunatik stop tests/xdp/drop > /dev/null 2>&1
 	lunatik stop tests/xdp/detach > /dev/null 2>&1
@@ -128,6 +129,27 @@ detach_case()
 	ktap_pass "xdp detach: callback stops firing and traffic resumes"
 }
 
+zerokey_case()
+{
+	bpftool prog load "$DIR/xdp_zerokey.bpf.o" "${PIN}_zerokey" type xdp ||
+		{ ktap_fail "xdp zero-key: failed to load XDP program"; return 1; }
+	bpftool net attach xdp pinned "${PIN}_zerokey" dev "$IFACE" ||
+		{ ktap_fail "xdp zero-key: failed to attach XDP program"; bpftool prog unpin "${PIN}_zerokey"; return 1; }
+
+	mark_dmesg
+	ip netns exec "$NETNS" ping -c 1 -W 2 "$TARGET" > /dev/null 2>&1
+	local reached=$?
+
+	bpftool net detach xdp dev "$IFACE" 2>/dev/null
+	rm -f "${PIN}_zerokey"
+
+	# the program drops on rejection, so a working guard blocks the ping: reachable means
+	# the kfunc was never exercised, a clean dmesg alone would be a false pass
+	check_dmesg || { ktap_fail "xdp zero-key: the kfunc crashed on a zero-sized key"; return 1; }
+	[ "$reached" -ne 0 ] || { ktap_fail "xdp zero-key: ping passed, the kfunc did not run"; return 1; }
+	ktap_pass "xdp zero-key: a zero-sized key is rejected without a crash"
+}
+
 run_case xdp_pass.bpf.o "${PIN}_pass" pass.lua yes "xdp pass" \
 	"xdp pass: verdict enforced, packet and argument content verified" softirq
 run_case xdp_drop.bpf.o "${PIN}_drop" drop.lua no "xdp drop" \
@@ -139,6 +161,8 @@ run_script "tests/xdp/attach_sleepable"
 check_dmesg || { ktap_totals; exit 1; }
 lunatik stop tests/xdp/attach_sleepable > /dev/null 2>&1
 ktap_pass "xdp attach: refuses a sleepable runtime"
+
+zerokey_case
 
 ktap_totals
 

--- a/tests/xdp/xdp_zerokey.bpf.c
+++ b/tests/xdp/xdp_zerokey.bpf.c
@@ -1,0 +1,24 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+extern int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *ctx,
+		void *arg, size_t arg__sz) __ksym;
+
+static char runtime[] = "tests/xdp/zerokey";
+
+SEC("xdp")
+int test_xdp_zerokey(struct xdp_md *ctx)
+{
+	/* drop on rejection, so a working guard blocks the ping and proves the kfunc ran */
+	int ret;
+	ret = bpf_luaxdp_run(runtime, 0, ctx, NULL, 0);
+	return ret < 0 ? XDP_DROP : XDP_PASS;
+}
+
+char LICENSE[] SEC("license") = "GPL";
+


### PR DESCRIPTION
The BPF verifier accepts a zero-sized memory argument (`check_mem_size_reg` with `zero_size_allowed`), so a verified eBPF program can call `bpf_luaxdp_run` with `key__sz` 0. The shared lookup computed `keylen = key__sz - 1`, underflowing to `SIZE_MAX`, and then wrote the null terminator at `key[SIZE_MAX]` — a wild write reachable from a legal program.

Guard the zero case in `lunatik_ebpf_lookupruntime`. The xdp suite gains a program that makes the zero-sized call and asserts the ping falls through to `XDP_PASS` with a clean dmesg; the negative side is a kernel crash, so it is not run.

Predates the shared helper (the same `- 1` was in luaxdp), but the helper is where it lives now.