### PR TITLE
docs: where a comment goes, and when the code should say it instead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,10 @@ Never `require("foo").method()`.
 * No comments restating obvious kernel or Lua API usage. Non obvious rationale is welcome.
 * A comment is one line carrying the reason the code is not obvious, nothing the code below already
   says. State the why; the what and the how are the code's job.
+* A comment about a specific call goes on that call's line, not above the function signature.
+* Reaching for a comment is a signal to reconsider the code's clarity first: a name that states the
+  intent, a helper that names the step, an enum instead of a bare constant. Comment what the code
+  cannot be made to say, not what a clearer shape would.
 * Public functions and object types get LDoc comments. Use `@type <class>` names that do not collide
   with a function name, or LDoc will attach the wrong things.
 * LDoc does not surface a method a class inherits. To show it on the subclass's page, add a doc-only


### PR DESCRIPTION
Two rules from the #693 review of a single comment.

An API-choice justification belongs on the line that makes the call, not floating above the signature; and before writing it, ask whether the call already carries the reason -- `raw_cpu_ptr` over `this_cpu_ptr` is its own comment to a kernel reader.

And reaching for a comment is first a signal to reconsider clarity: a better name, a named helper, a real enum. Comment what the code cannot be made to say.