### PR TITLE
docs: point the LPeg README status at the project board

### DIFF
--- a/doc/design/lpeg/README.md
+++ b/doc/design/lpeg/README.md
@@ -41,5 +41,7 @@ What is unusual about this project, and what to keep in mind:
 
 ## Status
 
-Tracked in the epic issue in this repository. Each phase lands as its own pull request.
+These documents describe the design; they do not track progress. What is in flight, and how far along
+each phase is, lives on the [LPeg binding board](https://github.com/orgs/luainkernel/projects/4). Each
+phase is an issue there and lands as its own pull request.
 


### PR DESCRIPTION
The `conntrack-nat`, `fsnotify` and `lsm-ebpf` design READMEs already point their `## Status` section
at the theme's org project board — the epic plus one issue per phase. `lpeg`, created later, still had
the old placeholder ("Tracked in the epic issue in this repository").

This brings `doc/design/lpeg/README.md` in line with the other three, linking the
[LPeg binding board](https://github.com/orgs/luainkernel/projects/4). The board now lists on the
repository's projects tab, so every design README cites where its work is tracked.
