### PR TITLE
ebpf: centralize common helpers and reuse in xdp

### DIFF
--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -31,11 +31,6 @@
 
 LUNATIK_EBPF_START();
 
-static char luaxdp_env_key;
-
-static lunatik_object_t *luaxdp_runtimes = NULL;
-static lunatik_object_t *luaxdp_percpu = NULL;
-
 typedef struct luaxdp_ctx_s {
 	struct xdp_buff  *xdp;
 	void             *arg;
@@ -129,7 +124,7 @@ static inline void luaxdp_handler_cleanup(luaxdp_ctx_t *lctx)
 
 static int luaxdp_handler(lua_State *L, luaxdp_ctx_t *ctx)
 {
-	luaxdp_ctx_t *lctx = lunatik_ebpf_getctx(L, &luaxdp_env_key);
+	luaxdp_ctx_t *lctx = lunatik_ebpf_getctx(L);
 	int ret = 0;
 
 	if (lctx == NULL)
@@ -142,21 +137,7 @@ static int luaxdp_handler(lua_State *L, luaxdp_ctx_t *ctx)
 	luadata_reset(lctx->packet, lctx->xdp->data, lctx->xdp->data_end - lctx->xdp->data, LUADATA_OPT_KEEP);
 	luadata_reset(lctx->argument, lctx->arg, lctx->arg__sz, LUADATA_OPT_KEEP);
 
-	lua_rawgeti(L, LUA_REGISTRYINDEX, lctx->callback_ref);
-	if (!lua_isfunction(L, -1)) {
-		pr_err_ratelimited("callback_ref is not a function\n");
-		lua_pop(L, 2);
-		ret = -1;
-		goto out;
-	}
-	lua_insert(L, -2);
-	if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
-		pr_err_ratelimited("%s\n", lua_tostring(L, -1));
-		lua_pop(L, 1);
-		ret = -1;
-		goto out;
-	}
-out:
+	ret = lunatik_ebpf_invoke(L, lctx->callback_ref);
 	luaxdp_handler_cleanup(lctx);
 	return ret;
 }
@@ -164,12 +145,6 @@ out:
 __bpf_kfunc int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *xdp_ctx, void *arg, size_t arg__sz)
 {
 	int action = -1;
-	int ret;
-
-	lunatik_object_t *runtime = lunatik_ebpf_lookupruntime(&luaxdp_runtimes, &luaxdp_percpu,
-			key, key__sz, raw_smp_processor_id());
-	if (runtime == NULL)
-		goto out;
 
 	luaxdp_ctx_t ctx = {
 		.xdp     = (struct xdp_buff *)xdp_ctx,
@@ -178,9 +153,7 @@ __bpf_kfunc int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *xdp_ctx
 		.action  = &action,
 	};
 
-	lunatik_run(runtime, luaxdp_handler, ret, &ctx);
-	lunatik_putobject(runtime);
-out:
+	LUNATIK_EBPF_RUN(key, key__sz, luaxdp_handler, &ctx);
 	return action;
 }
 
@@ -200,17 +173,14 @@ LUNATIK_EBPF_KFUNC_DEFINE_SET(xdp, bpf_luaxdp_run);
 */
 static int luaxdp_detach(lua_State *L)
 {
-	luaxdp_ctx_t *lctx = lunatik_ebpf_getctx(L, &luaxdp_env_key);
+	luaxdp_ctx_t *lctx = lunatik_ebpf_getctx(L);
 
 	if (lctx == NULL)
 		return 0;
 
-	luaL_unref(L, LUA_REGISTRYINDEX, lctx->callback_ref);
-	lctx->callback_ref = LUA_NOREF;
-	lua_pop(L, 1);
+	lunatik_ebpf_detach(L, &lctx->callback_ref);
 	lunatik_unregister(L, lctx->packet);
 	lunatik_unregister(L, lctx->argument);
-	lunatik_unregister(L, &luaxdp_env_key);
 	return 0;
 }
 
@@ -277,12 +247,7 @@ static int luaxdp_attach(lua_State *L)
 	lunatik_register(L, -1, ctx->argument);
 	lua_pop(L, 1);
 
-	lua_pushvalue(L, 1);
-	ctx->callback_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-
-	lunatik_register(L, -1, &luaxdp_env_key);
-	lua_pop(L, 1);
-
+	lunatik_ebpf_attach(L, &ctx->callback_ref);
 	return 0;
 }
 #endif
@@ -295,24 +260,11 @@ static const luaL_Reg luaxdp_lib[] = {
 	{NULL, NULL}
 };
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0))
-LUNATIK_CLASSES(xdp, &luaxdp_class);
-#else
-static const lunatik_class_t *luaxdp_classes[] = { NULL };
-#endif
-LUNATIK_NEWLIB(xdp, luaxdp_lib, luaxdp_classes);
+LUNATIK_EBPF_NEWLIB(xdp, luaxdp_lib, &luaxdp_class);
 
 LUNATIK_EBPF_KFUNC_INIT(xdp, BPF_PROG_TYPE_XDP);
 
-static void __exit luaxdp_exit(void)
-{
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0))
-	if (luaxdp_runtimes != NULL)
-		lunatik_putobject(luaxdp_runtimes);
-	if (luaxdp_percpu != NULL)
-		lunatik_putobject(luaxdp_percpu);
-#endif
-}
+LUNATIK_EBPF_EXIT(xdp);
 
 module_init(luaxdp_init);
 module_exit(luaxdp_exit);

--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -8,6 +8,10 @@
 
 #include "lib/luarcu.h"
 
+static char lunatik_ebpf_env_key;
+static lunatik_object_t *lunatik_ebpf_runtimes = NULL;
+static lunatik_object_t *lunatik_ebpf_percpu = NULL;
+
 /* a zero size is allowed by the verifier and would underflow the length */
 static inline int lunatik_ebpf_checkkey(char *key, size_t key_sz, size_t *keylen)
 {
@@ -18,44 +22,43 @@ static inline int lunatik_ebpf_checkkey(char *key, size_t key_sz, size_t *keylen
 	return 0;
 }
 
-static inline int lunatik_ebpf_checkruntimes(lunatik_object_t **runtimes, lunatik_object_t **percpu)
+static inline int lunatik_ebpf_checkruntimes(void)
 {
 	static const char runtimes_key[] = "runtimes";
 	static const char percpu_key[] = "percpu";
-	if (*runtimes == NULL)
-		*runtimes = luarcu_getobject(lunatik_env, runtimes_key, sizeof(runtimes_key) - 1);
-	if (*percpu == NULL)
-		*percpu = luarcu_getobject(lunatik_env, percpu_key, sizeof(percpu_key) - 1);
-	return *runtimes && *percpu ? 0 : -1;
+	if (lunatik_ebpf_runtimes == NULL)
+		lunatik_ebpf_runtimes = luarcu_getobject(lunatik_env, runtimes_key, sizeof(runtimes_key) - 1);
+	if (lunatik_ebpf_percpu == NULL)
+		lunatik_ebpf_percpu = luarcu_getobject(lunatik_env, percpu_key, sizeof(percpu_key) - 1);
+	return lunatik_ebpf_runtimes && lunatik_ebpf_percpu ? 0 : -1;
 }
 
-static inline lunatik_object_t *lunatik_ebpf_lookupruntime(lunatik_object_t **runtimes,
-		lunatik_object_t **percpu, char *key, size_t key_sz, int cpuid)
+static inline lunatik_object_t *lunatik_ebpf_lookupruntime(char *key, size_t key_sz, int cpuid)
 {
 	lunatik_object_t *runtime = NULL;
 	size_t keylen;
 
 	if (lunatik_ebpf_checkkey(key, key_sz, &keylen) != 0)
 		return NULL;
-	if (unlikely(lunatik_ebpf_checkruntimes(runtimes, percpu) != 0)) {
+	if (unlikely(lunatik_ebpf_checkruntimes() != 0)) {
 		pr_err_ratelimited("couldn't find _ENV.runtimes or _ENV.percpu\n");
 		return NULL;
 	}
-	runtime = luarcu_getobject(*runtimes, key, keylen);
+	runtime = luarcu_getobject(lunatik_ebpf_runtimes, key, keylen);
 	if (!runtime) {
 		char cpu_key[LUARCU_MAXKEY];
 		size_t cpulen;
 		cpulen = scnprintf(cpu_key, sizeof(cpu_key), "%s:%d", key, cpuid);
-		runtime = luarcu_getobject(*percpu, cpu_key, cpulen);
+		runtime = luarcu_getobject(lunatik_ebpf_percpu, cpu_key, cpulen);
 	}
 	return runtime;
 }
 
 /* on success the context userdata stays on the stack, ready to be passed to the callback */
-static inline void *lunatik_ebpf_getctx(lua_State *L, char *env_key)
+static inline void *lunatik_ebpf_getctx(lua_State *L)
 {
 	lunatik_object_t *obj;
-	if (lunatik_getregistry(L, env_key) != LUA_TUSERDATA) {
+	if (lunatik_getregistry(L, &lunatik_ebpf_env_key) != LUA_TUSERDATA) {
 		lua_pop(L, 1);
 		pr_err_ratelimited("couldn't find the context object\n");
 		return NULL;
@@ -63,6 +66,58 @@ static inline void *lunatik_ebpf_getctx(lua_State *L, char *env_key)
 	obj = (lunatik_object_t *)lunatik_toobject(L, -1);
 	return obj->private;
 }
+
+/* invokes the Lua callback referenced by 'callback_ref', consuming the
+ * context userdata that lunatik_ebpf_getctx() left on top of the stack */
+static inline int lunatik_ebpf_invoke(lua_State *L, int callback_ref)
+{
+	lua_rawgeti(L, LUA_REGISTRYINDEX, callback_ref);
+	if (!lua_isfunction(L, -1)) {
+		pr_err_ratelimited("callback_ref is not a function\n");
+		lua_pop(L, 2);
+		return -1;
+	}
+
+	lua_insert(L, -2);
+	if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
+		pr_err_ratelimited("%s\n", lua_tostring(L, -1));
+		lua_pop(L, 1);
+		return -1;
+	}
+	return 0;
+}
+
+/* references the Lua function at stack index 1 as the callback and binds its
+ * lifetime to 'env_key' (the ctx object must already be on top of the stack) */
+static inline void lunatik_ebpf_attach(lua_State *L, int *callback_ref)
+{
+	lua_pushvalue(L, 1);
+	*callback_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+	lunatik_register(L, -1, &lunatik_ebpf_env_key);
+	lua_pop(L, 1);
+}
+
+/* the caller still unregisters any binding specific sub-objects */
+static inline void lunatik_ebpf_detach(lua_State *L, int *callback_ref)
+{
+	luaL_unref(L, LUA_REGISTRYINDEX, *callback_ref);
+	*callback_ref = LUA_NOREF;
+	lunatik_unregister(L, &lunatik_ebpf_env_key);
+	lua_pop(L, 1);
+}
+
+/* looks up the runtime for 'key'/'key_sz', runs 'handler' with 'ctxp' on it,
+ * and releases the runtime; a no-op if no matching runtime is found */
+#define LUNATIK_EBPF_RUN(key, key_sz, handler, ctxp) \
+do { \
+	lunatik_object_t *__runtime = lunatik_ebpf_lookupruntime((key), (key_sz), raw_smp_processor_id()); \
+	if (__runtime != NULL) { \
+		int __ret; \
+		lunatik_run(__runtime, (handler), __ret, (ctxp)); \
+		lunatik_putobject(__runtime); \
+	} \
+} while (0)
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
 #define LUNATIK_EBPF_START() __bpf_kfunc_start_defs()
@@ -93,16 +148,36 @@ static inline void *lunatik_ebpf_getctx(lua_State *L, char *env_key)
 	};
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0))
+#define LUNATIK_EBPF_NEWLIB(subsys, lib, class) \
+	LUNATIK_CLASSES(subsys, class); \
+	LUNATIK_NEWLIB(subsys, lib, lua##subsys##_classes)
+
 #define LUNATIK_EBPF_KFUNC_INIT(subsys, prog_type) \
 static int __init lua##subsys##_init(void) \
 { \
 	return register_btf_kfunc_id_set(prog_type, &bpf_lua##subsys##_kfunc_set); \
 }
+#define LUNATIK_EBPF_EXIT(subsys) \
+static void __exit lua##subsys##_exit(void) \
+{ \
+	if (lunatik_ebpf_runtimes != NULL) \
+		lunatik_putobject(lunatik_ebpf_runtimes); \
+	if (lunatik_ebpf_percpu != NULL) \
+		lunatik_putobject(lunatik_ebpf_percpu); \
+}
 #else
+#define LUNATIK_EBPF_NEWLIB(subsys, lib, class) \
+	static const lunatik_class_t *lua##subsys##_classes[] = { NULL }; \
+	LUNATIK_NEWLIB(subsys, lib, lua##subsys##_classes)
+
 #define LUNATIK_EBPF_KFUNC_INIT(subsys, prog_type) \
 static int __init lua##subsys##_init(void) \
 { \
 	return 0; \
+}
+#define LUNATIK_EBPF_EXIT(subsys) \
+static void __exit lua##subsys##_exit(void) \
+{ \
 }
 #endif
 


### PR DESCRIPTION
This refactors the eBPF bindings to move common runtime, callback, registration, and teardown logic into the shared `lunatik_ebpf.h` layer.