### PR TITLE
docs: pull-request review and refactor conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,6 +364,9 @@ On the comments themselves:
   beyond them. Where the tree itself is inconsistent and a style seems worth settling, that is an
   exclusive pull request — one that fixes the whole tree and records the convention here — never a
   finding on someone's feature work.
+* Work a review defers to a later pull request is captured as an issue, linked from the comment that
+  defers it. A "we can do this separately" that lives only in the thread is lost when the pull
+  request merges; the issue makes the deferral a tracked plan, not a promise.
 * A finding names its severity from what is traced, not from what is feared. A crash is a crash only
   when a reachable path reaches it; short of that it is a contract or parity gap, said as one. The
   same discipline the commit rules ask of a root cause applies to a review's own claims.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,6 +367,9 @@ On the comments themselves:
 * Work a review defers to a later pull request is captured as an issue, linked from the comment that
   defers it. A "we can do this separately" that lives only in the thread is lost when the pull
   request merges; the issue makes the deferral a tracked plan, not a promise.
+* A reply to an author's comment opens with a quote of the line it answers. An issue comment does
+  not thread, so a bare reply floats free of what prompted it; the quote makes it a reply instead of
+  a stray remark.
 * A finding names its severity from what is traced, not from what is feared. A crash is a crash only
   when a reachable path reaches it; short of that it is a contract or parity gap, said as one. The
   same discipline the commit rules ask of a root cause applies to a review's own claims.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,7 +327,12 @@ is posted before the maintainer has seen both.
    finding to report: separate the artifact under test from the tool exercising it — the same
    program the distribution's loader rejects may load under a current one — and exhaust the working
    path before writing "could not run". A reviewer with the machine drives it to ground rather than
-   asking the author to confirm what the machine could have said.
+   asking the author to confirm what the machine could have said. Read the PR's own conversation too,
+   not only its diff: an author's comment may raise a question or propose an alternative the review
+   has to engage with, and a verdict that ignores an open author thread is incomplete. A PR based on
+   another branch rather than `master` is stacked: review it against its own base, and read the whole
+   stack first, because what one PR seems to delete may have moved to a PR stacked on top of it —
+   check there before reporting a deletion as a loss.
 2. Work on `review/<pr number>`, started from the author's head. The number is what lets the author,
    and the next reviewer, find the branch; a name of your own choosing does not.
 3. One fixup per finding, `git commit --fixup=<the author's commit>`. Not one per file, and not one

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,8 +349,9 @@ is posted before the maintainer has seen both.
 
 On the comments themselves:
 
-* Each one states the defect and the change it requires, and links the fixup that makes it. Showing
-  the shape of the fix costs the author less than a paragraph describing it. A linked fixup's SHA is
+* Each one states the defect and the change it requires, and links the fixup that makes it as a full
+  commit URL — never a backtick'd SHA, which renders as code and does not link. Showing the shape of
+  the fix costs the author less than a paragraph describing it. A linked fixup's SHA is
   a published reference the moment the comment posts; amending or rebasing the review branch after
   that rewrites the SHA and leaves the link pointing at the superseded version. Leave the branch be
   once posted; when a change is unavoidable, refresh the SHAs in the comments it moved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,11 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
 * Prefer a named `static inline` helper over an open coded repetition, and do not inline an existing
   named helper into its callers while refactoring; they exist for readability and symmetry.
 * When a two line pattern repeats in every method, collapse it into one helper or macro.
+* A helper meant to be shared is held to a higher design bar than a one-off, because everything
+  built on it inherits its shape: a pair mirrors, so whatever one half acquires or registers its
+  partner releases or unregisters, and an argument on one appears on the other; a family of helpers
+  or macros names the same argument the same way, carries the same prefix, and types a value for
+  what it is, not for how it is stored.
 * A secondary check that must always follow a `LUNATIK_PRIVATECHECKER` (a field that must be set,
   the class identity of the object) goes in the macro's vararg body, in the mold of `luaskb_check`;
   `L` and `ix` are in scope there. A hand written checker only when the macro's shape does not fit.
@@ -307,7 +312,10 @@ the body.
 3. new API is documented and listed in `config.ld` and the README;
 4. new tests are wired into their suite and described;
 5. error paths audited: for each raise, everything already acquired is released;
-6. commits are small, ordered, and none of them undoes another.
+6. commits are small, ordered, and none of them undoes another;
+7. every helper the change introduces has a caller. A helper extracted to remove duplication but
+   left unused, while the duplication it replaces still stands, is the refactor half-done. Grep the
+   new symbols for a caller before sending.
 
 ## Reviewing a pull request
 
@@ -324,7 +332,10 @@ is posted before the maintainer has seen both.
    and the next reviewer, find the branch; a name of your own choosing does not.
 3. One fixup per finding, `git commit --fixup=<the author's commit>`. Not one per file, and not one
    per target commit: a comment pointing at a commit that does three unrelated things cannot be
-   accepted in parts, and the author is the one who autosquashes what they accept.
+   accepted in parts, and the author is the one who autosquashes what they accept. A fixup touches
+   only what the pull request introduced; check the symbol's provenance before changing it, since one
+   already on `master` is a separate change on its own branch, not a fixup folded into this review. A
+   consistency fix on the branch's own code is done now, not deferred.
 4. Rebase the review branch when `master` moves under it, so the fixups still apply to what the
    author will rebase onto.
 5. Draft the comments and hand them over. The repository's public voice is the maintainer's; a
@@ -334,7 +345,10 @@ is posted before the maintainer has seen both.
 On the comments themselves:
 
 * Each one states the defect and the change it requires, and links the fixup that makes it. Showing
-  the shape of the fix costs the author less than a paragraph describing it.
+  the shape of the fix costs the author less than a paragraph describing it. A linked fixup's SHA is
+  a published reference the moment the comment posts; amending or rebasing the review branch after
+  that rewrites the SHA and leaves the link pointing at the superseded version. Leave the branch be
+  once posted; when a change is unavoidable, refresh the SHAs in the comments it moved.
 * A request for changes is not a place for praise. Padding buries the change being asked for.
 * Missing tests are a finding of their own, written as such, not a remark appended to another
   comment.


### PR DESCRIPTION
Rules from the eBPF-layer reviews.

A shared helper is held to a higher design bar than a one-off: a pair mirrors what it acquires and releases, and a helper family names and types its arguments consistently.

A helper a change introduces has a caller; one extracted to remove duplication but left unused is the refactor half-done. A review fixup touches only what the PR introduced — check a symbol's provenance before changing it, since one already on master is a separate change, not a fixup folded into someone else's PR.

A linked fixup SHA is a published reference once the comment posts: amending or rebasing the review branch afterward orphans the link. Leave the branch be once posted; if a change is unavoidable, refresh the SHAs in the comments it moved.

Read the PR's own conversation, not only its diff: an open author thread must be engaged before a verdict. And a PR based on another branch is stacked — review it against its own base and read the whole stack, since what one PR seems to delete may have moved to a PR stacked on top.

Work a review defers to a later PR becomes a tracked issue, not a loose promise in a thread. And a reply to an author's comment quotes the line it answers, since an issue comment does not thread.