### PR TITLE
examples: share the TLS SNI parser between the filtering examples

### DIFF
--- a/examples/common/sni.lua
+++ b/examples/common/sni.lua
@@ -1,0 +1,42 @@
+--
+-- SPDX-FileCopyrightText: (c) 2024-2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+--- Server Name Indication (SNI) parsing shared by the packet-filtering examples.
+-- @module examples.common.sni
+
+local HANDSHAKE      <const> = 0x16
+local CLIENT_HELLO   <const> = 0x01
+local SERVER_NAME    <const> = 0x0000
+local SESSION        <const> = 43
+local MAX_EXTENSIONS <const> = 17
+
+local function u16(packet, at)
+	return packet:getbyte(at) << 8 | packet:getbyte(at + 1)
+end
+
+--- Returns the host name in the TLS ClientHello at `base`, or `nil`.
+-- @function sni
+-- @tparam userdata packet buffer answering `getbyte`/`getstring`
+-- @tparam integer base offset of the TLS record within the packet
+-- @treturn string|nil the host name
+local function sni(packet, base)
+	if packet:getbyte(base) ~= HANDSHAKE or packet:getbyte(base + 5) ~= CLIENT_HELLO then
+		return
+	end
+
+	local cipher      = base + SESSION + 1 + packet:getbyte(base + SESSION)
+	local compression = cipher + 2 + u16(packet, cipher)
+	local extension   = compression + 3 + packet:getbyte(compression)
+
+	for _ = 1, MAX_EXTENSIONS do
+		local body = extension + 4
+		if u16(packet, extension) == SERVER_NAME then
+			return packet:getstring(body + 5, u16(packet, body + 3))
+		end
+		extension = body + u16(packet, extension + 2)
+	end
+end
+
+return sni
+

--- a/examples/filter/sni.lua
+++ b/examples/filter/sni.lua
@@ -5,6 +5,7 @@
 
 local xdp    = require("xdp")
 local action = require("linux.xdp")
+local sni    = require("examples.common.sni")
 
 local function set(t)
 	local s = {}
@@ -16,66 +17,22 @@ local blacklist = set{
 	"ebpf.io",
 }
 
-local function log(sni, verdict)
-	print(string.format("filter_sni: %s %s", sni, verdict))
-end
-
-local function unpacker(packet, base)
-	local byte = function (offset)
-		return packet:getbyte(base + offset)
-	end
-
-	local short = function (offset)
-		local offset = base + offset
-		return packet:getbyte(offset) << 8 | packet:getbyte(offset + 1)
-	end
-
-	local str = function (offset, length)
-		return packet:getstring(base + offset, length)
-	end
-
-	return byte, short, str
+local function log(host, verdict)
+	print(string.format("filter_sni: %s %s", host, verdict))
 end
 
 local function offset(argument)
-	return select(2, unpacker(argument, 0))(0)
+	return argument:getbyte(0) << 8 | argument:getbyte(1)
 end
 
-local client_hello = 0x01
-local handshake    = 0x16
-local server_name  = 0x00
-
-local session = 43
-local max_extensions = 17
-
 local function filter_sni(ctx)
-	local packet = ctx:packet()
-	local argument = ctx:argument()
-	local byte, short, str = unpacker(packet, offset(argument))
-
-	if byte(0) ~= handshake or byte(5) ~= client_hello then
-		ctx:action(action.PASS)
+	local host = sni(ctx:packet(), offset(ctx:argument()))
+	if host then
+		local verdict = blacklist[host] and "DROP" or "PASS"
+		log(host, verdict)
+		ctx:action(action[verdict])
 		return
 	end
-
-	local cipher = (session + 1) + byte(session)
-	local compression = cipher + 2 + short(cipher)
-	local extension = compression + 3 + byte(compression)
-
-	for i = 1, max_extensions do
-		local data = extension + 4
-		if short(extension) == server_name then
-			local length = short(data + 3)
-			local sni = str(data + 5, length)
-
-			verdict = blacklist[sni] and "DROP" or "PASS"
-			log(sni, verdict)
-			ctx:action(action[verdict])
-			return
-		end
-		extension = data + short(extension + 2)
-	end
-
 	ctx:action(action.PASS)
 end
 


### PR DESCRIPTION
The `filter` (xdp) and `sniclassify` (tc, #717) examples both parse the SNI from a TLS ClientHello with the same code. Extract that parser to `examples/common/sni.lua` (`require("examples.common.sni")`, taking `(packet, base)` and returning the host name) and move `filter/sni.lua` onto it. #717's sniclassify then requires the same module instead of carrying a second copy.

Test plan:
- Loaded both examples in softirq — they attach cleanly, no dmesg errors.
- Verified the extracted parser is equivalent to the original: a crafted ClientHello fed through both the old closure parser and the new module returns the same SNI, and both return nil on a non-ClientHello.