### PR TITLE
docs: add the kernel TLS design notes

### DIFF
--- a/doc/design/ktls/README.md
+++ b/doc/design/ktls/README.md
@@ -1,0 +1,43 @@
+# Kernel TLS binding
+
+Working documents for the `ktls` binding: a Lua interface to Linux kernel TLS, so kernel scripts can
+key a connected socket for TLS, read and write plaintext while the kernel does the record-layer
+crypto, delegate the handshake to the userspace `tlshd` daemon through the kernel handshake upcall,
+and splice plaintext between sockets — enough to build a TLS proxy or an in-kernel TLS tunnel in Lua.
+
+They exist so that a new contributor, with or without an AI coding assistant, can pick the work up
+without first learning where kTLS ends and the TLS handshake begins.
+
+| Document | What it is for |
+|----------|----------------|
+| [plan.md](plan.md) | Current state (including the prior work), gap analysis, the incremental phases, non goals, risks, definition of done |
+| [api.md](api.md) | Proposed Lua API: `socket:setsockopt`, the `tls` keying module, the `handshake` upcall module, `ktls` high level helpers, and the tunnel, with worked examples |
+| [kernel-notes.md](kernel-notes.md) | Verified kernel reference: the two-step keying, exported symbols, the ULP framework and why we ride the `tls` ULP, plaintext I/O gotchas, version drift |
+| [testing.md](testing.md) | Test strategy — keying a loopback session with known vectors (no `tlshd`), and skipping the real handshake when the daemon is absent |
+
+Start with `plan.md`. Read `kernel-notes.md` before writing any C.
+
+## Working on this
+
+The repository conventions that apply to every change here (build, test, style, kernel context rules,
+commit discipline) are in [AGENTS.md](../../../AGENTS.md) at the root of the repository. Read it once
+before the first patch.
+
+Three facts shape everything here, and are worth carrying from the start:
+
+1. **The kernel does the TLS record layer, not the handshake.** There is no TLS handshake
+   implementation in the kernel, by design. So this binding is not a kernel TLS stack; it keys
+   sockets and moves plaintext, and the handshake comes from userspace (`tlshd`, or an application).
+2. **This is incremental, and half the foundation already exists.** A parked `claude_tls` branch
+   already has `socket:setsockopt`, a `tls` crypto-info packer, and a `handshake` upcall binding — but
+   against an old base. The first increments rebase that onto the current tree; later increments add
+   the plaintext data path and the tunnel. Each phase is a shippable pull request.
+3. **kTLS is a TCP ULP.** We ride the kernel's existing `tls` upper-layer protocol; we do not write a
+   Lua ULP. A generic "Lua is a ULP" binding is a worthwhile *separate* project (see the non goals in
+   `plan.md`), not part of this one.
+
+## Status
+
+Tracked in the epic issue and the project board — the epic plus one issue per phase. Each phase lands
+as its own pull request.
+

--- a/doc/design/ktls/api.md
+++ b/doc/design/ktls/api.md
@@ -1,0 +1,139 @@
+# Proposed Lua API: `ktls`
+
+This is a design proposal, not a specification. Names and shapes are open for review; the kernel
+constraints behind them (`kernel-notes.md`) are not. Some of this exists already on the parked
+`claude_tls` branch and is rebased in; the rest is new.
+
+Four pieces, low to high level:
+
+* `socket:setsockopt` plus `socket.sol` / `socket.tcp` option namespaces — a generic socket facility
+  (phase 1);
+* `tls` — kTLS constants and the `crypto_info` packer (phase 2);
+* `handshake` — the kernel handshake upcall to `tlshd` (phase 4);
+* `ktls` — high level helpers and the tunnel (phases 4–5), in Lua.
+
+## Conventions
+
+* Keys, IVs, salts and sequence numbers are binary strings; `tls.pack` assembles them into the exact
+  `tls12_crypto_info_*` layout `setsockopt(SOL_TLS)` expects.
+* Everything here is process-context: keying, handshake and the relay loop run in a `run` (process) or
+  `spawn` runtime, never softirq. The kernel does the record crypto; Lua never touches a cipher.
+* A kTLS socket is an ordinary Lunatik `socket` object once keyed; `send`/`receive` carry plaintext.
+
+## Phase 1 — `socket:setsockopt`
+
+    local socket = require("socket")
+
+    sock:setsockopt(socket.sol.TCP, socket.tcp.ULP, "tls")     -- attach the tls ULP
+    sock:setsockopt(socket.sol.TLS, tls.TX, crypto_info)       -- install keys (phase 2)
+
+`sock:setsockopt(level, optname, optval)` maps to the kernel `setsockopt`, passing `optval` as a
+string payload (the kernel side uses `KERNEL_SOCKPTR`, so a Lua string becomes the option buffer with
+no copy round trip through userspace). `socket.sol` carries `SOCKET`, `TCP`, `TLS`, …; `socket.tcp`
+carries `ULP` and the rest. This is generic — it is not TLS specific, and TLS is its first user.
+
+## Phase 2 — `tls`: keying
+
+    local tls = require("tls")
+
+    local info = tls.pack(tls.version.TLS_1_3, tls.cipher.AES_GCM_128,
+                          iv, key, salt, rec_seq)
+    sock:setsockopt(socket.sol.TCP, socket.tcp.ULP, "tls")
+    sock:setsockopt(socket.sol.TLS, tls.TX, info)              -- transmit direction
+    sock:setsockopt(socket.sol.TLS, tls.RX, info_rx)           -- receive direction
+
+`tls.pack(version, cipher, iv, key, salt, rec_seq)` returns the packed `tls12_crypto_info_*` for the
+chosen cipher, sized exactly as the kernel requires (a wrong length is rejected). Constants:
+`tls.version.{TLS_1_2, TLS_1_3}`, `tls.cipher.{AES_GCM_128, AES_GCM_256, CHACHA20_POLY1305, …}`,
+`tls.{TX, RX}`. Missing salt for ChaCha20 (salt size 0) is handled by the packer.
+
+The socket must already be connected (the ULP attach requires `TCP_ESTABLISHED`); installing a
+direction twice raises (`-EBUSY`). Keys come from somewhere — a userspace handshake (phase 4) or, for
+tests, fixed vectors.
+
+## Phase 3 — plaintext I/O and control records
+
+Once keyed, `sock:receive` returns decrypted plaintext and `sock:send` takes plaintext. Two additions
+this phase makes real:
+
+    local data, record = sock:receive(n)     -- record defaults to "data"
+
+`receive` carries a `msg_control` buffer so a non-application record surfaces as a second return
+(`"alert"`, `"handshake"`, …) instead of failing the read with `-EIO`. A returned alert can be
+inspected (level, description) so a close_notify is a clean end of stream rather than an error.
+
+    sock:send(payload)                       -- application data
+    sock:close_notify()                      -- send a close_notify alert record
+
+`close_notify` sends a control record via the `TLS_SET_RECORD_TYPE` cmsg. Receives are bounded
+(`sock:timeout(ms)` or a non-blocking flag) so a relay loop in a kthread stays stoppable.
+
+## Phase 4 — `handshake`: delegating to `tlshd`
+
+    local handshake = require("handshake")
+
+    -- process/spawn runtime only; blocks until tlshd answers
+    local ok, peerid = handshake.client(sock, {
+        peername = "example.com",            -- SNI
+        timeout  = 5000,
+        cert     = my_cert_serial,           -- optional x509 (keyring serials)
+        privkey  = my_key_serial,
+    })
+
+`handshake.client(sock, opts)` fills `tls_handshake_args`, calls the exported `tls_client_hello_x509`
+(or `_anon` / `_psk` by which options are present), and waits on a completion while `tlshd` performs
+the handshake in userspace and installs the kTLS keys on the socket. On return the socket is keyed;
+`sock:receive`/`sock:send` carry plaintext. `handshake.server(sock, opts)` mirrors it for the server
+side. Requires `tlshd` running in the socket's network namespace.
+
+The socket handed in must be connected and must have a `struct file` attached (the binding sets this
+up). `sk_data_ready` is muted for the duration so nothing races `tlshd` on the byte stream.
+
+## Phase 4 — `ktls`: the high level client
+
+    local ktls = require("ktls")
+
+    local sock = ktls.connect("93.184.216.34", 443, "example.com", 5000)
+    sock:send("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+    print(sock:receive(4096))
+
+`ktls.connect(ip, port, peername, timeout)` is `socket.new` → `connect` → attach ULP →
+`handshake.client` → a keyed socket, in one call. Pure Lua over the pieces above.
+
+## Phase 5 — the tunnel
+
+The use case, in Lua. A spawned kthread relays plaintext between two sockets; one or both may be kTLS.
+
+    local thread = require("thread")
+    local linux  = require("linux")
+
+    local function relay(a, b, transform)
+        local data, record = a:receive(4096)
+        if data and record == "data" then
+            b:send(transform and transform(data) or data)
+        end
+    end
+
+    return function()
+        while not thread.shouldstop() do
+            relay(client, upstream, inspect)     -- decrypted in, re-encrypted out
+            relay(upstream, client)
+            linux.schedule(10)
+        end
+    end
+
+Both receives are bounded; the loop polls `shouldstop()`. `inspect` is where plaintext policy or
+rewriting lives — the point of doing it in Lua. Which flows enter the tunnel can be decided by a
+separate netfilter/XDP hook; the byte-moving loop stays here, in a sleepable kthread.
+
+## Open questions for review
+
+1. Whether `receive` returns `(data, record)` (proposed) or exposes the record type through a separate
+   accessor. The two-return form reads well and matches how a caller must branch on control records.
+2. Whether `tls.pack` should take a table (`{version=, cipher=, iv=, key=, …}`) rather than positional
+   arguments; positional mirrors the existing `claude_tls` shape, a table reads better with many fields.
+3. Whether `handshake.client`/`server` belong in their own `handshake` module or under `ktls`. They
+   are usable without kTLS keying being visible, which argues for a separate module.
+4. Whether the tunnel ships as a library helper (`ktls.tunnel(a, b, opts)` returning the thread body)
+   or only as an example. A helper is convenient; an example keeps the loop visible and tweakable.
+

--- a/doc/design/ktls/kernel-notes.md
+++ b/doc/design/ktls/kernel-notes.md
@@ -1,0 +1,156 @@
+# Kernel notes: kernel TLS binding
+
+Reference sheet for the `ktls` binding. Verified against Linux 6.8
+(`/home/ubuntu/linux-hwe-6.8-6.8.0`, and the running kernel's `Module.symvers`), with version drift
+noted. Re-check on the kernel you build for.
+
+## The one fact that shapes everything
+
+The kernel implements the TLS **record** subprotocol, not the **handshake**.
+`Documentation/networking/tls-handshake.rst` states it: "there is no TLS handshake implementation in
+the Linux kernel." kTLS does symmetric record crypto once keys are installed; negotiating those keys
+(ClientHello/ServerHello, cert exchange, validation) happens in userspace — an application's TLS
+library, or the `tlshd` daemon reached through the handshake upcall. Design against this; do not try
+to make the kernel negotiate TLS.
+
+## Config and environment
+
+| Config | For | Running kernel |
+|--------|-----|----------------|
+| `CONFIG_TLS` (`tls.ko`) | kTLS itself | `=m`, module present |
+| `CONFIG_TLS_DEVICE` | NIC offload (not required) | `=y` |
+| `CONFIG_NET_HANDSHAKE` | the handshake upcall | `=y`, built in |
+
+`tlshd` (from Oracle's `ktls-utils`) is **not installed** on the development box. The handshake path
+(phase 4) therefore cannot be exercised here without installing it; the keying and plaintext paths
+(phases 2–3) can, using fixed key vectors on a loopback pair.
+
+## Keying — the two-step setsockopt path
+
+1. `setsockopt(sk, SOL_TCP, TCP_ULP, "tls", 4)` → `tls_init` (`net/tls/tls_main.c:948`), which
+   **requires `sk->sk_state == TCP_ESTABLISHED`** (`-ENOTCONN` otherwise): the socket must already be
+   connected and handshaken. It attaches the `tls_context` and swaps `sk_prot`.
+2. `setsockopt(sk, SOL_TLS, TLS_TX | TLS_RX, &crypto_info, len)` → `do_tls_setsockopt_conf`
+   (`tls_main.c:612`). It copies the 4-byte header `struct tls_crypto_info { __u16 version;
+   __u16 cipher_type; }`, looks up the cipher, requires `optlen` to equal that cipher's struct size
+   exactly, and copies the rest. A second install on the same direction returns `-EBUSY`
+   (`tls_main.c:637`).
+
+`uapi/linux/tls.h`: option names `TLS_TX=1`, `TLS_RX=2`, `TLS_TX_ZEROCOPY_RO=3`,
+`TLS_RX_EXPECT_NO_PAD=4`. Versions: TLS 1.2 `0x0303`, TLS 1.3 `0x0304`. Ciphers in 6.8: AES-GCM-128
+(51), AES-GCM-256 (52), AES-CCM-128 (53), CHACHA20-POLY1305 (54, salt 0 / IV 12), SM4-GCM (55),
+SM4-CCM (56), ARIA-GCM-128 (57), ARIA-GCM-256 (58). Each cipher's `tls12_crypto_info_*` carries
+`iv`, `key`, `salt`, `rec_seq` after the common header — this is what `tls.pack` assembles.
+
+### No in-kernel setup API, but a module can drive setsockopt directly
+
+There is **no exported** `tls_set_sw_offload`, `tcp_set_ulp`, or `do_tls_setsockopt`; they are static
+or module-internal. But the setsockopt handlers take `sockptr_t` and `copy_from_sockptr` accepts
+kernel pointers, and the entry points `sock_common_setsockopt` / `tcp_setsockopt` are exported. So a
+module holding a `struct socket *sock` does:
+
+    sock->ops->setsockopt(sock, SOL_TCP, TCP_ULP, KERNEL_SOCKPTR("tls"), 4);
+    sock->ops->setsockopt(sock, SOL_TLS, TLS_TX, KERNEL_SOCKPTR(&info), sizeof(info));
+
+This is the same mechanism `net/mptcp/sockopt.c` and `net/smc` use for `TCP_ULP`. It is not a blessed
+kTLS API, but it is structurally supported and is exactly what `tlshd` does over the fd. This is what
+`socket:setsockopt` wraps.
+
+## The ULP framework, and why we ride the `tls` ULP
+
+kTLS is a TCP Upper Layer Protocol. `struct tcp_ulp_ops` (`include/net/tcp.h:2532`) has `init`,
+`update`, `release`, `clone`, `get_info`, a `name[TCP_ULP_NAME_MAX]` (16), and `owner`; it does **not**
+list `sendmsg`/`recvmsg`. A ULP intercepts the data path by having its `init` swap `sk->sk_prot` to a
+`struct proto` with its own `sendmsg`/`recvmsg` — which is exactly what `tls` does
+(`tcp_register_ulp(&tcp_tls_ulp_ops)`, `.name="tls"`, `tls_main.c:1123`; `update_sk_prot` at `:131`).
+`tcp_register_ulp` / `tcp_unregister_ulp` are `EXPORT_SYMBOL_GPL`.
+
+A socket carries **exactly one ULP**. This binding attaches the kernel's `tls` ULP and uses it; it
+does not register a ULP of its own. Writing a *Lua* ULP (a `tcp_ulp_ops` whose `init` binds a Lunatik
+runtime, so Lua becomes an upper-layer protocol for arbitrary L7) is a separate project — it is the
+generalization the 2020 `net/tls` fork lacked and what Pedro Tammela's 2019 `ulp-lua` prototyped, but
+it cannot share a socket with `tls`, so it does not compose into this one. Kept as a non goal in
+`plan.md`.
+
+## Plaintext I/O from a `struct socket *`
+
+Once keyed, write plaintext with `kernel_sendmsg` (`net/socket.c:788`) and read decrypted data with
+`kernel_recvmsg` (`:1088`); they land in `tls_sw_sendmsg` / `tls_sw_recvmsg`. Gotchas, all verified:
+
+* **A control buffer is mandatory to see record types.** `tls_record_content_type` attaches a
+  `TLS_GET_RECORD_TYPE` cmsg on the first record of a `recvmsg` (`tls_sw.c:1756`); if a non-DATA
+  record arrives and the caller supplied no `msg_control`, the read fails `-EIO` (`tls_sw.c:1768`).
+  `kernel_recvmsg` does not set up `msg_control`, so the plaintext read path needs a custom `recvmsg`
+  carrying a control buffer. `tls_get_record_type` and `tls_alert_recv` (`net/handshake/alert.c`,
+  both `EXPORT_SYMBOL`) decode the cmsg and the alert.
+* **Setting a TX record type** (to emit a close_notify or other non-data record) uses a
+  `TLS_SET_RECORD_TYPE` cmsg at `SOL_TLS`; `tls_process_cmsg` (`tls_main.c:238`) parses it, flushing
+  any open record. Default is `TLS_RECORD_TYPE_DATA`.
+* **kvec sends are always copied** — `tls_sw_sendmsg_locked` treats `is_kvec` specially
+  (`tls_sw.c:1103`); kernel plaintext writes do not take the zerocopy/splice path. Fine, just not
+  zero-copy.
+* **RX waits on the strparser.** `tls_sw_recvmsg` blocks in `tls_rx_rec_wait` honoring
+  `MSG_DONTWAIT`/`MSG_WAITALL` (`tls_sw.c:2015`); the wait does **not** check `kthread_should_stop`.
+  So a relay loop must pass `MSG_DONTWAIT` or a receive timeout and poll `shouldstop()` — an unbounded
+  read here is the classic unstoppable-kthread hazard.
+
+## The handshake upcall — module-facing and exported
+
+`net/handshake` (Linux **6.4**; first consumers NFS/SunRPC and NVMe-TCP in **6.5**). Include
+`<net/handshake.h>`. A consumer fills:
+
+    struct tls_handshake_args {
+        struct socket  *ta_sock;        /* connected, MUST have ta_sock->file */
+        tls_done_func_t ta_done;        /* completion callback */
+        void           *ta_data;        /* cookie */
+        const char     *ta_peername;    /* SNI, optional */
+        unsigned int    ta_timeout_ms;
+        key_serial_t    ta_keyring, ta_my_cert, ta_my_privkey;
+        unsigned int    ta_num_peerids;
+        key_serial_t    ta_my_peerids[5];
+    };
+
+and calls one of (all `EXPORT_SYMBOL`, plain — not GPL — present in this kernel's `Module.symvers`):
+`tls_client_hello_x509`, `tls_client_hello_psk`, `tls_client_hello_anon`, `tls_server_hello_x509`,
+`tls_server_hello_psk`, plus `tls_handshake_cancel(sk)` and `tls_handshake_close(sock)`. Each wraps
+`handshake_req_submit`, which multicasts a netlink event that `tlshd` consumes; `tlshd` runs the
+handshake, promotes the socket to the `tls` ULP, installs keys via `SOL_TLS`, and returns it. The
+callback `tls_done_func_t(void *data, int status, key_serial_t peerid)` fires once, from netlink
+(process) context; `status` 0 means the session is up.
+
+Hard constraints:
+
+* `handshake_req_submit` returns `-EINVAL` without `sock->file` (`net/handshake/request.c:230`): the
+  binding must attach a `struct file` to the socket before submitting.
+* The submit contract is clean: 0 guarantees exactly one callback; a negative return guarantees no
+  callback and the request is already freed — safe to build a state machine on.
+* Mute `sk_data_ready` for the handshake and resume normal recv only after the callback
+  (`tls-handshake.rst`), so nothing races `tlshd`.
+* In-tree consumers submit then `wait_for_completion_interruptible_timeout` — in Lunatik this is a
+  **sleepable** (`spawn`/process) runtime, never softirq.
+* `tlshd` must run in the socket's network namespace; auth material (certs, PSKs) lives in kernel
+  keyrings referenced by serial in the args.
+
+## Version drift
+
+| Feature | Landed | Note for 6.8 |
+|---------|--------|--------------|
+| TLS 1.3 | 5.1 | present |
+| ChaCha20-Poly1305 | ~5.7 | present |
+| handshake upcall (`net/handshake`, `tlshd`) | 6.4 / 6.5 | present |
+| TLS 1.3 **KeyUpdate** / re-keying on RX | **6.14** | **absent in 6.8** — a long-lived 1.3 session that re-keys breaks; document and scope out |
+| zerocopy `sendfile` for device offload TX | 6.11 | not needed here |
+
+## Key file references
+
+* keying / setsockopt: `net/tls/tls_main.c:948` (`tls_init`, ESTABLISHED), `:612`
+  (`do_tls_setsockopt_conf`), `:238` (`tls_process_cmsg`)
+* record type cmsg: `net/tls/tls_sw.c:1756` (`tls_record_content_type`), `:1768` (`-EIO` guard)
+* SW paths: `tls_sw_sendmsg` `:1226`, `tls_sw_recvmsg` `:1954`
+* ULP: `include/net/tcp.h:2532` (`tcp_ulp_ops`), `net/tls/tls_main.c:1123` (register)
+* kernel socket I/O: `net/socket.c:788` (`kernel_sendmsg`), `:1088` (`kernel_recvmsg`)
+* handshake upcall: `include/net/handshake.h`, `net/handshake/tlshd.c` (exports), `request.c:223`
+  (`handshake_req_submit`), doc `Documentation/networking/tls-handshake.rst`
+* alert/record readers: `net/handshake/alert.c` (`tls_get_record_type`, `tls_alert_recv`, exported)
+* UAPI: `include/uapi/linux/tls.h`
+

--- a/doc/design/ktls/plan.md
+++ b/doc/design/ktls/plan.md
@@ -1,0 +1,197 @@
+# Plan: kernel TLS binding
+
+Execution plan for the `ktls` binding. Built incrementally: each phase is a shippable pull request,
+and the early phases rebase existing parked work rather than starting from zero.
+
+## Expected results
+
+1. A kernel Lua script can turn a connected kernel socket into a kTLS socket: attach the `"tls"` ULP
+   and install a TLS session (version, cipher, iv, key, salt, sequence) with `setsockopt`.
+2. Once keyed, a script reads decrypted plaintext and writes plaintext over the socket while the
+   kernel does the record crypto transparently, with bounded receives safe for a kernel thread, and
+   observes TLS control records (alert, close_notify) instead of erroring on them.
+3. A script can request a TLS handshake on a connected socket through the kernel handshake upcall
+   (`tls_client_hello_*` / `tls_server_hello_*`), delegating negotiation to `tlshd`, and get back a
+   keyed socket — no in-kernel handshake, no forked `net/tls`.
+4. Composing the above: a TLS tunnel written in Lua — a spawned kernel thread that splices decrypted
+   plaintext between two sockets (one or both kTLS), the in-kernel TLS tunnel use case.
+5. Examples plus a KTAP suite: a client `ktls.connect` example and a tunnel example, plus tests that
+   key a loopback kTLS session with known vectors (no `tlshd` required) and exercise send, receive and
+   alerts; the real-handshake test skips when the daemon is absent.
+
+## Where we are today
+
+kTLS is not reachable from Lua on `master`, but this is not a clean slate — there are two prior
+efforts, and the gap between them is the whole story.
+
+**The 2020 GSoC project** ([luainkernel/ktls](https://luainkernel.github.io/ktls/), Xinzhe Wang)
+forked the kernel's `net/tls` out of tree and patched `tls_sw.c` to call Lua on decrypted plaintext in
+`recvmsg`, with one `lua_State` per socket and a GnuTLS handshake in userspace. It reached the
+interesting goal — Lua over decrypted L7 in the kernel — but by a route that does not survive: `net/tls`
+has been reworked heavily since 5.4, a per-socket raw `lua_State` predates the whole modern runtime
+model, and the report itself measured it slower than userspace Lua + kTLS. It is a design reference,
+not a base.
+
+**The parked `claude_tls` branch** (unmerged, based on `lunatik 4.2`, ~84 commits behind) is the
+modern, in-tree-native approach that patches nothing:
+
+* `lib/luasocket.c` adds `sock:setsockopt(level, optname, optval)` plus `socket.sol` / `socket.tcp`
+  namespaces, including `TCP_ULP`. **This is the foundation, and it is not on `master`** —
+  `master`'s `luasocket` has no `setsockopt` at all.
+* `lib/luatls.c` provides `tls.pack(version, cipher, iv, key, salt, rec_seq)`, which builds the
+  `tls12_crypto_info_*` binary blob for `setsockopt(SOL_TLS)`, plus the constants; AES-GCM-128/256 and
+  ChaCha20-Poly1305, TLS 1.2/1.3, version-gated.
+* `lib/luahandshake.c` binds the kernel handshake upcall (`tls_client_hello_x509` /
+  `tls_server_hello_x509`), blocking on a completion while `tlshd` runs the handshake.
+* `lib/ktls.lua` is a high level `ktls.connect(ip, port, peername, timeout)`.
+
+What `claude_tls` does **not** have, and what this project adds, is the data path: it does client-side
+session establishment and then plain `send`/`receive`, but no plaintext relay, no tunnel, and no
+control-record handling. It also needs rebasing onto the current tree.
+
+## What is missing
+
+| Expected result | Gap |
+|-----------------|-----|
+| Key a socket for kTLS | `setsockopt` and the `tls.pack` packer exist only on the stale `claude_tls` branch, not `master`. |
+| Plaintext I/O with control records | No binding reads decrypted data with a `msg_control` buffer, so TLS control records (alert, close_notify) would error `-EIO` rather than being surfaced. |
+| Handshake upcall | The `luahandshake` binding exists on `claude_tls` but against an old base and without the socket+file plumbing spelled out. |
+| The tunnel | Nothing splices plaintext between two sockets. |
+| Tests and examples | The `claude_tls` tests cover connect; nothing covers keying with fixed vectors, alerts, or a tunnel. |
+
+Supporting gaps:
+
+* no `SOL_TLS` / `TLS_TX` / `TLS_RX` / `TCP_ULP` constants on `master`;
+* the handshake upcall needs a connected `struct socket` **with a `struct file` attached**, which the
+  socket binding must be able to provide;
+* `tlshd` is not part of the repo's test environment, so the real-handshake path is not testable
+  without installing `ktls-utils`.
+
+## Shape of the work
+
+New surface is small and mostly Lua, because kTLS is driven through socket options and the record
+crypto is the kernel's. The C side is: the `setsockopt` binding (a generic socket facility, useful
+beyond TLS), a `crypto_info` packer, and a handshake-upcall wrapper (socket+file setup plus a
+sleepable wait around the exported `tls_*_hello_*` calls). Everything above that — keying, the relay
+loop, policy on plaintext — is Lua.
+
+The full API proposal is in `api.md`; the constraints are in `kernel-notes.md`. The one fact that
+shapes the whole project:
+
+> The Linux kernel implements the TLS **record** layer but not the TLS **handshake**. Every honest
+> "in-kernel TLS" — nginx `SSL_sendfile`, HAProxy, Cilium's Envoy-based visibility, `tlshd` — keeps
+> the handshake, certificate validation and policy in userspace and only kernelizes record crypto and
+> byte movement. So a "TLS tunnel in Lua" is not a kernel TLS stack; it is a plaintext-splicing proxy
+> over already-keyed kTLS sockets, with the handshake sourced from userspace. Design against that, or
+> you end up forking `net/tls` like 2020 did.
+
+The second shaping fact: kTLS is a TCP **ULP** (`tcp_register_ulp`, `.name = "tls"`), and a socket
+carries exactly one ULP. We ride the existing `tls` ULP. Writing a *Lua* ULP — the generalization the
+2020 fork should have used, and what Pedro Tammela's 2019 `ulp-lua` thesis prototyped — is a real and
+appealing project, but it answers a different question (transparent interception of an application's
+own socket) and cannot coexist with the `tls` ULP on one socket. It is a non goal here; see below.
+
+## Phases
+
+Each phase is one or more self-contained pull requests. The order is chosen so the first increment is
+small, independently useful, and unblocks the rest.
+
+### Phase 1: `setsockopt` on the socket (the foundation)
+
+Rebase the `claude_tls` `sock:setsockopt(level, optname, optval)` plus the `socket.sol` / `socket.tcp`
+constant namespaces onto the current tree. This is useful on its own (any socket option becomes
+reachable, `TCP_ULP` included) and it is the prerequisite for everything else. Ship it as its own PR,
+not folded into TLS.
+
+Deliverables: the `setsockopt` method and the option-level namespaces in `lib/luasocket.c`, tests,
+README and `config.ld` updates.
+
+### Phase 2: key a socket for kTLS
+
+The `tls` module: the `SOL_TLS` / `TLS_TX` / `TLS_RX` constants and `tls.pack(version, cipher, iv,
+key, salt, rec_seq)` producing the `tls12_crypto_info_*` blob. Attach the ULP
+(`sock:setsockopt(tcp.ULP, "tls")`) and install a session from Lua. Rebase `luatls.c`. Cover the
+cipher/version matrix and the error cases (`-ENOTCONN` before connect, `-EBUSY` on a second install).
+
+### Phase 3: plaintext I/O with control records
+
+Read decrypted plaintext and write plaintext over the keyed socket, with bounded receives, and — the
+new part — a `msg_control` buffer so a received alert or close_notify is surfaced (via
+`tls_get_record_type` / `tls_alert_recv`) rather than turning into `-EIO`. Sending a non-data record
+(a controlled close_notify) via the `TLS_SET_RECORD_TYPE` cmsg is included. This is the phase that
+makes the socket usable as a data path, not just keyable.
+
+### Phase 4: the handshake upcall
+
+The `handshake` module binding `tls_client_hello_*` / `tls_server_hello_*`: build a connected socket
+with a `struct file`, fill `tls_handshake_args`, submit, and wait on a completion in a sleepable
+runtime while `tlshd` negotiates and keys the socket. Mute `sk_data_ready` for the duration. Rebase
+`luahandshake.c` and `ktls.lua`; land the `ktls.connect` client example. Tests skip cleanly when
+`tlshd` is not installed.
+
+### Phase 5: the TLS tunnel
+
+The use case: a spawned kernel thread that relays plaintext between two sockets — bounded `recv` on
+side A, optional plaintext inspection or rewrite in Lua, `send` on side B (which re-encrypts if it is
+a kTLS TX socket), symmetrically B to A, polling `thread.shouldstop()` each pass and yielding with
+`linux.schedule()`. One or both sides may be kTLS. Steering (which flows enter the tunnel) can come
+from a netfilter/XDP hook, but the relay stays in the kthread.
+
+### Phase 6: examples and documentation
+
+A client example and a tunnel example, a documentation pass, and the API cleanup the examples expose.
+The tunnel example is honest about its limits (single buffer per read, no reassembly beyond what the
+socket delivers), and documents the `tlshd` dependency and the TLS 1.3 KeyUpdate caveat.
+
+## Sizing
+
+Sized by what fits in a reviewable pull request.
+
+| Scope | Phases |
+|-------|--------|
+| Minimum useful | 1 to 3. A socket can be keyed and used for plaintext I/O from Lua, tested with fixed vectors. |
+| Complete | 1 to 6. Adds the delegated handshake, the tunnel, and the examples. |
+
+Phase 3 is the boundary that matters: through it, kTLS is a usable data path in Lua with no userspace
+dependency (keys installed directly). Phase 4 onward brings in `tlshd` for real handshakes.
+
+## Non goals
+
+* **A kernel TLS handshake.** The kernel has none by design; the handshake stays in userspace
+  (`tlshd`, or an application). This binding never negotiates TLS itself.
+* **A Lua ULP.** Writing a `tcp_ulp_ops` whose `init` binds a Lunatik runtime to the socket — letting
+  Lua *be* an upper-layer protocol for arbitrary L7, the modern successor to Pedro Tammela's `ulp-lua`
+  and the right framing the 2020 fork lacked — is a separate, worthwhile project. It serves transparent
+  interception of an application's own socket, cannot share a socket with the `tls` ULP, and is more C
+  and lower level. Its reusable ideas (ULP `init` to a runtime, a backlog-sized pool of pre-warmed
+  runtimes, skb-as-`data`) are noted for that project, not built here.
+* **A transparent `luatls` ULP** that both keys via kTLS and exposes plaintext to a Lua hook (the 2020
+  dream done without a fork). Appealing, but it is the hard evolution on top of both this project and a
+  Lua-ULP; not a first build.
+* **Forking or patching `net/tls`.** The whole point of the modern approach is that it patches nothing.
+* **Zero-copy sockmap/`sk_msg` datapath.** BPF socket-splice is a real optimization and a reference
+  architecture, but it is C/BPF not Lua, carries live limitations (splice vs the psock queue, RCU),
+  and is not needed for a first working tunnel. Deferred.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| `claude_tls` is 84 commits stale; the socket changes may conflict | Rebase phase by phase, starting with `setsockopt` alone, not as one big drop. Re-verify against current `lib/luasocket.c`. |
+| An unbounded `recv` in a kthread hangs the machine (the strparser does not check `kthread_should_stop`) | Every receive is bounded (`MSG_DONTWAIT` / `SO_RCVTIMEO_NEW`) and the loop polls `shouldstop()`; this is a hard rule, tested in phase 5. |
+| Control records error `-EIO` without a `msg_control` buffer | Phase 3 makes the plaintext read path always carry a control buffer; tested with a close_notify. |
+| Handshake upcall needs a `struct socket` with a `struct file` and a running `tlshd` | Phase 4 builds the file plumbing explicitly; tests skip when `tlshd` is absent, and the phase-3 path (manual keys) needs neither. |
+| TLS 1.3 KeyUpdate is unsupported before kernel 6.14 | Documented; long-lived 1.3 sessions that re-key are out of scope on older kernels, and tests note it. |
+| kTLS key/nonce reuse is not checked by the kernel | Documented as a caller responsibility; the packer does not invent sequence numbers. |
+
+## Definition of done, per phase
+
+1. builds clean on the target kernel, no new warnings;
+2. LDoc on every new function and object type; new modules listed in `config.ld` in alphabetical order;
+3. a row in the README module table;
+4. a test in the right suite, wired into its `run.sh`, and described in `tests/README.md`;
+5. the test skips (not fails) when the kernel lacks the config, or when `tlshd` is absent;
+6. the full suite still passes: `sudo lunatik test`;
+7. error paths audited: for every raise, whatever was acquired is released;
+8. commits are small and each one stands alone; a rebased import is a distinct, reviewable commit.
+

--- a/doc/design/ktls/testing.md
+++ b/doc/design/ktls/testing.md
@@ -1,0 +1,99 @@
+# Testing the kernel TLS binding
+
+Lunatik's tests are shell scripts emitting KTAP, driving a kernel Lua script and asserting on `dmesg`
+or on what userspace observes. `tests/socket/` is the closest existing model; read it and `tests/lib.sh`
+(`run_test`, `mark_dmesg`, `dmesg_since`, `check_dmesg`, `ktap_skip`) first.
+
+Run everything with `sudo lunatik test`, one suite with `sudo lunatik test ktls`.
+
+## What this suite needs that others do not
+
+**Keying without a handshake.** The whole point of testing phases 1–3 is that they need no `tlshd` and
+no real peer: install a known TLS session with **fixed key vectors** on both ends of a loopback socket
+pair and exercise send/receive. This is exactly how the kernel's own kTLS selftest
+(`tools/testing/selftests/net/tls.c`) works — both directions get the same key material, so plaintext
+written on one end comes back decrypted on the other, with no negotiation. Use a published test vector
+(or any fixed key) for AES-GCM-128 and ChaCha20-Poly1305.
+
+**A skip gate for `tlshd`.** The handshake path (phase 4) needs the `tlshd` daemon and auth material in
+keyrings. The suite's `run.sh` checks for it once and reports `ktap_skip` per planned handshake test
+when it is absent, so a green run on a box without `tlshd` shows skips rather than a false pass. The
+development box does not have it.
+
+**A config gate for `CONFIG_TLS`.** Skip cleanly if `tls.ko` is unavailable.
+
+## Test matrix
+
+Coverage means the matrix of operation × cipher × outcome, including the successes and the clean
+failures, not a list of features.
+
+### Phase 1: `setsockopt`
+
+| Test | Proves |
+|------|--------|
+| `setsockopt.sh` | a socket option round-trips (set then, where readable, get); `socket.sol`/`socket.tcp` constants resolve; an unknown level/option raises rather than silently passing |
+| `ulp.sh` | `setsockopt(TCP, ULP, "tls")` on a connected socket attaches the ULP; on an unconnected socket it raises `ENOTCONN` |
+
+### Phase 2: keying
+
+| Test | Proves |
+|------|--------|
+| `pack.sh` | `tls.pack` produces a blob of the exact size the kernel wants for each cipher; a wrong-length or unknown cipher raises |
+| `key_gcm.sh` | attach ULP + install TLS 1.3 AES-GCM-128 TX and RX with fixed vectors succeeds |
+| `key_chacha.sh` | same for ChaCha20-Poly1305 (salt size 0 handled) |
+| `key_errors.sh` | installing before connect raises `ENOTCONN`; installing a direction twice raises `EBUSY` |
+
+### Phase 3: plaintext I/O
+
+| Test | Proves |
+|------|--------|
+| `loopback.sh` | with matching keys on both ends of a loopback pair, plaintext sent on A returns decrypted on B, both ciphers |
+| `record_type.sh` | `receive` returns `"data"` for application data; a received close_notify surfaces as an `"alert"` record instead of `-EIO`; the alert decodes to close_notify |
+| `close_notify.sh` | `sock:close_notify()` emits a control record the peer reads as an alert |
+| `bounded_recv.sh` | a bounded `receive` on an empty socket returns promptly (timeout / would-block), not blocking forever — the property a kthread relay depends on |
+
+`loopback.sh` and `record_type.sh` carry the phase: the first proves the data path works with no
+userspace TLS at all, the second proves control records do not break reads.
+
+### Phase 4: handshake (skips without `tlshd`)
+
+| Test | Proves |
+|------|--------|
+| `handshake_anon.sh` | `handshake.client` on a connected socket to a local TLS server completes and yields a keyed socket (anon/encryption-only); skips if `tlshd` is absent |
+| `handshake_timeout.sh` | a handshake to a non-responding peer times out cleanly and the socket is usable/closable, not wedged |
+| `connect.sh` | `ktls.connect` performs connect + ULP + handshake and returns a socket that sends/receives plaintext against a local TLS echo server; skips without `tlshd` |
+
+### Phase 5: the tunnel
+
+| Test | Proves |
+|------|--------|
+| `tunnel_plain.sh` | a spawned tunnel relays bytes between two plain sockets; `stop` actually stops it (bounded recv + `shouldstop`), run twice with no leak |
+| `tunnel_tls.sh` | a tunnel with a kTLS side relays plaintext in and re-encrypted out; the far end reads correct data (fixed vectors, no `tlshd`) |
+| `tunnel_inspect.sh` | a plaintext transform in the relay is observed on the far end (proves the inspection point) |
+
+`tunnel_plain.sh` is the stoppability test and must run first: a tunnel that cannot be stopped is a
+hung machine, so prove `stop` before adding TLS.
+
+### Phase 6: examples
+
+| Test | Proves |
+|------|--------|
+| `example_connect.sh` | the client example runs against a local TLS server (skips without `tlshd`) |
+| `example_tunnel.sh` | the tunnel example forwards a request and stops cleanly (fixed-vector kTLS, no `tlshd`) |
+
+## Conventions to follow
+
+* skip, do not fail, when the kernel lacks `CONFIG_TLS`, or when `tlshd` is absent;
+* mark `dmesg` before the run, read only what came after, and `check_dmesg` at the end;
+* clean up sockets and stop threads in a `trap`, and run the cleanup once up front;
+* `lunatik run` exits 0 even when the script fails to load — assert on output, never on exit status;
+* one `.sh` per row, wired into `tests/ktls/run.sh` and described in `tests/README.md`, same commit as
+  the code it tests.
+
+## A note on the loopback keying trick
+
+The fixed-vector loopback pattern lets phases 1–3 and the TLS tunnel be tested with **no** `tlshd`, no
+certificates, and no real peer — the same shortcut the kernel selftest uses. It exercises the record
+layer and the whole Lua data path honestly; only the handshake delegation genuinely needs the daemon,
+and those tests skip when it is missing. Keep the vectors in the test, not in the library.
+


### PR DESCRIPTION
Design notes for the kernel TLS (kTLS) epic (#723), in the same shape as the other
`doc/design/<theme>/` sets: plan, proposed API, verified kernel reference, test strategy.

`doc/design/ktls/` covers a kTLS binding so Lua scripts can key a connected socket for TLS, read and
write plaintext while the kernel does the record-layer crypto, delegate the handshake to `tlshd`
through the kernel handshake upcall, and splice plaintext between sockets — enough for a TLS proxy or
an in-kernel TLS tunnel in Lua.

The design turns on one fact, stated up front so a contributor does not rediscover it the hard way:

> The Linux kernel implements the TLS record layer but not the handshake. Every honest "in-kernel TLS"
> — nginx `SSL_sendfile`, HAProxy, Cilium's Envoy-based visibility, `tlshd` — keeps the handshake,
> certificate validation and policy in userspace and only kernelizes record crypto and byte movement.
> So a "TLS tunnel in Lua" is a plaintext-splicing proxy over already-keyed kTLS sockets, not a kernel
> TLS stack — design against that, or you fork `net/tls` like the 2020 GSoC project did.

It is built incrementally, and half the foundation already exists on a parked `claude_tls` branch
(`socket:setsockopt`, a `tls` crypto-info packer, a handshake-upcall binding — but not on `master`,
and without the data path). The early phases rebase that; the later phases add plaintext I/O with
control records, the handshake plumbing, and the tunnel. kTLS is a TCP ULP and a socket carries one
ULP, so we ride the kernel's `tls` ULP; a Lua ULP (the successor to Pedro Tammela's `ulp-lua`) is a
separate project, kept as a non goal.

The `kernel-notes.md` facts were verified against Linux 6.8 source and the running kernel's exported
symbols: the two-step setsockopt keying, the module-callable handshake upcall (`tls_client_hello_*`,
all plain `EXPORT_SYMBOL`), the `-EIO`-without-a-control-buffer gotcha on the plaintext read path, and
the version drift (TLS 1.3 KeyUpdate lands in 6.14, absent in 6.8).
