### PR TITLE
eBPF: clean up the shared binding header

### DIFF
--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -247,7 +247,7 @@ static int luaxdp_attach(lua_State *L)
 	lunatik_register(L, -1, ctx->argument);
 	lua_pop(L, 1);
 
-	lunatik_ebpf_attach(L, &ctx->callback_ref);
+	lunatik_ebpf_attach(L, 1, &ctx->callback_ref);
 	return 0;
 }
 #endif

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -38,7 +38,7 @@ typedef struct luaxdp_ctx_s {
 	int              *action;
 	lunatik_object_t *packet;
 	lunatik_object_t *argument;
-	int              callback_ref;
+	int              cb;
 } luaxdp_ctx_t;
 
 LUNATIK_PRIVATECHECKER(luaxdp_ctx_check, luaxdp_ctx_t *,
@@ -137,7 +137,7 @@ static int luaxdp_handler(lua_State *L, luaxdp_ctx_t *ctx)
 	luadata_reset(lctx->packet, lctx->xdp->data, lctx->xdp->data_end - lctx->xdp->data, LUADATA_OPT_KEEP);
 	luadata_reset(lctx->argument, lctx->arg, lctx->arg__sz, LUADATA_OPT_KEEP);
 
-	ret = lunatik_ebpf_invoke(L, lctx->callback_ref);
+	ret = lunatik_ebpf_invoke(L, lctx->cb);
 	luaxdp_handler_cleanup(lctx);
 	return ret;
 }
@@ -178,7 +178,7 @@ static int luaxdp_detach(lua_State *L)
 	if (lctx == NULL)
 		return 0;
 
-	lunatik_ebpf_detach(L, &lctx->callback_ref);
+	lunatik_ebpf_detach(L, &lctx->cb);
 	lunatik_unregister(L, lctx->packet);
 	lunatik_unregister(L, lctx->argument);
 	return 0;
@@ -247,7 +247,7 @@ static int luaxdp_attach(lua_State *L)
 	lunatik_register(L, -1, ctx->argument);
 	lua_pop(L, 1);
 
-	lunatik_ebpf_attach(L, 1, &ctx->callback_ref);
+	lunatik_ebpf_attach(L, 1, &ctx->cb);
 	return 0;
 }
 #endif

--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -65,9 +65,9 @@ static inline void *lunatik_ebpf_getctx(lua_State *L)
 	return obj->private;
 }
 
-static inline int lunatik_ebpf_invoke(lua_State *L, int callback_ref)
+static inline int lunatik_ebpf_invoke(lua_State *L, int cb)
 {
-	lua_rawgeti(L, LUA_REGISTRYINDEX, callback_ref);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, cb);
 	lua_insert(L, -2);
 	if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
 		pr_err_ratelimited("%s\n", lua_tostring(L, -1));
@@ -77,19 +77,19 @@ static inline int lunatik_ebpf_invoke(lua_State *L, int callback_ref)
 	return 0;
 }
 
-static inline void lunatik_ebpf_attach(lua_State *L, int ix, int *callback_ref)
+static inline void lunatik_ebpf_attach(lua_State *L, int ix, int *cb)
 {
 	lua_pushvalue(L, ix);
-	*callback_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+	*cb = luaL_ref(L, LUA_REGISTRYINDEX);
 
 	lunatik_register(L, -1, &lunatik_ebpf_env_key);
 	lua_pop(L, 1);
 }
 
-static inline void lunatik_ebpf_detach(lua_State *L, int *callback_ref)
+static inline void lunatik_ebpf_detach(lua_State *L, int *cb)
 {
-	luaL_unref(L, LUA_REGISTRYINDEX, *callback_ref);
-	*callback_ref = LUA_NOREF;
+	luaL_unref(L, LUA_REGISTRYINDEX, *cb);
+	*cb = LUA_NOREF;
 	lunatik_unregister(L, &lunatik_ebpf_env_key);
 	lua_pop(L, 1);
 }

--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -69,12 +69,6 @@ static inline void *lunatik_ebpf_getctx(lua_State *L)
 static inline int lunatik_ebpf_invoke(lua_State *L, int callback_ref)
 {
 	lua_rawgeti(L, LUA_REGISTRYINDEX, callback_ref);
-	if (!lua_isfunction(L, -1)) {
-		pr_err_ratelimited("callback_ref is not a function\n");
-		lua_pop(L, 2);
-		return -1;
-	}
-
 	lua_insert(L, -2);
 	if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
 		pr_err_ratelimited("%s\n", lua_tostring(L, -1));

--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -116,17 +116,17 @@ do { \
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
-#define LUNATIK_BTF_SET_START(name) BTF_KFUNCS_START(name)
-#define LUNATIK_BTF_SET_END(name)   BTF_KFUNCS_END(name)
+#define LUNATIK_EBPF_BTF_SET_START(name) BTF_KFUNCS_START(name)
+#define LUNATIK_EBPF_BTF_SET_END(name)   BTF_KFUNCS_END(name)
 #else
-#define LUNATIK_BTF_SET_START(name) BTF_SET8_START(name)
-#define LUNATIK_BTF_SET_END(name)   BTF_SET8_END(name)
+#define LUNATIK_EBPF_BTF_SET_START(name) BTF_SET8_START(name)
+#define LUNATIK_EBPF_BTF_SET_END(name)   BTF_SET8_END(name)
 #endif
 
 #define LUNATIK_EBPF_KFUNC_DEFINE_SET(subsys, kfunc) \
-	LUNATIK_BTF_SET_START(bpf_lua##subsys##_set) \
+	LUNATIK_EBPF_BTF_SET_START(bpf_lua##subsys##_set) \
 	BTF_ID_FLAGS(func, kfunc) \
-	LUNATIK_BTF_SET_END(bpf_lua##subsys##_set) \
+	LUNATIK_EBPF_BTF_SET_END(bpf_lua##subsys##_set) \
 	static const struct btf_kfunc_id_set bpf_lua##subsys##_kfunc_set = { \
 		.owner = THIS_MODULE, \
 		.set   = &bpf_lua##subsys##_set, \

--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -30,7 +30,7 @@ static inline int lunatik_ebpf_checkruntimes(void)
 		lunatik_ebpf_runtimes = luarcu_getobject(lunatik_env, runtimes_key, sizeof(runtimes_key) - 1);
 	if (lunatik_ebpf_percpu == NULL)
 		lunatik_ebpf_percpu = luarcu_getobject(lunatik_env, percpu_key, sizeof(percpu_key) - 1);
-	return lunatik_ebpf_runtimes && lunatik_ebpf_percpu ? 0 : -1;
+	return !(lunatik_ebpf_runtimes && lunatik_ebpf_percpu);
 }
 
 static inline lunatik_object_t *lunatik_ebpf_lookupruntime(char *key, size_t key_sz, int cpuid)

--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -84,9 +84,9 @@ static inline int lunatik_ebpf_invoke(lua_State *L, int callback_ref)
 	return 0;
 }
 
-static inline void lunatik_ebpf_attach(lua_State *L, int *callback_ref)
+static inline void lunatik_ebpf_attach(lua_State *L, int ix, int *callback_ref)
 {
-	lua_pushvalue(L, 1);
+	lua_pushvalue(L, ix);
 	*callback_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
 	lunatik_register(L, -1, &lunatik_ebpf_env_key);

--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -47,8 +47,7 @@ static inline lunatik_object_t *lunatik_ebpf_lookupruntime(char *key, size_t key
 	runtime = luarcu_getobject(lunatik_ebpf_runtimes, key, keylen);
 	if (!runtime) {
 		char cpu_key[LUARCU_MAXKEY];
-		size_t cpulen;
-		cpulen = scnprintf(cpu_key, sizeof(cpu_key), "%s:%d", key, cpuid);
+		size_t cpulen = scnprintf(cpu_key, sizeof(cpu_key), "%s:%d", key, cpuid);
 		runtime = luarcu_getobject(lunatik_ebpf_percpu, cpu_key, cpulen);
 	}
 	return runtime;

--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -54,7 +54,6 @@ static inline lunatik_object_t *lunatik_ebpf_lookupruntime(char *key, size_t key
 	return runtime;
 }
 
-/* on success the context userdata stays on the stack, ready to be passed to the callback */
 static inline void *lunatik_ebpf_getctx(lua_State *L)
 {
 	lunatik_object_t *obj;
@@ -67,8 +66,6 @@ static inline void *lunatik_ebpf_getctx(lua_State *L)
 	return obj->private;
 }
 
-/* invokes the Lua callback referenced by 'callback_ref', consuming the
- * context userdata that lunatik_ebpf_getctx() left on top of the stack */
 static inline int lunatik_ebpf_invoke(lua_State *L, int callback_ref)
 {
 	lua_rawgeti(L, LUA_REGISTRYINDEX, callback_ref);
@@ -87,8 +84,6 @@ static inline int lunatik_ebpf_invoke(lua_State *L, int callback_ref)
 	return 0;
 }
 
-/* references the Lua function at stack index 1 as the callback and binds its
- * lifetime to 'env_key' (the ctx object must already be on top of the stack) */
 static inline void lunatik_ebpf_attach(lua_State *L, int *callback_ref)
 {
 	lua_pushvalue(L, 1);
@@ -98,7 +93,6 @@ static inline void lunatik_ebpf_attach(lua_State *L, int *callback_ref)
 	lua_pop(L, 1);
 }
 
-/* the caller still unregisters any binding specific sub-objects */
 static inline void lunatik_ebpf_detach(lua_State *L, int *callback_ref)
 {
 	luaL_unref(L, LUA_REGISTRYINDEX, *callback_ref);
@@ -107,8 +101,6 @@ static inline void lunatik_ebpf_detach(lua_State *L, int *callback_ref)
 	lua_pop(L, 1);
 }
 
-/* looks up the runtime for 'key'/'key_sz', runs 'handler' with 'ctxp' on it,
- * and releases the runtime; a no-op if no matching runtime is found */
 #define LUNATIK_EBPF_RUN(key, key_sz, handler, ctxp) \
 do { \
 	lunatik_object_t *__runtime = lunatik_ebpf_lookupruntime((key), (key_sz), raw_smp_processor_id()); \


### PR DESCRIPTION
Cleanup of `lunatik_ebpf.h` after #716.

- Pass the callback's stack index to `attach` (named `ix`, the base's convention) instead of hardcoding argument 1 in the shared helper.
- Drop the redundant callback type check in `invoke`: the callback is validated as a function at attach, so it is always one here, and `lua_pcall` would catch a non-callable anyway.
- Name the callback reference `cb`, matching the base (luarcu, luahid); `callback_ref` was the only `_ref` name in the tree.
- Simplify the `checkruntimes` result to `!(a && b)` (the caller only tests against zero).
- Drop the block comments the base keeps off internal `static inline` helpers — lunatik.h carries none — keeping only `checkkey`'s.
- Initialize `cpulen` at declaration (C99).
- Prefix the `BTF_SET` macros with `LUNATIK_EBPF_`, aligning them with the family. Closes #722.

Test plan:
- `make` builds `luaxdp.ko` clean against the changed header.