### PR TITLE
docs: conventions from the eBPF cleanup (naming, comments, redundancy)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,9 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
 * Symbols in a library are prefixed `LUA<LIBNAME>_` or `lua<libname>_`.
 * The `l` prefix on a Lua binding (`lunatik_lruntime`) exists to disambiguate from a C function of
   the same name. Without that collision, the plain name is the right one.
+* A name matches what the tree already calls the same thing; grep for it before choosing. A Lua stack
+  index is `ix`, a callback `cb`. Importing `arg` or `callback_ref` where the base settled on a
+  shorter word is a deviation.
 * Kernel headers first, then a blank line, then `#include <lunatik.h>`. Do not remove that blank line.
 * `<lua.h>` and `<lauxlib.h>` are already pulled in by `lunatik.h`.
 * Every file ends with a trailing blank line. A pre commit hook rejects files that do not.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,10 @@ the body.
   paths is not a guarantee: make it structural or do not offer it. Merging a half measure and opening
   a follow up that deletes it pollutes the history across pull requests the same way a commit that
   undoes another one pollutes a branch.
+* Removing a check as redundant is verified, not asserted: trace the invariant to whoever establishes
+  it and confirm every path that sets the value does. `invoke`'s type check is redundant because
+  `attach` validates the callback first, so it is always a function there; a `pcall` that would catch
+  a bad value anyway is a second reason, not the trace.
 * Refusing is a legitimate outcome. When a combination has no sound semantics yet, refuse it where it
   is registered, with an error that names the reason, rather than shipping an approximation. Lifting
   the refusal afterwards is one line and a test.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,10 @@ Never `require("foo").method()`.
 * Reaching for a comment is a signal to reconsider the code's clarity first: a name that states the
   intent, a helper that names the step, an enum instead of a bare constant. Comment what the code
   cannot be made to say, not what a clearer shape would.
+* An internal `static inline` helper carries no block comment — `lunatik.h` keeps none on any of its
+  own. A comment describing what such a helper does restates the code; the fix is removing it, not
+  trimming it. A block survives only for a reason the code cannot state, as `checkkey`'s zero-size
+  note does.
 * Public functions and object types get LDoc comments. Use `@type <class>` names that do not collide
   with a function name, or LDoc will attach the wrong things.
 * LDoc does not surface a method a class inherits. To show it on the subclass's page, add a doc-only


### PR DESCRIPTION
Three conventions from the #731 cleanup round, so the mistakes it corrected are not repeated.

- A name follows the term the tree already uses (`ix` for a stack index, `cb` for a callback), grepped for before choosing rather than imported from habit.
- An internal `static inline` helper carries no block comment — `lunatik.h` keeps none on any of its own — so the fix for one that restates the code is removal, not trimming.
- Removing a check as redundant is verified by tracing the invariant to whoever establishes it, not asserted.