### PR TITLE
tests/runtime: skip the percpu rollback test on a single CPU

### DIFF
--- a/tests/runtime/percpu.sh
+++ b/tests/runtime/percpu.sh
@@ -67,16 +67,21 @@ case "$listed" in
 esac
 ktap_pass "spawn refuses percpu without creating runtimes"
 
-output=$(lunatik run "$FAIL_SCRIPT" percpu 2>&1)
-echo "$output" | grep -q "intentional error on the second instance" || \
-	fail "the percpu run did not fail as intended: $output"
-mark_dmesg
-run_script "$FAIL_CHECK"
-check_dmesg || { ktap_totals; exit 1; }
-lunatik stop "$FAIL_CHECK" > /dev/null 2>&1
-run_script "$FAIL_SCRIPT"
-lunatik stop "$FAIL_SCRIPT" > /dev/null 2>&1
-ktap_pass "a failing instance rolls back the ones already created"
+# the rollback needs a second instance to fail, so it runs only with >1 possible CPU
+if [ "$(nproc --all)" -ge 2 ]; then
+	output=$(lunatik run "$FAIL_SCRIPT" percpu 2>&1)
+	echo "$output" | grep -q "intentional error on the second instance" || \
+		fail "the percpu run did not fail as intended: $output"
+	mark_dmesg
+	run_script "$FAIL_CHECK"
+	check_dmesg || { ktap_totals; exit 1; }
+	lunatik stop "$FAIL_CHECK" > /dev/null 2>&1
+	run_script "$FAIL_SCRIPT"
+	lunatik stop "$FAIL_SCRIPT" > /dev/null 2>&1
+	ktap_pass "a failing instance rolls back the ones already created"
+else
+	ktap_skip "a failing instance rolls back the ones already created (needs >1 CPU)"
+fi
 
 run_script "$SCRIPT" percpu
 lunatik stop "$SCRIPT:0" > /dev/null 2>&1


### PR DESCRIPTION
On a host with a single possible CPU, `tests/runtime/percpu.sh`'s rollback case failed. The case runs a script that errors on the second instance to check the earlier instances roll back, but with one CPU only one instance is ever created, so the intentional failure never fires and the `run` succeeds — which the test reported as a failure (seen by a newcomer on a 1-vCPU VM).

Guard the case with `nproc --all` and skip it when there is only one CPU; the plan stays at 6.

Test plan:
- 6 CPUs: the case runs and passes (suite 6/6).
- Simulated single CPU (nproc shim returning 1): the case skips, suite green (pass:5 skip:1 fail:0).