### PR TITLE
tests/tc: cover re-attaching a callback in the same runtime

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -286,6 +286,10 @@ BTF, or `bpftool`, `clang` or `tc` is unavailable.
 - **tc drop**: `action.ACT_SHOT` blocks the ping; the runtime is percpu,
   covering the per-CPU kfunc lookup.
 
+- **tc reattach**: the script attaches one callback and then a second in the
+  same runtime; the ping passes because only the last callback runs, exercising
+  the re-attach path.
+
 - **tc detach**: the callback drops the first ping and calls `tc.detach()`
   from inside the callback; traffic resumes because `bpf_luatc_run` then
   returns `-1` and the eBPF program falls back to `TC_ACT_OK`.

--- a/tests/tc/Makefile
+++ b/tests/tc/Makefile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: (c) 2026 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
 # SPDX-License-Identifier: MIT OR GPL-2.0-only
 
-all: tc_pass.bpf.o tc_drop.bpf.o tc_detach.bpf.o tc_zerokey.bpf.o
+all: tc_pass.bpf.o tc_drop.bpf.o tc_detach.bpf.o tc_zerokey.bpf.o tc_reattach.bpf.o
 
 vmlinux.h:
 	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $@
@@ -18,6 +18,9 @@ tc_detach.bpf.o: tc_detach.bpf.c vmlinux.h
 tc_zerokey.bpf.o: tc_zerokey.bpf.c vmlinux.h
 	clang -target bpf -Wall -O2 -c -g $<
 
+tc_reattach.bpf.o: tc_reattach.bpf.c vmlinux.h
+	clang -target bpf -Wall -O2 -c -g $<
+
 clean:
-	rm -f vmlinux.h tc_pass.bpf.o tc_drop.bpf.o tc_detach.bpf.o tc_zerokey.bpf.o
+	rm -f vmlinux.h tc_pass.bpf.o tc_drop.bpf.o tc_detach.bpf.o tc_zerokey.bpf.o tc_reattach.bpf.o
 

--- a/tests/tc/reattach.lua
+++ b/tests/tc/reattach.lua
@@ -1,0 +1,22 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the tc re-attach test (see test_tc.sh).
+
+local tc     = require("tc")
+local action = require("linux.tc")
+
+local function replaced(ctx)
+	print("tc reattach test fail: the replaced callback ran")
+	ctx:action(action.ACT_SHOT)
+end
+
+local function current(ctx)
+	print("tc reattach test pass: re-attach installed the last callback")
+	ctx:action(action.ACT_OK)
+end
+
+tc.attach(replaced)
+tc.attach(current)
+

--- a/tests/tc/tc_reattach.bpf.c
+++ b/tests/tc/tc_reattach.bpf.c
@@ -1,0 +1,24 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb) __ksym;
+
+static char runtime[] = "tests/tc/reattach";
+
+int const TC_ACT_OK = 0;
+
+SEC("classifier")
+int test_tc_reattach(struct __sk_buff *skb)
+{
+	int ret;
+	ret = bpf_luatc_run(runtime, sizeof(runtime), skb);
+	return ret < 0 ? TC_ACT_OK : ret;
+}
+
+char _license[] SEC("license") = "Dual MIT/GPL";
+

--- a/tests/tc/test_tc.sh
+++ b/tests/tc/test_tc.sh
@@ -38,7 +38,7 @@ tc_unload()
 }
 
 ktap_header
-ktap_plan 5
+ktap_plan 6
 
 skip_all()
 {
@@ -64,6 +64,7 @@ cleanup()
 	tc qdisc del dev "$IFACE" clsact 2>/dev/null
 	lunatik stop tests/tc/pass > /dev/null 2>&1
 	lunatik stop tests/tc/drop > /dev/null 2>&1
+	lunatik stop tests/tc/reattach > /dev/null 2>&1
 	lunatik stop tests/tc/detach > /dev/null 2>&1
 	lunatik stop tests/tc/attach_sleepable > /dev/null 2>&1
 	ip netns del "$NETNS" 2>/dev/null
@@ -164,6 +165,8 @@ run_case tc_pass.bpf.o pass.lua yes "tc pass" \
 	"tc pass test pass: packet content verified" softirq
 run_case tc_drop.bpf.o drop.lua no "tc drop" \
 	"tc drop test pass: verdict set to drop" softirq percpu
+run_case tc_reattach.bpf.o reattach.lua yes "tc reattach" \
+	"tc reattach test pass: re-attach installed the last callback" softirq
 detach_case
 
 mark_dmesg


### PR DESCRIPTION
New coverage stacked on #713: a tc re-attach case. The script attaches one callback, then a second in the same runtime; the ping passes because only the last callback runs. xdp has no equivalent test.

Note: on #713's current code re-attaching leaks the previous binding (see the review comment there). This test exercises the re-attach path and the replace semantics; it passes both before and after that fix, since the leak is not functionally observable (the env-key registration is simply overwritten).

Test plan:
- `sudo lunatik test tc` -> 6/6, the new `tc reattach` case passes.