### PR TITLE
lunatik: promote pushoptinteger to a shared helper

### DIFF
--- a/lib/luaskb.c
+++ b/lib/luaskb.c
@@ -26,9 +26,6 @@ LUNATIK_PRIVATECHECKER(luaskb_check, luaskb_t *,
 	luaL_argcheck(L, private->skb != NULL, ix, "skb is not set");
 );
 
-#define luaskb_pushoptinteger(L, cond, val)	\
-	((cond) ? lua_pushinteger(L, val) : lua_pushnil(L))
-
 /* FRAGLIST GSO skbs hold segments in frag_list; skb_copy refuses to copy
  * them (ambiguous semantics: copy the container or the segments?). */
 #ifdef SKB_GSO_FRAGLIST
@@ -77,7 +74,7 @@ static int luaskb_ifindex(lua_State *L)
 {
 	luaskb_t *lskb = luaskb_check(L, 1);
 	struct net_device *dev = lskb->skb->dev;
-	luaskb_pushoptinteger(L, dev, dev->ifindex);
+	lunatik_pushoptinteger(L, dev, dev->ifindex);
 	return 1;
 }
 
@@ -89,7 +86,7 @@ static int luaskb_vlan(lua_State *L)
 {
 	luaskb_t *lskb = luaskb_check(L, 1);
 	struct sk_buff *skb = lskb->skb;
-	luaskb_pushoptinteger(L, skb_vlan_tag_present(skb), skb_vlan_tag_get_id(skb));
+	lunatik_pushoptinteger(L, skb_vlan_tag_present(skb), skb_vlan_tag_get_id(skb));
 	return 1;
 }
 
@@ -223,7 +220,7 @@ static int luaskb_connmark(lua_State *L)
 
 	if (ct && set)
 		WRITE_ONCE(ct->mark, value);
-	luaskb_pushoptinteger(L, ct, (lua_Integer)(u32)READ_ONCE(ct->mark));
+	lunatik_pushoptinteger(L, ct, (lua_Integer)(u32)READ_ONCE(ct->mark));
 	return 1;
 }
 #endif /* CONFIG_NF_CONNTRACK_MARK */

--- a/lunatik.h
+++ b/lunatik.h
@@ -130,6 +130,8 @@ static inline const char *lunatik_pushstring(lua_State *L, char *s, size_t len)
 	return lua_pushexternalstring(L, s, len, alloc, ud);
 }
 
+#define lunatik_pushoptinteger(L, cond, val)	((cond) ? lua_pushinteger((L), (val)) : lua_pushnil((L)))
+
 static inline void *lunatik_realloc(lua_State *L, void *ptr, size_t size)
 {
 	LUNATIK_ALLOC(L, alloc, ud);

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -166,10 +166,7 @@ static int lunatik_lresume(lua_State *L)
 */
 static int lunatik_cpu(lua_State *L)
 {
-	if (lunatik_ispercpu(L))
-		lua_pushinteger(L, lunatik_getcpu(L));
-	else
-		lua_pushnil(L);
+	lunatik_pushoptinteger(L, lunatik_ispercpu(L), lunatik_getcpu(L));
 	return 1;
 }
 


### PR DESCRIPTION
`luaskb` had a local `pushoptinteger` macro; `lunatik_cpu` in the core open-coded the same "push this integer, or nil" as an if/else. This promotes it to `lunatik.h` as `lunatik_pushoptinteger` and uses it in both — a shared helper with two independent consumers (core + luaskb), which is what earns it a place in `lunatik.h`.

It stays a macro, not a `static inline`: the call sites pass values meaningful only when the condition holds (`dev->ifindex`, `skb_vlan_tag_get_id`, `READ_ONCE(ct->mark)`), and a function would evaluate them unconditionally — dereferencing a NULL `dev` or `ct` in exactly the case the guard exists for. The ternary evaluates `val` only on the truthy arm.

**Test:** `lunatik test runtime` is green (percpu 6/6, percpu_refuse 4/4) — the per-CPU `lunatik.cpu` path, now going through the helper, reports each instance's id.
