### PR TITLE
lunatik: unload every loaded module on reload, not just the configured set

### DIFF
--- a/bin/lunatik
+++ b/bin/lunatik
@@ -25,7 +25,7 @@ end
 
 local function sh(command, module, loaded)
 	local op = loaded and "&&" or "||"
-	os.execute(string.format("MODULE=%s;grep -wq $MODULE /proc/modules %s%s", module, op, command))
+	return os.execute(string.format("MODULE=%s;grep -wq $MODULE /proc/modules %s%s", module, op, command))
 end
 
 local function load_modules()
@@ -43,13 +43,37 @@ local function load_modules()
 	if result ~= "" then error(result) end
 end
 
+local function readall(handle)
+	local h <close> = handle
+	return h and h:read("a") or ""
+end
+
+local function holders()
+	return readall(io.popen("ls /sys/module/lunatik/holders 2>/dev/null"))
+end
+
+local function refcount(module)
+	return tonumber(readall(io.open("/sys/module/" .. module .. "/refcnt")))
+end
+
+local function unload_unused()
+	local removed = 0
+	for m in (holders() .. " lunatik"):gmatch("%S+") do
+		if refcount(m) == 0 and sh("rmmod $MODULE", m, true) then
+			removed = removed + 1
+		end
+	end
+	return removed
+end
+
 local function unload_modules()
 	if probe() then
-		dostring("lunatik.runner.shutdown()")
+		local result = dostring("lunatik.runner.shutdown()")
+		if result ~= "" then error(result) end
 	end
-	for i = #modules, 1, -1 do
-		sh("rmmod $MODULE", modules[i], true)
-	end
+	repeat
+		local removed = unload_unused()
+	until removed == 0
 end
 
 local function reload_modules()


### PR DESCRIPTION
A module left loaded from another build — a different config, or a feature branch — can pin the core and wedge the next `reload` when the configured set no longer lists it.

`unload` now unloads every module holding `lunatik.ko` (from `/sys/module/lunatik/holders`) and `lunatik` itself, peeling by dependency: each round `rmmod`s the modules the kernel reports ready (`refcnt 0`) and counts what actually came off, repeating until a round removes nothing. `refcnt` counts both symbol users and the runtime's `require`/`module_get` pins — which the holders graph does not show — so it is the complete readiness signal: no order is hardcoded, and a module that cannot be removed ends the loop instead of spinning it.

So a leftover the current config no longer lists comes off with the rest (a renamed or disabled module, one only a feature branch builds), and nothing that does not hold lunatik is touched. Discovery is a directory listing plus `refcnt`, not a `/proc/modules` parse, and needs no Makefile/autogen change.

**Test:** `lunatik unload` brings the loaded set to zero with no rmmod errors; with `luadarken` loaded but removed from `config.modules`, `reload` still unloads it (the configured-set unload left it as a leftover).
