### PR TITLE
tests/xdp: declare the BPF programs Dual MIT/GPL

### DIFF
--- a/tests/xdp/xdp_detach.bpf.c
+++ b/tests/xdp/xdp_detach.bpf.c
@@ -19,5 +19,5 @@ int test_xdp_detach(struct xdp_md *ctx)
 	return ret < 0 ? XDP_PASS : ret;
 }
 
-char LICENSE[] SEC("license") = "GPL";
+char _license[] SEC("license") = "Dual MIT/GPL";
 

--- a/tests/xdp/xdp_drop.bpf.c
+++ b/tests/xdp/xdp_drop.bpf.c
@@ -19,5 +19,5 @@ int test_xdp_drop(struct xdp_md *ctx)
 	return ret < 0 ? XDP_PASS : ret;
 }
 
-char LICENSE[] SEC("license") = "GPL";
+char _license[] SEC("license") = "Dual MIT/GPL";
 

--- a/tests/xdp/xdp_pass.bpf.c
+++ b/tests/xdp/xdp_pass.bpf.c
@@ -20,5 +20,5 @@ int test_xdp_pass(struct xdp_md *ctx)
 	return ret < 0 ? XDP_PASS : ret;
 }
 
-char LICENSE[] SEC("license") = "GPL";
+char _license[] SEC("license") = "Dual MIT/GPL";
 

--- a/tests/xdp/xdp_zerokey.bpf.c
+++ b/tests/xdp/xdp_zerokey.bpf.c
@@ -20,5 +20,5 @@ int test_xdp_zerokey(struct xdp_md *ctx)
 	return ret < 0 ? XDP_DROP : XDP_PASS;
 }
 
-char LICENSE[] SEC("license") = "GPL";
+char _license[] SEC("license") = "Dual MIT/GPL";
 


### PR DESCRIPTION
The four `tests/xdp/*.bpf.c` programs declared `char LICENSE[] SEC("license") = "GPL"`, while the rest of the tree — `examples/filter/https.c` and the tc test programs — uses `char _license[] SEC("license") = "Dual MIT/GPL"`, which matches these files' dual `SPDX-License-Identifier: MIT OR GPL-2.0-only`. Align the xdp programs to that form.

No behavior change: `Dual MIT/GPL` is GPL-compatible, so the programs still load and call the kfunc. The xdp suite stays green (5/5).
