### PR TITLE
ebpf: factor the per-object attach and rename the callback bind/unbind

### DIFF
--- a/lib/luatc.c
+++ b/lib/luatc.c
@@ -159,8 +159,8 @@ static int luatc_detach(lua_State *L)
 	if (lctx == NULL)
 		return 0;
 
-	lunatik_ebpf_detach(L, &lctx->cb);
-	lunatik_unregister(L, lctx->skb_obj);
+	lunatik_ebpf_unbind(L, &lctx->cb);
+	lunatik_ebpf_detach(L, lctx, skb_obj);
 	return 0;
 }
 
@@ -216,12 +216,9 @@ static int luatc_attach(lua_State *L)
 	lunatik_object_t *object = lunatik_newobject(L, &luatc_class, sizeof(luatc_ctx_t), LUNATIK_OPT_NONE);
 	luatc_ctx_t *ctx = (luatc_ctx_t *)object->private;
 
-	ctx->skb_obj = luaskb_new(L);
-	lunatik_getobject(ctx->skb_obj);
-	lunatik_register(L, -1, ctx->skb_obj);
-	lua_pop(L, 1);
+	lunatik_ebpf_attach(L, ctx, skb_obj, luaskb_new);
 
-	lunatik_ebpf_attach(L, 1, &ctx->cb);
+	lunatik_ebpf_bind(L, 1, &ctx->cb);
 	return 0;
 }
 #endif

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -178,9 +178,9 @@ static int luaxdp_detach(lua_State *L)
 	if (lctx == NULL)
 		return 0;
 
-	lunatik_ebpf_detach(L, &lctx->cb);
-	lunatik_unregister(L, lctx->packet);
-	lunatik_unregister(L, lctx->argument);
+	lunatik_ebpf_unbind(L, &lctx->cb);
+	lunatik_ebpf_detach(L, lctx, packet);
+	lunatik_ebpf_detach(L, lctx, argument);
 	return 0;
 }
 
@@ -237,17 +237,10 @@ static int luaxdp_attach(lua_State *L)
 	lunatik_object_t *object = lunatik_newobject(L, &luaxdp_class, sizeof(luaxdp_ctx_t), LUNATIK_OPT_NONE);
 	luaxdp_ctx_t *ctx = (luaxdp_ctx_t *)object->private;
 
-	ctx->packet = luadata_new(L, LUNATIK_OPT_SINGLE);
-	lunatik_getobject(ctx->packet);
-	lunatik_register(L, -1, ctx->packet);
-	lua_pop(L, 1);
+	lunatik_ebpf_attach(L, ctx, packet, luadata_new, LUNATIK_OPT_SINGLE);
+	lunatik_ebpf_attach(L, ctx, argument, luadata_new, LUNATIK_OPT_SINGLE);
 
-	ctx->argument = luadata_new(L, LUNATIK_OPT_SINGLE);
-	lunatik_getobject(ctx->argument);
-	lunatik_register(L, -1, ctx->argument);
-	lua_pop(L, 1);
-
-	lunatik_ebpf_attach(L, 1, &ctx->cb);
+	lunatik_ebpf_bind(L, 1, &ctx->cb);
 	return 0;
 }
 #endif

--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -77,7 +77,17 @@ static inline int lunatik_ebpf_invoke(lua_State *L, int cb)
 	return 0;
 }
 
-static inline void lunatik_ebpf_attach(lua_State *L, int ix, int *cb)
+#define lunatik_ebpf_attach(L, obj, field, new_fn, ...)	\
+do {								\
+	obj->field = new_fn((L), ##__VA_ARGS__);		\
+	lunatik_getobject(obj->field);				\
+	lunatik_register((L), -1, obj->field);			\
+	lua_pop((L), 1);					\
+} while (0)
+
+#define lunatik_ebpf_detach(L, obj, field)	lunatik_unregister((L), obj->field)
+
+static inline void lunatik_ebpf_bind(lua_State *L, int ix, int *cb)
 {
 	lua_pushvalue(L, ix);
 	*cb = luaL_ref(L, LUA_REGISTRYINDEX);
@@ -86,7 +96,7 @@ static inline void lunatik_ebpf_attach(lua_State *L, int ix, int *cb)
 	lua_pop(L, 1);
 }
 
-static inline void lunatik_ebpf_detach(lua_State *L, int *cb)
+static inline void lunatik_ebpf_unbind(lua_State *L, int *cb)
 {
 	luaL_unref(L, LUA_REGISTRYINDEX, *cb);
 	*cb = LUA_NOREF;


### PR DESCRIPTION
`luaxdp` and `luatc` open-coded the same `new + getobject + register + pop` for every per-callback object (`packet`, `argument`, `skb`). This factors it into the shared eBPF header:

```c
#define lunatik_ebpf_attach(L, obj, field, new_fn, ...) \
do { \
	obj->field = new_fn((L), ##__VA_ARGS__); \
	lunatik_getobject(obj->field); \
	lunatik_register((L), -1, obj->field); \
	lua_pop((L), 1); \
} while (0)

#define lunatik_ebpf_detach(L, obj, field)	lunatik_unregister((L), obj->field)
```

The object gets **attach/detach** — mirroring `lunatik.h`'s `lunatik_attach`/`lunatik_detach` (the object registry pair). The `getobject` is what sets it apart: the eBPF bindings hold an owning reference because `release` puts it after a possible detach, so `detach` only unregisters and the put stays in `release`.

That freed the `attach`/`detach` names, so the callback registration — which was mis-holding them — becomes **bind/unbind**: `lunatik_ebpf_bind(L, ix, cb)` binds the Lua callback to the runtime, `lunatik_ebpf_unbind` releases it.

No behavior change. tc suite green (6/6), xdp green (5/5).
