### PR TITLE
Fix ranged linux.random using unsigned modulo

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ Install and run the test suites:
 ```sh
 sudo make install
 sudo lunatik test           # run all suites
-sudo lunatik test thread    # run a specific suite (bpf, crypto, io, monitor,
-                            # netlink, notifier, probe, rcu, runtime, set, skb,
-                            # socket, struct, thread, xdp)
+sudo lunatik test thread    # run a specific suite (bpf, crypto, io, linux,
+                            # monitor, netlink, notifier, probe, rcu, runtime,
+                            # set, skb, socket, struct, thread, xdp)
 ```
 
 `lunatik test` reloads the modules before the run and unloads them

--- a/lib/lualinux.c
+++ b/lib/lualinux.c
@@ -67,7 +67,7 @@ static int lualinux_random(lua_State *L)
 	luaL_argcheck(L, low <= up, 1, "interval is empty");
 	luaL_argcheck(L, low >= 0 || up <= LUA_MAXINTEGER + low, 1, "interval too large");
 
-	rand = low + ((lua_Integer)get_random_u64()) % (up - low + 1);
+	rand = low + (lua_Integer)(get_random_u64() % ((lua_Unsigned)up - (lua_Unsigned)low + 1));
 	lua_pushinteger(L, rand);
 	return 1;
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -75,6 +75,11 @@ Covers the `crypto` module: `shash`, `skcipher`, `aead`, `rng`, `hkdf`,
 - **test**: kernel `io` library (open/read/write/seek/lines/type); also
   asserts `io` is absent from softirq runtimes.
 
+### linux
+
+- **random**: `linux.random` ranged draws stay within `[m, n]`, covering
+  the two-argument, one-argument and negative-range forms.
+
 ### monitor
 
 Regression tests for `lunatik_monitor` (spinlock + GC interaction).

--- a/tests/linux/random.lua
+++ b/tests/linux/random.lua
@@ -1,0 +1,32 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Harshdeep Singh
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the linux.random test (see run.sh).
+--
+
+local linux = require("linux")
+local test = require("util").test
+
+test("linux.random(m, n) stays within [m, n]", function()
+	for i = 1, 10000 do
+		local r = linux.random(32, 126)
+		assert(type(r) == "number", "expected number")
+		assert(r >= 32 and r <= 126, "out of range: " .. r)
+	end
+end)
+
+test("linux.random(n) stays within [1, n]", function()
+	for i = 1, 1000 do
+		local r = linux.random(1000)
+		assert(r >= 1 and r <= 1000, "out of range: " .. r)
+	end
+end)
+
+test("linux.random(m, n) stays within a negative range", function()
+	for i = 1, 1000 do
+		local r = linux.random(-126, -32)
+		assert(r >= -126 and r <= -32, "out of range: " .. r)
+	end
+end)
+

--- a/tests/linux/run.sh
+++ b/tests/linux/run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Harshdeep Singh
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Runs all linux tests and reports aggregated KTAP results.
+#
+# Usage: sudo bash tests/linux/run.sh
+
+DIR="$(dirname "$(readlink -f "$0")")"
+
+source "$DIR/../lib.sh"
+
+TESTS="random"
+TOTAL=$(echo $TESTS | wc -w)
+
+ktap_header
+ktap_plan $TOTAL
+
+for t in $TESTS; do
+	if run_test "tests/linux/$t"; then
+		ktap_pass "linux/$t"
+	else
+		ktap_fail "linux/$t"
+	fi
+done
+
+ktap_totals
+[ $KTAP_FAIL -eq 0 ]
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -38,6 +38,7 @@ run_suite "$DIR/bpf/run.sh"
 run_suite "$DIR/xdp/run.sh"
 run_suite "$DIR/crypto/run.sh"
 run_suite "$DIR/io/test.sh"
+run_suite "$DIR/linux/run.sh"
 run_suite "$DIR/probe/run.sh"
 run_suite "$DIR/notifier/run.sh"
 


### PR DESCRIPTION
Fixes #740.

linux.random(m, n) returned values outside the [m, n] range because get_random_u64() was being used with signed modulo. This also caused the string.char call in the passwd example to fail.
This change uses unsigned u64 values for the span and offset calculations, ensuring the result stays within the requested range.
It also adds a regression test under tests/linux/random and documents the test suite in tests/README.md.
I verified this with sudo lunatik test linux and passwd smoke test.