### PR TITLE
lunatikc: host bytecode compiler for kernel Lua scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ doc/*
 !doc/design
 !doc/design/**
 /lib/linux/
+bin/lunatikc
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,25 @@ MKDIR = mkdir -p -m 0755
 LN = ln -sf
 INSTALL = install -o root -g root
 
+# host compiler for kernel Lua scripts; same lua/ sources and _KERNEL configuration as lunatik.ko
+HOSTCC ?= cc
+LUNATIKC := bin/lunatikc
+LUNATIKC_CORE := lapi lcode lctype ldebug ldo ldump lfunc lgc llex lmem lobject lopcodes \
+	lparser lstate lstring ltable ltm lundump lvm lzio lauxlib
+LUNATIKC_SRCS := ${LUNATIKC}.c $(addprefix lua/,$(addsuffix .c,$(LUNATIKC_CORE)))
+LUNATIKC_CFLAGS := -std=gnu99 -O2 -Wall -D_KERNEL -DLUA_USE_LINUX -I. -Ilua
+
+# BYTECODE=1 installs kernel Lua scripts as stripped chunks, under their .lua names
+ifeq ($(BYTECODE),1)
+define INSTALL_LUA
+	for f in $(1); do ${LUNATIKC} -s -o $(2)/$$(basename $$f) $$f || exit 1; done
+endef
+else
+define INSTALL_LUA
+	${INSTALL} -m 0644 $(1) $(2)
+endef
+endif
+
 CONFIG_LUNATIK ?= m
 CONFIG_LUNATIK_RUNTIME ?= y
 CONFIG_LUNATIK_RUN ?= m
@@ -62,14 +81,17 @@ AUTOGEN_KEY := $(KERNEL_RELEASE)|$(LUNATIK_MODULES)
 	tests_install tests_uninstall \
 	ebpf ebpf_install ebpf_uninstall
 
-all: lunatik_sym.h autogen
+all: lunatik_sym.h autogen ${LUNATIKC}
 	${MAKE} -C ${MODULES_BUILD_PATH} M=${PWD} $(LUNATIK_CONFIG_FLAGS)
+
+${LUNATIKC}: ${LUNATIKC_SRCS} lunatik_conf.h
+	${HOSTCC} ${LUNATIKC_CFLAGS} -o $@ ${LUNATIKC_SRCS} -lm
 
 clean:
 	${MAKE} -C ${MODULES_BUILD_PATH} M=${PWD} clean
 	${MAKE} -C ${MODULES_BUILD_PATH} M=${PWD}/autogen clean
 	${MAKE} -C examples/filter clean
-	${RM} lunatik_sym.h
+	${RM} lunatik_sym.h ${LUNATIKC}
 	${RM} -r lib/linux
 	${RM} autogen/lunatik/*.lua autogen/linux/*.lua \
 		autogen/dump_*.c autogen/dump_*.pp \
@@ -88,27 +110,28 @@ scripts_install:
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/bpf
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/linux
 	${MKDIR} ${LUA_PATH}/lunatik
-	${INSTALL} -m 0644 driver.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/class.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/mailbox.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/net.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/struct.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/netlink.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/util.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/lighten.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/lunatik/*.lua ${SCRIPTS_INSTALL_PATH}/lunatik
-	${INSTALL} -m 0644 lib/socket/*.lua ${SCRIPTS_INSTALL_PATH}/socket
-	${INSTALL} -m 0644 lib/netlink/*.lua ${SCRIPTS_INSTALL_PATH}/netlink
-	${INSTALL} -m 0644 lib/netlink/rt/*.lua ${SCRIPTS_INSTALL_PATH}/netlink/rt
-	${INSTALL} -m 0644 lib/netlink/nl80211/*.lua ${SCRIPTS_INSTALL_PATH}/netlink/nl80211
-	${INSTALL} -m 0644 lib/syscall/*.lua ${SCRIPTS_INSTALL_PATH}/syscall
-	${INSTALL} -m 0644 lib/crypto/*.lua ${SCRIPTS_INSTALL_PATH}/crypto
-	${INSTALL} -m 0644 lib/bpf/*.lua ${SCRIPTS_INSTALL_PATH}/bpf
+	$(call INSTALL_LUA,driver.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/class.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/mailbox.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/net.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/struct.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/netlink.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/util.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/lighten.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/lunatik/*.lua,${SCRIPTS_INSTALL_PATH}/lunatik)
+	$(call INSTALL_LUA,lib/socket/*.lua,${SCRIPTS_INSTALL_PATH}/socket)
+	$(call INSTALL_LUA,lib/netlink/*.lua,${SCRIPTS_INSTALL_PATH}/netlink)
+	$(call INSTALL_LUA,lib/netlink/rt/*.lua,${SCRIPTS_INSTALL_PATH}/netlink/rt)
+	$(call INSTALL_LUA,lib/netlink/nl80211/*.lua,${SCRIPTS_INSTALL_PATH}/netlink/nl80211)
+	$(call INSTALL_LUA,lib/syscall/*.lua,${SCRIPTS_INSTALL_PATH}/syscall)
+	$(call INSTALL_LUA,lib/crypto/*.lua,${SCRIPTS_INSTALL_PATH}/crypto)
+	$(call INSTALL_LUA,lib/bpf/*.lua,${SCRIPTS_INSTALL_PATH}/bpf)
 	# NOTE: `lib/linux/` exists only as LDoc stubs (see doc-stubs); never install it.
-	${INSTALL} -m 0644 autogen/linux/*.lua ${SCRIPTS_INSTALL_PATH}/linux
+	$(call INSTALL_LUA,autogen/linux/*.lua,${SCRIPTS_INSTALL_PATH}/linux)
 	${INSTALL} -m 0644 autogen/lunatik/*.lua ${SCRIPTS_INSTALL_PATH}/lunatik
 	${LN} ${SCRIPTS_INSTALL_PATH}/lunatik/config.lua ${LUA_PATH}/lunatik/config.lua
 	${INSTALL} -D -m 0755 bin/lunatik ${LUNATIK_INSTALL_PATH}/lunatik
+	${INSTALL} -D -m 0755 ${LUNATIKC} ${LUNATIK_INSTALL_PATH}/lunatikc
 
 scripts_uninstall:
 	${RM} ${SCRIPTS_INSTALL_PATH}/driver.lua
@@ -126,7 +149,7 @@ scripts_uninstall:
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/crypto
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/bpf
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/linux
-	${RM} ${LUNATIK_INSTALL_PATH}/lunatik
+	${RM} ${LUNATIK_INSTALL_PATH}/lunatik ${LUNATIK_INSTALL_PATH}/lunatikc
 	${RM} -r ${LUA_PATH}/lunatik
 
 ebpf:
@@ -143,10 +166,10 @@ EXAMPLE_DIRS := $(patsubst examples/%/,%,$(wildcard examples/*/))
 
 examples_install:
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/examples
-	${INSTALL} -m 0644 examples/*.lua ${SCRIPTS_INSTALL_PATH}/examples
+	$(call INSTALL_LUA,examples/*.lua,${SCRIPTS_INSTALL_PATH}/examples)
 	for d in $(EXAMPLE_DIRS); do \
 		${MKDIR} ${SCRIPTS_INSTALL_PATH}/examples/$$d; \
-		${INSTALL} -m 0644 examples/$$d/*.lua ${SCRIPTS_INSTALL_PATH}/examples/$$d; \
+		$(call INSTALL_LUA,examples/$$d/*.lua,${SCRIPTS_INSTALL_PATH}/examples/$$d); \
 	done
 
 examples_uninstall:

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ Install and run the test suites:
 ```sh
 sudo make install
 sudo lunatik test           # run all suites
-sudo lunatik test thread    # run a specific suite (bpf, crypto, io, monitor,
-                            # netlink, notifier, probe, rcu, runtime, set, skb,
-                            # socket, struct, thread, xdp)
+sudo lunatik test thread    # run a specific suite (bpf, crypto, io, luac,
+                            # monitor, netlink, notifier, probe, rcu, runtime,
+                            # set, skb, socket, struct, thread, xdp)
 ```
 
 `lunatik test` reloads the modules before the run and unloads them

--- a/README.md
+++ b/README.md
@@ -100,6 +100,31 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [
 * `stop`: stop the runtime environment created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_
 
+### lunatikc
+
+```Shell
+usage: lunatikc [-s] [-o output] [-n chunkname] input.lua ...
+```
+
+Compiles kernel Lua scripts into binary chunks. `lunatikc` is built with the host compiler from the
+same `lua/` sources and configuration as `lunatik.ko`, so its chunks match the kernel's opcode set
+and integer-only number format; chunks from the distribution `luac` are rejected by the kernel.
+
+* `-s`: strip debug information (line numbers, local and upvalue names)
+* `-o output`: output file, or a directory when compiling several inputs (default: `<input>.luac`)
+* `-n chunkname`: chunk name recorded in the dump, as in `load` (default: `@<input>`)
+
+A chunk is installed and run under the usual `.lua` name; the kernel detects it by its signature:
+
+```Shell
+lunatikc -s -o hello.lua hello.lua    # overwrite with the stripped chunk
+sudo cp hello.lua /lib/modules/lua/
+sudo lunatik run hello
+```
+
+`BYTECODE=1 make install` installs the kernel Lua libraries and the examples as stripped chunks
+instead of source.
+
 ### Testing
 
 Install and run the test suites:

--- a/bin/lunatikc.c
+++ b/bin/lunatikc.c
@@ -1,0 +1,166 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+/*
+* lunatikc: compiles kernel Lua scripts into binary chunks for lunatik.
+*
+* Built from the same lua/ sources and _KERNEL configuration as lunatik.ko,
+* so that its chunks match the kernel's opcode set and number format.
+*/
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include <lua.h>
+#include <lauxlib.h>
+
+#define LUNATIKC_EXT	".luac"
+
+static const char *progname = "lunatikc";
+
+static void usage(void)
+{
+	fprintf(stderr, "usage: %s [-s] [-o output] [-n chunkname] input.lua ...\n"
+		"  -s             strip debug information\n"
+		"  -o output      output file (or directory, with several inputs); default: input" LUNATIKC_EXT "\n"
+		"  -n chunkname   chunk name recorded in the dump; default: @input\n", progname);
+	exit(2);
+}
+
+static void fail(const char *msg)
+{
+	fprintf(stderr, "%s: %s\n", progname, msg);
+	exit(1);
+}
+
+static char *readfile(const char *path, size_t *size)
+{
+	FILE *f = fopen(path, "rb");
+	if (f == NULL || fseek(f, 0, SEEK_END) != 0)
+		return NULL;
+
+	long n = ftell(f);
+	if (n < 0 || fseek(f, 0, SEEK_SET) != 0)
+		return NULL;
+
+	char *buffer = malloc(n);
+	if (buffer != NULL && fread(buffer, 1, n, f) != (size_t)n) {
+		free(buffer);
+		buffer = NULL;
+	}
+	fclose(f);
+	*size = (size_t)n;
+	return buffer;
+}
+
+static int writer(lua_State *L, const void *p, size_t size, void *ud)
+{
+	(void)L;
+	return size != 0 && fwrite(p, size, 1, (FILE *)ud) != 1;
+}
+
+static int isdir(const char *path)
+{
+	struct stat st;
+	return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
+static char *outname(const char *output, const char *input)
+{
+	const char *base = strrchr(input, '/');
+	base = base != NULL ? base + 1 : input;
+
+	size_t n = strlen(base);
+	if (n > 4 && strcmp(base + n - 4, ".lua") == 0)
+		n -= 4;
+
+	const char *dir = output != NULL ? output : "";
+	char *name = malloc(strlen(dir) + 1 + n + sizeof(LUNATIKC_EXT));
+	if (name == NULL)
+		fail(strerror(ENOMEM));
+
+	if (output == NULL) /* next to the input */
+		sprintf(name, "%.*s%.*s" LUNATIKC_EXT, (int)(base - input), input, (int)n, base);
+	else
+		sprintf(name, "%s/%.*s" LUNATIKC_EXT, dir, (int)n, base);
+	return name;
+}
+
+static void compile(lua_State *L, const char *input, const char *output, const char *chunkname, int strip)
+{
+	size_t size;
+	char *source = readfile(input, &size);
+	if (source == NULL) {
+		fprintf(stderr, "%s: cannot read %s: %s\n", progname, input, strerror(errno));
+		exit(1);
+	}
+
+	char name[PATH_MAX + 1];
+	if (chunkname == NULL) {
+		snprintf(name, sizeof(name), "@%s", input);
+		chunkname = name;
+	}
+
+	if (luaL_loadbufferx(L, source, size, chunkname, "t") != LUA_OK)
+		fail(lua_tostring(L, -1));
+	free(source);
+
+	FILE *f = fopen(output, "wb");
+	if (f == NULL) {
+		fprintf(stderr, "%s: cannot write %s: %s\n", progname, output, strerror(errno));
+		exit(1);
+	}
+
+	int ret = lua_dump(L, writer, f, strip);
+	if (ret != 0 || fclose(f) != 0) {
+		remove(output);
+		fprintf(stderr, "%s: cannot write %s\n", progname, output);
+		exit(1);
+	}
+	lua_pop(L, 1);
+}
+
+int main(int argc, char **argv)
+{
+	const char *output = NULL, *chunkname = NULL;
+	int strip = 0;
+	int i;
+
+	for (i = 1; i < argc && argv[i][0] == '-'; i++) {
+		if (strcmp(argv[i], "-s") == 0)
+			strip = 1;
+		else if (strcmp(argv[i], "-o") == 0 && i + 1 < argc)
+			output = argv[++i];
+		else if (strcmp(argv[i], "-n") == 0 && i + 1 < argc)
+			chunkname = argv[++i];
+		else
+			usage();
+	}
+
+	int ninputs = argc - i;
+	if (ninputs < 1)
+		usage();
+	if (ninputs > 1 && (chunkname != NULL || (output != NULL && !isdir(output))))
+		fail("several inputs need a directory as -o and no -n");
+
+	lua_State *L = luaL_newstate();
+	if (L == NULL)
+		fail("cannot create state");
+
+	for (; i < argc; i++) {
+		const char *input = argv[i];
+		char *name = (output != NULL && !isdir(output)) ? NULL : outname(output, input);
+		compile(L, input, name != NULL ? name : output, chunkname, strip);
+		free(name);
+	}
+
+	lua_close(L);
+	return 0;
+}
+

--- a/bin/lunatikc.c
+++ b/bin/lunatikc.c
@@ -49,7 +49,7 @@ static char *readfile(const char *path, size_t *size)
 	if (n < 0 || fseek(f, 0, SEEK_SET) != 0)
 		return NULL;
 
-	char *buffer = malloc(n);
+	char *buffer = malloc(n + 1); /* n may be 0 */
 	if (buffer != NULL && fread(buffer, 1, n, f) != (size_t)n) {
 		free(buffer);
 		buffer = NULL;

--- a/doc/design/luac/README.md
+++ b/doc/design/luac/README.md
@@ -1,0 +1,49 @@
+# Bytecode compiler for Lunatik
+
+Working documents for `lunatikc`: a userspace compiler that turns kernel Lua scripts into precompiled
+binary chunks the in-kernel Lua accepts, including cross-compiling on a development host for a
+different target (32-bit, other endianness), so that scripts can ship as bytecode — no parser pass at
+load time, no source on the device, smaller files, and a path to a kernel build without the compiler
+front end at all.
+
+They exist so that a new contributor, with or without an AI coding assistant, can pick the work up
+without first rediscovering why the distribution `luac` does not work here.
+
+| Document | What it is for |
+|----------|----------------|
+| [plan.md](plan.md) | Current state, what is missing, the incremental phases, non goals, risks, definition of done |
+| [api.md](api.md) | The tool's command line, the build and install hooks, and what (little) changes on the kernel side |
+| [kernel-notes.md](kernel-notes.md) | Verified reference: the kernel Lua fork's bytecode format, what makes stock `luac` incompatible, what is endianness-dependent, how loading already works in the kernel, bytecode trust |
+| [testing.md](testing.md) | Test strategy — a `luac` KTAP suite compiling on the host and running in the kernel, plus the harness pitfall with stripped chunks |
+
+Start with `plan.md`. Read `kernel-notes.md` before touching `lunatik_conf.h` or the `lua/` submodule.
+
+## Working on this
+
+The repository conventions that apply to every change here (build, test, style, kernel context rules,
+commit discipline) are in [AGENTS.md](../../../AGENTS.md) at the root of the repository. Read it once
+before the first patch.
+
+Three facts shape everything here, and are worth carrying from the start:
+
+1. **The kernel already loads bytecode.** Every in-kernel file load goes through `lunatik_loadfile`
+   with mode `NULL` (`"bt"`), and `lua_load` detects a binary chunk by its first byte. Nothing on the
+   kernel side has to change for a correctly built chunk to run; the whole problem is producing one.
+2. **Stock `luac` cannot produce one.** The kernel Lua is an integer-only fork: under `_KERNEL` the
+   opcode enum drops the float opcodes (so every opcode after `OP_LOADI` is renumbered), `/` compiles
+   to integer division, and `lua_Number` is `lua_Integer`, which the bytecode header checks. The
+   compiler must be built from the same `lua/` sources with the same `_KERNEL` configuration, on the
+   host. This is the only correct way to get an identical front end; a reimplementation is not.
+3. **Cross-endian is the only real cross-compilation problem.** Sizes in a Lua 5.5 chunk are
+   endian-independent varints and `lua_Integer` is 8 bytes on every Lunatik target, 32-bit included.
+   Only the raw instruction vector, the absolute line table and the header probes carry the
+   host's byte order, so a host that matches the target's endianness produces a valid chunk with no
+   special handling, and a byte-swapping dump (a change in the `lua/` fork) covers the rest.
+
+## Status
+
+Design notes plus a prototype on the `claude_luac` branch (on top of `origin/master`): the compiler,
+its build and install wiring, `BYTECODE=1`, the `luac` suite and the `runner.lua` trim fix — phases
+1–3 of `plan.md`, full suite green with source and with bytecode installs. Cross-endian (phase 4)
+and the follow-ups are not started. Not yet an epic; the phases are sized to become one issue each.
+

--- a/doc/design/luac/api.md
+++ b/doc/design/luac/api.md
@@ -1,0 +1,72 @@
+# Proposed interface: `lunatikc`
+
+This is a design proposal, not a specification. Names are open for review (`lunatikc` avoids
+shadowing the distribution `luac`; `lunatik compile` as a CLI subcommand is a possible wrapper);
+the constraints behind the behavior (`kernel-notes.md`) are not.
+
+## Command line
+
+```
+lunatikc [-s] [-o output] [-n chunkname] [-e big|little] input.lua [input.lua ...]
+```
+
+| Option | Meaning | Default |
+|--------|---------|---------|
+| `-s` | strip debug information (`lua_dump` strip): no line numbers, local or upvalue names, no source name | off |
+| `-o output` | output file; with several inputs, a directory | `<input>.luac` next to each input |
+| `-n chunkname` | chunk name baked into the dump, as `lua_load` would receive it (`@path` or `=name`) | `@<input>` |
+| `-e big\|little` | target byte order (phase 4) | host |
+
+* Input is always parsed as **text** (`luaL_loadbufferx(..., "t")`); a binary input is an error.
+* Exit status 0 only if every input compiled and was written; otherwise the first error goes to
+  stderr as `lunatikc: <input>:<line>: <message>` and the status is 1. Nothing is written for a
+  failed input.
+* No `-l` listing and no `-p` parse-only in phase 1. `-p` is cheap to add (`-o /dev/null`);
+  listing needs a fork of `luac.c`'s printer with the float cases removed and is not worth it
+  until someone needs to read kernel opcodes.
+
+Examples:
+
+```sh
+lunatikc examples/echod/daemon.lua                         # -> examples/echod/daemon.luac
+lunatikc -s -n @/lib/modules/lua/net.lua -o /lib/modules/lua/net.lua lib/net.lua
+lunatikc -s -o build/ lib/lunatik/*.lua                    # one .luac per input in build/
+```
+
+## Build and install
+
+```sh
+make                 # also builds bin/lunatikc with the host compiler
+make install         # installs lunatikc next to lunatik (LUNATIK_INSTALL_PATH)
+BYTECODE=1 make install   # phase 3: ships kernel Lua libs and examples as stripped chunks
+```
+
+`lunatikc` is built from the same `lua/` sources and `_KERNEL` configuration as `lunatik.ko`, so
+its chunks always match the installed kernel module built from the same tree. Mixing a tool and a
+module from different `lua/` revisions is caught by the chunk header only when the format
+changes; keep them from the same build.
+
+## Using the output
+
+A chunk is installed **under the `.lua` name** and used exactly like source:
+
+```sh
+sudo cp hello.luac /lib/modules/lua/hello.lua
+sudo lunatik run hello
+```
+
+`require("foo")` in the kernel resolves `/lib/modules/lua/foo.lua` through the same loader, so
+libraries can be chunks too. `lunatik spawn` is no different.
+
+## Kernel side
+
+No new API. The only change in phase 1 is that `lunatik_conf.h` becomes host-includable: the
+number configuration shared by the kernel and the tool stays at the top, the kernel-only part is
+under `#ifdef __KERNEL__`. The kernel build sees the same macros with the same values.
+
+Possible later knobs (not in phase 1; each is its own decision):
+
+* a module parameter / Kconfig forcing text-only loads (`"t"`) — the parser as a sanity filter;
+* `CONFIG_LUNATIK_BYTECODE_ONLY` — no parser in the kernel at all;
+* a `"b"` option in `darken.run` for encrypted chunks.
+

--- a/doc/design/luac/api.md
+++ b/doc/design/luac/api.md
@@ -1,8 +1,9 @@
-# Proposed interface: `lunatikc`
+# Interface: `lunatikc`
 
-This is a design proposal, not a specification. Names are open for review (`lunatikc` avoids
-shadowing the distribution `luac`; `lunatik compile` as a CLI subcommand is a possible wrapper);
-the constraints behind the behavior (`kernel-notes.md`) are not.
+The tool is named `lunatikc` (settled with the maintainer, 2026-08-23): it avoids shadowing the
+distribution `luac`, and a `lunatik compile` CLI subcommand remains possible as a wrapper later.
+Option shapes are still open for review; the constraints behind the behavior (`kernel-notes.md`)
+are not.
 
 ## Command line
 

--- a/doc/design/luac/kernel-notes.md
+++ b/doc/design/luac/kernel-notes.md
@@ -1,0 +1,161 @@
+# Kernel notes: bytecode for the kernel Lua
+
+Reference sheet for `lunatikc`. Verified on 2026-08-23 against the `lua/` submodule at `d7ca49b3`
+(upstream Lua 5.5.0 plus the `_KERNEL` patch), `lunatik_conf.h`, and a running 6.8.0-136 aarch64
+kernel with the prototype on the `claude_luac` branch. Re-check whenever `lua/` is bumped.
+
+## The one fact that shapes everything
+
+The kernel Lua is **not** stock Lua 5.5, and the difference is visible in the bytecode. Under
+`_KERNEL` (the define every kernel object is built with, `Kbuild` `LUNATIK_FLAGS`):
+
+| Where | What changes | Effect on a chunk |
+|-------|--------------|-------------------|
+| `lua/lopcodes.h` | `OP_LOADF`, `OP_POWK`, `OP_DIVK`, `OP_POW`, `OP_DIV` are compiled out | every opcode after `OP_LOADI` has a different number than upstream |
+| `lua/lparser.c` | `/` maps to `OPR_IDIV`; `^` is not an operator; no `TK_FLT` | `7 / 2` compiles to `OP_IDIV` (= 3) |
+| `lua/ldump.c`, `lua/lundump.c` | `LUA_VNUMFLT` and `dumpNumber`/`loadNumber` compiled out | no float constants exist |
+| `lunatik_conf.h` | `LUA_NUMBER` is `LUA_INTEGER` | header probe `LUAC_NUM = cast_num(-370.5)` is the 8-byte integer `-370` |
+
+A chunk from the distribution `luac` (or from `string.dump` in any userspace Lua) therefore fails
+the header (`bad binary format (Lua number format mismatch)`, verified), and even a hand-patched
+header would run the wrong opcodes. The compiler has to be built from `lua/` with `-D_KERNEL` and the
+same `lunatik_conf.h` number configuration. There is no shortcut through a reimplementation.
+
+## Chunk format (Lua 5.5, `lua/ldump.c` / `lua/lundump.c`)
+
+Header, `dumpHeader` / `checkHeader` (`lundump.c:381`):
+
+| Field | Value | Endian-dependent |
+|-------|-------|------------------|
+| `LUA_SIGNATURE` | `"\x1bLua"` | no |
+| `LUAC_VERSION` | `0x55` (5.5) | no |
+| `LUAC_FORMAT` | `0` | no |
+| `LUAC_DATA` | `"\x19\x93\r\n\x1a\n"` | no |
+| `sizeof(int)` + `int LUAC_INT` | `4`, `-0x5678` | **yes** (raw bytes) |
+| `sizeof(Instruction)` + `LUAC_INST` | `4`, `0x12345678` | **yes** |
+| `sizeof(lua_Integer)` + `LUAC_INT` | `8`, `-0x5678` | **yes** |
+| `sizeof(lua_Number)` + `LUAC_NUM` | `8`, `-370` (integer, see above) | **yes** |
+
+Body. Lua 5.5 encodes every count, size and `int` field as a 7-bit-per-byte varint (`dumpVarint`,
+`dumpSize`, `dumpInt`), and **integer constants as zigzag varints** (`dumpInteger`, `ldump.c:127`:
+in 5.4 they were raw `loadVar`) — all endian-independent. Strings are dumped once and reused by
+index. What is dumped raw, in host byte order:
+
+* the instruction vector (`dumpCode`: `dumpAlign` then `dumpVector(f->code)`),
+* `abslineinfo` (array of `{int pc; int line}`, `dumpAlign` + `dumpVector`; absent with `-s`),
+* the four header probes above.
+
+`lineinfo` is a byte vector (portable). Upvalue descriptors, local names, `linedefined`, `numparams`
+and flags are bytes or varints (portable). `lundump.c:52` states the intended hook: "All high-level
+loads go through loadVector; you can change it to adapt to the endianness of the input".
+
+**Consequence for cross-compilation.** `lua_Integer` is `long long` on every Lunatik target (the
+kernel build never defines `LUA_32BITS`; `Kbuild` only adds libgcc 64-bit division helpers on
+`!CONFIG_64BIT`), `int` and `Instruction` are 4 bytes everywhere. So a 64-bit little-endian host
+produces chunks that load unchanged on 32-bit little-endian targets (ARM, x86). Only a big-endian
+target (e.g. MIPS routers on OpenWrt) needs a byte-swapping dump, and only for three things: the
+32-bit instruction vector, `abslineinfo` (gone with `-s`) and the header probes. That hook does not
+exist upstream; it is a change in the `lua/` fork (`ldump.c`), behind a host-only define — the
+eLua `luac.cross` model (`DumpTargetInfo` + swap in `DumpVector`/`DumpCode`), not the OpenWrt 5.1
+model of swapping on load — or a `qemu-user` run of the native tool.
+
+## Stripping (`lua_dump(..., strip)`)
+
+`-s` drops `source`, `lineinfo`, `abslineinfo`, local variable names and upvalue names
+(`dumpDebug`). Verified effect on a runtime error:
+
+```
+full:   ...err.lua:3: attempt to index a nil value (local 't')
+strip:  ?:?: attempt to index a nil value
+```
+
+The chunk name is baked in at compile time as `"@<path given to the compiler>"`; the tool must let
+the caller set it (otherwise kernel error messages point at a build-tree path).
+
+## How the kernel loads a file today
+
+* `lunatik_core.c:219` builds the path as `LUA_ROOT "<script>.lua"` (`/lib/modules/lua/`), so the
+  script name is relative and the `.lua` suffix is fixed — a bytecode file installed **as `.lua`**
+  is picked up with no change; `lua_load` detects a binary chunk by `LUA_SIGNATURE[0]`.
+* `lunatik_core.c:239` calls `lunatik_loadfile(L, script, NULL)`: mode `NULL` means `"bt"`.
+  `lunatik_conf.h` redefines `luaL_loadfilex` to `lunatik_loadfile`, so `require`'s `searcher_Lua`
+  (`lua/loadlib.c`) takes the same path with the same mode. **Binary chunks are accepted everywhere
+  already.**
+* `lunatik_loadfile` (`lunatik_aux.c:36`) reads through a `PAGE_SIZE` `kmalloc` buffer with
+  `kernel_read`; it never skips a `#!` line or BOM (unlike upstream `luaL_loadfilex`).
+* `package.path` is `LUA_ROOT "?.lua;" LUA_ROOT "?/init.lua"` (`lunatik_conf.h`): a `.luac` suffix
+  would need an entry there. Not needed if bytecode is installed under the `.lua` name.
+* `lib/luadarken.c:120` loads the decrypted buffer with mode `"t"` — the one explicit text-only
+  load in the tree. Encrypted bytecode is a follow-up, not a conflict.
+* `/dev/lunatik` writes go through `driver.lua`'s `load(buf)` (mode `"bt"`), so the CLI could also
+  send a chunk — but the CLI sends `lunatik.runner.run("<name>")` strings, not script bodies.
+
+## Lua 5.5 "fixed buffer" mode
+
+`lua_load` mode `'B'` (`ldo.c:1130`, `luaU_undump(..., fixed=1)`) keeps the instruction vector,
+line tables and strings pointing **into the caller's buffer** (`PF_FIXED`, `getaddr` in
+`lundump.c`) instead of copying them; `dumpAlign` pads the dump so those vectors are aligned in
+place. `lbaselib.c:348` forbids `'B'` from Lua code. The buffer must outlive the closure. This is
+the zero-copy path for bytecode living in a persistent kernel buffer (firmware section, a
+`vmalloc`ed image loaded once); `lunatik_loadfile`'s page-sized streaming buffer does not qualify.
+Opportunity, not a requirement (see non goals in `plan.md`).
+
+## Bytecode trust
+
+Lua has had no bytecode verifier since 5.2 (removed after Peter Cawley's exploits of the 5.1
+verifier; the 5.5 manual: "Lua does not check the consistency of binary chunks. Maliciously crafted
+binary chunks can crash the interpreter"). `lundump.c` checks the header and sizes, not the
+semantics of instructions; `luai_verifycode` is an empty hook. A hostile chunk can read and write
+arbitrary memory of the Lua state — in the kernel, that is a kernel compromise. The kernel already
+runs Lua **source** with full kernel privileges from a root-owned directory over a root-only
+device, so accepting bytecode from the same directory does not widen who can run code; it only
+removes the parser as a sanity filter. Precedent: NetBSD's kernel Lua loads through `"bt"` but
+refuses the `0x1b` signature unless `kern.lua.bytecode=1` (default 0). The consequence for design:
+never add a path that loads bytecode from an untrusted source, and keep a text-only knob available
+for deployments that want the parser as a filter (mode `"t"` in `lunatik_loadfile`, see `plan.md`
+risks).
+
+## Other precedents worth knowing
+
+* **eLua `luac.cross`** (5.1): `-cci bits -ccn type bits -cce big|little`; a `DumpTargetInfo`
+  struct and byte swapping on the dump side, a separate `luaU_dump_crosscompile` entry point. The
+  closest model for a cross-endian Lunatik dump.
+* **NodeMCU `luac.cross`** (5.3): host built with the target's number config, no swapping (host and
+  ESP both little-endian); its LFS (bytecode executed from flash) is the ancestor of 5.5's fixed
+  buffers.
+* **OpenWrt** (5.1 package): swap on *load* (`030-archindependent-bytecode.patch`), host `luac`
+  for MIPS BE routers. Loader-side swapping is the option we do not want (it costs the kernel).
+* **Lua 5.1 `etc/noparser.c`**: stub `luaY_parser` + drop `lcode/llex/lparser` ("35 % of the
+  core"). 5.5's `f_parser` (`ldo.c:1123`) still only calls `luaU_undump` or `luaY_parser`, so the
+  technique applies unchanged to a bytecode-only kernel build.
+* **FreeBSD lualoader**: same integer-only `lua_Number` trick (`LUA_FLOAT_INT64`), ships source.
+* No pure-Lua compiler targets 5.4/5.5; the 5.5 format (string reuse, alignment) has readers but
+  no independent writer. The interpreter's own `ldump.c` is the only correct writer.
+
+## Sizes (for the "no parser in the kernel" follow-up)
+
+`size` on a 6.8 aarch64 build: `lparser.o` 19556 + `lcode.o` 14944 + `llex.o` 8873 = ~43 KB of
+text out of 234 KB in `lunatik.ko` (~18 %). `ldump.o` is 3 KB and `lundump.o` 4.5 KB. Dropping the
+front end is a real but modest saving; it also removes `load`/`loadstring` of text, `string.dump`
+stays. Not part of the first phases.
+
+## Host build of the compiler (verified)
+
+`lua/` has no `luac.c` (only upstream `lua.c`); `onelua.c` still references it under `MAKE_LUAC`.
+A host compiler needs only the core: `lapi lcode lctype ldebug ldo ldump lfunc lgc llex lmem
+lobject lopcodes lparser lstate lstring ltable ltm lundump lvm lzio lauxlib` — **not** `lbaselib`,
+`loadlib`, `linit`, `liolib`, which under `_KERNEL` reference `luaL_loadfilex`/`lsys_*` provided by
+`lunatik_conf.h`. Built with `-D_KERNEL -DLUA_USE_LINUX` and a `lunatik_conf.h` whose kernel-only
+parts (`printk`, `<linux/module.h>`, `<linux/random.h>`, `lunatik_loadfile`, `LUA_EXTRASPACE`
+struct) are fenced with `#ifdef __KERNEL__`, the result is a ~200 KB static binary whose output the
+kernel runs (verified: full and stripped chunks, `7/2 == 3`).
+
+Details that bit during the prototype:
+
+* `lua_dump`'s writer is called with `size == 0` blocks; `fwrite(p, 0, 1, f)` returns 0 and looks
+  like a failure. Treat `size == 0` as success.
+* `luaL_loadbufferx(..., "t")` on the host so that the tool never re-dumps a chunk it did not
+  compile (a stock chunk fed by mistake is rejected at the parse step, not silently copied).
+* The `lunatik_conf.h` redefinition of `lua_getlocaledecpoint` must stay under `__KERNEL__` (the
+  host `luaconf.h` already defines it; redefining warns).
+

--- a/doc/design/luac/plan.md
+++ b/doc/design/luac/plan.md
@@ -1,0 +1,201 @@
+# Plan: bytecode compiler for Lunatik
+
+Execution plan for `lunatikc`, the userspace compiler and cross-compiler for kernel Lua scripts.
+Built incrementally: each phase is a shippable pull request, and the first one is the whole
+user-visible feature. Phases 1–3 are prototyped on the `claude_luac` branch (four commits on top of
+`origin/master`, full suite green with source and with bytecode installs); this plan was revised
+against that prototype.
+
+## Expected results
+
+1. `lunatikc script.lua` on a development host produces a binary chunk that the kernel Lua loads
+   and runs, with the same semantics as the source (integer-only arithmetic, `/` as integer
+   division), optionally stripped of debug information.
+2. Installing compiled chunks is a build option: `make install` can ship the kernel-side Lua
+   libraries (`lib/lunatik/*.lua`, `lib/*.lua`, …) and examples as bytecode instead of source, with
+   the test suite passing either way.
+3. A chunk compiled on a 64-bit host runs on a 32-bit little-endian target unchanged, and a big-endian
+   target is reachable through a byte-order option — a real cross-compiler for the OpenWrt
+   targets Lunatik is deployed on.
+4. A `luac` KTAP suite that compiles on the host and runs in the kernel, covering the happy path,
+   strip, and rejection of foreign chunks.
+5. Follow-ups that become possible once bytecode is first class: a kernel build without the
+   parser, zero-copy loading of resident chunks (`'B'` mode), encrypted bytecode through `darken`.
+
+## Where we are today
+
+* The kernel already accepts binary chunks everywhere (`lunatik_loadfile` mode `NULL` = `"bt"`,
+  also used by `require`); `ldump.o` and `lundump.o` are in `lunatik.ko`; `string.dump` exists.
+  Nothing in the tree exercises it — no test, doc, issue or branch mentions bytecode.
+* There is no way to produce a chunk. `lua/` ships no `luac.c`, the `Makefile` builds no host
+  tool (the host `lua5.4` is only used for `autogen.lua` and LDoc), and the distribution `luac`
+  is incompatible with the kernel fork (`kernel-notes.md`): different opcode numbering, `/`
+  semantics, no floats, integer `lua_Number` in the header. Verified: a stock 5.5 chunk fails with
+  `bad binary format (Lua number format mismatch)`.
+* `lunatik_conf.h` mixes the number configuration the compiler must share (`LUA_NUMBER =
+  LUA_INTEGER`, …) with kernel-only material (`printk`, `<linux/module.h>`, `lunatik_loadfile`,
+  the `LUA_EXTRASPACE` struct), so it cannot be included by a host build as is.
+* Verified on the prototype: the Lua core (`lapi … lzio`, `lauxlib`) built on the host with
+  `-D_KERNEL -DLUA_USE_LINUX` and the shared part of `lunatik_conf.h` yields a ~200 KB static
+  compiler whose chunks, installed under `/lib/modules/lua/<name>.lua`, run in the kernel, full and
+  stripped. With every kernel Lua library and example installed as stripped chunks (`BYTECODE=1`),
+  the whole suite passes (117/117, 6.8.0-136 aarch64), `driver.lua` included — so `lunatik_run`
+  loads a chunk at `modprobe` time too. The kernel libraries shrink from 12.8 KB of source to
+  4.0 KB of stripped bytecode.
+* Found by the suite: `runner.lua`'s `trim()` used `gsub("(%w+).lua", "%1")`, where the dot
+  matches any character, so any script path with a word, a character and `lua` in it was mangled
+  (`tests/luac/x` → `testsc/x`). Fixed on the branch (`trim` now drops only a trailing `.lua`); a
+  prerequisite for a suite named `luac`, and a latent bug for any such path.
+
+## What is missing
+
+1. A host-buildable `lunatik_conf.h`: fence the kernel-only parts with `#ifdef __KERNEL__`, keep
+   the number configuration and limits shared. One header, one source of truth — no shim copy.
+2. The tool itself: a small C driver (`luaL_loadbufferx` text-only + `lua_dump`), with `-s`,
+   `-o`, a chunk name option, and multiple inputs; built from the `lua/` core with host `cc`.
+3. Build and install wiring: a `lunatikc` Makefile target, installed next to `bin/lunatik`; an
+   opt-in `BYTECODE=1` for `scripts_install`/`examples_install` that compiles instead of copies.
+4. Tests and docs: `tests/luac/`, `tests/README.md`, README usage section, and the `check_dmesg`
+   fix for stripped chunks (`testing.md`; `run_script` already fails on any output upstream).
+5. Cross-endian: a dump-side byte swap in the `lua/` fork, behind a host-only define, with a
+   `-e big|little` option (and a `-B`-mode loader, a parser-less kernel, `darken` bytecode as
+   separate follow-ups).
+
+## Shape of the work
+
+**Host tool, not kernel feature.** The kernel side is already done; resist the temptation to "add
+bytecode support" in C. The only kernel-visible change in phase 1 is the `__KERNEL__` fence in
+`lunatik_conf.h`, which is a no-op for the kernel build (same macros, same values).
+
+**Same front end, by construction.** The compiler links the very `lua/` sources `lunatik.ko` is
+built from, with the same `_KERNEL` define. Bumping the submodule rebuilds both. This is what makes
+"bytecode the kernel accepts" a tautology rather than a maintenance burden; do not fork `ldump.c`
+into the tool.
+
+**Install bytecode under the `.lua` name.** `lunatik run <name>` and `require` append `.lua` in
+the kernel (`lunatik_core.c:219`, `package.path`); `lua_load` sniffs the signature byte. Keeping
+the name means zero changes to the runner, the CLI, `package.path`, and every `SCRIPT=` in the
+tests. A `.luac` suffix buys nothing and costs a kernel change plus a second search path.
+
+**Text-only on the host.** The tool parses with mode `"t"`, so it never re-emits a chunk it did not
+compile; a foreign `.luac` fed by mistake is a parse error, not a silently copied incompatibility.
+
+## Phases
+
+### Phase 1 — the compiler (`bin/lunatikc.c`, `lunatik_conf.h`, `Makefile`) — prototyped
+
+* `lunatik_conf.h`: fence kernel-only parts with `#ifdef __KERNEL__`. Shared on both sides:
+  `LUAI_UACNUMBER`, `LUA_NUMBER`, `LUA_NUMBER_FMT`, `l_randomizePivot`, `LUAL_BUFFERSIZE`,
+  `LUAI_MAXSTACK`, `LUNATIK_GCCOUNT`, `lua_getlocaledecpoint` (so the host parser ignores the
+  locale). Kernel only: `<linux/random.h>` / `luai_makeseed`, `lua_write*`, `l_signalT`, `panic`,
+  `<linux/module.h>` and `lsys_*`, `lunatik_loadfile`/`luaL_loadfilex`, `LUA_ROOT`/`LUA_PATH_DEFAULT`,
+  `lunatik_runtime_t`/`LUA_EXTRASPACE`, `luaS_hash`, the `current` undef.
+* `bin/lunatikc.c`: `lunatikc [-s] [-o out] [-n chunkname] in.lua…`. Reads the file, parses with
+  `"t"`, `lua_dump` with `strip`; writer tolerates empty blocks; default output `<in>.luac` next to
+  the input (`-o` is a directory when there are several inputs), default chunk name `@<in>` (so
+  errors point at the source the developer edits, and `-n` lets an installer set
+  `@/lib/modules/lua/<name>.lua`). Exit non-zero on any error, message on stderr. ~160 lines.
+* `Makefile`: `lunatikc` target compiling `bin/lunatikc.c` plus the `lua/` core list (no
+  `lbaselib`/`loadlib`/`linit`/`liolib`) with `$(HOSTCC)` `-std=gnu99 -O2 -D_KERNEL
+  -DLUA_USE_LINUX -I. -Ilua`; part of `all`; `clean` removes it; `scripts_install` installs it to
+  `LUNATIK_INSTALL_PATH` next to `lunatik`; `scripts_uninstall` removes it.
+* One commit for the header fence (no behavior change: same `lunatik.ko` text size with and
+  without it), one for the tool and its wiring, docs in the same commit (README usage section).
+  The `-Wall` host build shows one warning from the fork (`llex.c`: `expo` set but unused under
+  `_KERNEL`); a one-line fix in `luainkernel/lua`, not in this tree.
+
+### Phase 2 — the `luac` test suite (`tests/luac/`, `tests/lib.sh`, `lib/lunatik/runner.lua`) — prototyped
+
+* `tests/luac/run.sh`: compile the installed test scripts on the host with
+  `lunatikc` into `/lib/modules/lua/tests/luac/`, run it with `lunatik run`, assert the expected
+  `dmesg` line; repeat with `-s`; assert that a stock-format chunk (a crafted header with a
+  double `LUAC_NUM`) is rejected with `Lua number format mismatch`; assert a text-only wrapper
+  still works (`load(chunk, name, "t")` inside the kernel rejects the binary).
+* `tests/lib.sh`: `check_dmesg` recognises errors by `\.lua:[0-9]+:`; a stripped chunk errors as
+  `?:?:`. Extend the pattern so stripped failures do not pass silently (`testing.md`).
+* `lib/lunatik/runner.lua`: the `trim()` fix above, as its own commit (a bug on its own).
+* Register in `tests/run.sh`, `tests/README.md`, README `### Testing`.
+
+### Phase 3 — installing bytecode (`Makefile`) — prototyped, folded into phase 1
+
+* `BYTECODE=1 make install`: an `INSTALL_LUA` recipe macro that is `install -m 0644` by default
+  and `lunatikc -s -o <dest>/<name>` with `BYTECODE=1`; every `.lua` install line in
+  `scripts_install` and `examples_install` goes through it, so the list of files stays in one
+  place. Two exceptions stay source: `autogen/lunatik/config.lua` (symlinked into the host
+  `package.path` and read by the `lunatik` CLI under the host Lua 5.4) and the tests (the suite
+  compiles its own). `-n` is moot with `-s` (no source name is kept).
+* Default stays source. It came out at 15 Makefile lines, so it shipped with the tool rather than as
+  a separate phase; the full suite was run both ways.
+
+### Phase 4 — cross-endian (`lua/` fork, `bin/lunatikc.c`) — not started
+
+* `lua/ldump.c` in `luainkernel/lua`: a host-only `LUNATIK_DUMP_SWAP` (name open) that makes
+  `dumpVector` for `Instruction`, the `abslineinfo` vector and the header `dumpNumInfo` go through
+  a byte swap when `D->swap` is set — the eLua model. Set from a new field reached by
+  `lua_dump`… which has no such parameter: pass the target through the `DumpState` from a
+  `luaU_dump` variant (`luaU_dumpx(L, f, w, data, strip, swap)`), exported only on the host.
+* `lunatikc -e big|little` (default host). Then a submodule bump in lunatik and the option in the
+  tool. Verification: compile for big-endian on the development host and load it under `qemu-system-mips`
+  OpenWrt, or at minimum compare byte-for-byte with a chunk produced natively on a BE host.
+
+### Phase 5 — follow-ups (separate plans when picked up)
+
+* **Parser-less kernel build**: `CONFIG_LUNATIK_BYTECODE_ONLY` dropping `lcode/llex/lparser` from
+  `Kbuild` with a stub `luaY_parser` (the 5.1 `noparser.c` technique); ~43 KB of text; forces
+  `BYTECODE=1` install and text `load` becomes an error. Also a security posture: source can no
+  longer be injected through `/dev/lunatik`.
+* **Text-only knob**: a module parameter or Kconfig making `lunatik_loadfile` pass `"t"`
+  (NetBSD's `kern.lua.bytecode` precedent), for deployments that want the parser as a filter.
+* **Fixed-buffer loading**: `'B'` mode for chunks resident in a persistent buffer (firmware
+  section, `request_firmware`), saving the copy of code and strings; needs a loader that reads the
+  whole chunk once, not `lunatik_loadfile`'s page streaming.
+* **Encrypted bytecode**: `luadarken_run` loads with `"t"`; a `"b"` option and `shade.sh` running
+  `lunatikc` first.
+
+## Sizing
+
+| Phase | New code | Touches | Risk |
+|-------|----------|---------|------|
+| 1+3 | 166 lines C, ~50 Makefile | `lunatik_conf.h` (fence only) | low; prototyped, suite green both ways |
+| 2 | 1 shell + 5 Lua test files, `check_dmesg` pattern, `runner.lua` trim | `tests/run.sh`, READMEs | low; prototyped |
+| 4 | ~40 lines in `lua/ldump.c`, ~20 in the tool | `lua/` submodule bump | medium: needs a BE box or qemu to verify |
+| 5 | per follow-up | `Kbuild`, `Kconfig`, `lunatik_aux.c`, `luadarken.c` | separate plans |
+
+## Non goals
+
+* A Lua-to-bytecode compiler written in Lua, or any reimplementation of the front end: it would
+  have to track the `_KERNEL` patch by hand.
+* Changing the chunk format, adding a verifier, or signing chunks. Trust is by directory, as for
+  source today; a signing story belongs with a kernel lockdown discussion, not here.
+* A `.luac` extension, a second `package.path` entry, or any runner/CLI change for phase 1–3.
+* Compiling on the device: the point is the host; the device may have no toolchain at all.
+* Loader-side byte swapping (OpenWrt 5.1 model): it moves cost into the kernel for every load.
+
+## Risks
+
+* **Header fence regression.** Splitting `lunatik_conf.h` must not change a single macro the
+  kernel sees. Check: `make` before/after produces identical `lunatik.ko` text size and the full
+  suite passes; diff the preprocessed header under `-D__KERNEL__`.
+* **Test harness blind spot.** With `-s`, a failing script prints `?:?:` and `check_dmesg` would
+  not notice (`run_script` fails on any output since `e9e57297`). Fixed in the suite commit and
+  validated negatively: a failing stripped chunk is reported as `not ok`.
+* **Submodule drift.** Phase 4 lands in `luainkernel/lua` first; until the bump, the tool's
+  `-e` must fail loudly ("byte swap not supported by this build"), not emit a native chunk.
+* **Chunk name leakage.** A chunk keeps the path given at compile time; the install recipe must
+  pass `-n` so kernel messages name the installed file, and `-s` installs carry no path at all.
+* **`lua_Number` drift.** If the kernel fork ever changes number configuration, the header
+  probes catch it (mismatch error), but only at load time; the suite's stock-format rejection
+  test is the canary.
+
+## Definition of done, per phase
+
+1. `make` builds `lunatikc`; a chunk it produces, installed as `.lua`, runs under `lunatik run`
+   and via `require`; `-s` and `-n` behave as documented; a stock chunk is rejected; kernel build
+   unchanged. **Met on the prototype.**
+2. `sudo lunatik test luac` green; a deliberately failing stripped chunk is reported as a failure
+   by the harness. **Met on the prototype** (8/8; negative validation by hand).
+3. `BYTECODE=1 make install` followed by the full suite, green; `file /lib/modules/lua/*.lua` shows
+   Lua bytecode under the usual names. **Met on the prototype** (117/117).
+4. A big-endian chunk verified on a BE runtime (qemu or hardware), and the native path unchanged.
+5. Each follow-up has its own design note before code.
+

--- a/doc/design/luac/testing.md
+++ b/doc/design/luac/testing.md
@@ -1,0 +1,84 @@
+# Testing the bytecode compiler
+
+Lunatik's tests are shell scripts emitting KTAP, driving a kernel Lua script and asserting on
+`dmesg` or on what userspace observes. `tests/io/test.sh` is the closest model (one `.sh`, one
+`.lua`, `run_script` + `check_dmesg`); read it and `tests/lib.sh` first.
+
+Run everything with `sudo lunatik test`, one suite with `sudo lunatik test luac`.
+
+## What this suite needs that others do not
+
+**A host step.** The kernel script under test is not installed by `make tests_install` as is: the
+suite compiles it at run time with the installed `lunatikc` from the installed source
+(`/lib/modules/lua/tests/luac/*.lua`) into a sibling `.lua` that is the chunk. That keeps `make
+tests_install` unchanged (it copies `.lua` sources) and exercises the real install path of the
+tool. `cleanup()` removes the generated chunks.
+
+**A skip gate for the tool.** If `lunatikc` is not on `PATH` (`make install` not run, or a
+package without it), `run.sh` reports `ktap_skip` for the whole suite rather than failing.
+
+**A harness fix.** `check_dmesg` in `tests/lib.sh` recognised Lua errors by `\.lua:[0-9]+:`
+(`run_script` fails on any output, so it was already covered). A **stripped** chunk reports errors
+as `?:?:` (no source, no line), so a failing stripped script passed `check_dmesg`. The pattern now
+also matches `\?:\?:`; validated negatively on the prototype (a failing stripped chunk is `not
+ok`). Verified messages:
+
+```
+full:   /lib/modules/lua/tests/luac/err_bc.lua:8: attempt to index a nil value (local 't')
+strip:  ?:?: attempt to index a nil value
+```
+
+The suite's own scripts stay source under `make tests_install`, so they are compiled at run
+time: `tests/luac/run.sh` writes `hello_bc.lua`, `hello_s.lua`, `lib_bc.lua`, `err_bc.lua`,
+`err_s.lua` and the patched `stock.lua` next to the sources and removes them in `cleanup()`.
+
+**A runner fix.** `runner.lua`'s `trim()` mangled any script path containing a word, one
+character and `lua` (`tests/luac/hello_bc` → `testsc/hello_bc`); the suite is what found it. Fixed
+on the branch; without it the suite cannot be named `luac`.
+
+## Test matrix
+
+Coverage means the matrix of operation × variant × outcome, including the successes and the clean
+failures, not a list of features.
+
+### Phase 1–2: compile and run
+
+| Operation | Variant | Expected |
+|-----------|---------|----------|
+| `lunatikc t.lua` → `lunatik run` | full | script's `dmesg` marker present, no error |
+| same | `-s` | marker present, no error |
+| same | `-n @/lib/modules/lua/tests/luac/t.lua` + forced error | error message names the installed path and line |
+| same | `-s` + forced error | `?:?:` error, and the harness **fails** the test (negative validation of the lib.sh fix) |
+| `require("tests.luac.lib")` from a text script | lib installed as chunk | module loads and its function returns |
+| `lunatikc` on a file with a syntax error | | non-zero exit, message with `file:line:`, no output file |
+| `lunatikc` on a binary input | | non-zero exit (`attempt to load a binary chunk`), no output |
+| stock-format chunk installed as `.lua` | crafted header (`LUAC_NUM` as a double) | `bad binary format (Lua number format mismatch)` |
+| `load(chunk, "=x", "t")` in the kernel | chunk read with `io` | `attempt to load a binary chunk (mode is 't')` |
+| integer semantics | `7 / 2`, `2^3` absent, `3.5` literal | `3`; `^` is a syntax error on the host; `3.5` is `malformed number` on the host |
+
+### Phase 3: bytecode install
+
+| Operation | Expected |
+|-----------|----------|
+| `BYTECODE=1 make install` then `sudo lunatik test` | every suite green (driver, runner, net, mailbox, socket, netlink, bpf libs all run as stripped chunks) — 117/117 on the prototype |
+| `file /lib/modules/lua/net.lua` | "Lua bytecode" |
+| `lunatik run examples/…` | examples run as chunks |
+
+### Phase 4: cross-endian
+
+| Operation | Expected |
+|-----------|----------|
+| `lunatikc -e big` on a little-endian host, load on a big-endian runtime (qemu MIPS OpenWrt) | runs |
+| `lunatikc -e big` chunk loaded on the little-endian host | `int format mismatch` (header probe catches it) |
+| `-e little` on a little-endian host | byte-identical to no `-e` |
+| `-e big` with a tool built without the swap hook | loud error, no output |
+
+## How to fake a stock chunk without a stock `luac`
+
+The suite cannot depend on `luac5.5` being installed. Take a good chunk and patch the
+`lua_Number` probe: the header is `\x1bLua\x55\x00` + `LUAC_DATA` (6 bytes) + four
+`size,value` blocks; the last block is `\x08` + 8 bytes. Replace those 8 bytes with the IEEE-754
+little-endian image of `-370.5` (`00 00 00 00 00 28 77 c0`) with `printf | dd conv=notrunc`.
+The kernel must answer `Lua number format mismatch` — the same message a real stock chunk gives
+(verified with an upstream 5.5.0 `luac`).
+

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -26,7 +26,7 @@ local runner = {}
 -- @tparam string script script filename (e.g., "myscript.lua").
 -- @treturn string script name without the ".lua" extension (e.g., "myscript").
 local function trim(script) -- drop ".lua" file extension
-	return script:gsub("(%w+).lua", "%1")
+	return (script:gsub("%.lua$", ""))
 end
 
 local function key(script, cpu)

--- a/lunatik_conf.h
+++ b/lunatik_conf.h
@@ -6,17 +6,29 @@
 #ifndef lunatik_conf_h
 #define lunatik_conf_h
 
+/* shared by the kernel and the host compiler (bin/lunatikc): everything that shapes bytecode */
 #define LUAI_UACNUMBER		LUA_INTEGER
 #define LUA_NUMBER		LUA_INTEGER
 #define LUA_NUMBER_FMT		LUA_INTEGER_FMT
 
 #define l_randomizePivot(L)	(~0)
 
-#include <linux/random.h>
-#define luai_makeseed(L)		get_random_u32()
-
 #undef lua_getlocaledecpoint
 #define lua_getlocaledecpoint()		('.')
+
+/* frame size shouldn't be larger than 1024 bytes; thus, LUAL_BUFFERSIZE
+ * must be adjusted for the stack of functions that use luaL_Buffer */
+#undef LUAL_BUFFERSIZE
+#define LUAL_BUFFERSIZE		(256) /* {laux,load,lstr,ltab,lutf8}lib.c */
+
+#undef LUAI_MAXSTACK
+#define LUAI_MAXSTACK  200
+
+#define LUNATIK_GCCOUNT	/* LUA_GCCOUNT in bytes, instead of Kbytes */
+
+#ifdef __KERNEL__
+#include <linux/random.h>
+#define luai_makeseed(L)		get_random_u32()
 
 #define lua_writestring(s,l)		printk("%s",(s))
 #define lua_writeline()			pr_cont("\n")
@@ -24,11 +36,6 @@
 
 /* see https://www.gnu.org/software/libc/manual/html_node/Atomic-Types.html */
 #define l_signalT	int
-
-/* frame size shouldn't be larger than 1024 bytes; thus, LUAL_BUFFERSIZE
- * must be adjusted for the stack of functions that use luaL_Buffer */
-#undef LUAL_BUFFERSIZE
-#define LUAL_BUFFERSIZE		(256) /* {laux,load,lstr,ltab,lutf8}lib.c */
 
 #ifdef lauxlib_c
 #define panic	lua_panic
@@ -70,9 +77,6 @@ int lunatik_loadfile(lua_State *L, const char *filename, const char *mode);
 #undef LUA_PATH_DEFAULT
 #define LUA_PATH_DEFAULT  LUA_ROOT"?.lua;" LUA_ROOT"?/init.lua"
 
-#undef LUAI_MAXSTACK
-#define LUAI_MAXSTACK  200
-
 /* stored in L's extraspace; gates lunatik_run */
 struct lunatik_object_s;
 typedef struct lunatik_runtime_s {
@@ -89,13 +93,12 @@ unsigned int luaS_hash(const char *str, size_t l, unsigned int seed); /* require
 #define	lunatik_hash(str, l, seed)	luaS_hash((str), (l), (seed))
 #endif /* LUNATIK_RUNTIME */
 
-#define LUNATIK_GCCOUNT	/* LUA_GCCOUNT in bytes, instead of Kbytes */
-
 #if defined(lcode_c) || defined(ldebug_c) || defined(llex_c) || defined(lparser_c) || defined(lstate_c)
 #ifdef current /* defined by asm/current.h */
 #undef current /* conflicts with Lua namespace */
 #endif
 #endif
+#endif /* __KERNEL__ */
 
 #endif
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -75,6 +75,14 @@ Covers the `crypto` module: `shash`, `skcipher`, `aead`, `rng`, `hkdf`,
 - **test**: kernel `io` library (open/read/write/seek/lines/type); also
   asserts `io` is absent from softirq runtimes.
 
+### luac
+
+- **run**: the host bytecode compiler `lunatikc`: compiled chunks (full and
+  stripped) run under `lunatik run` and `require`; error messages carry the
+  `-n` chunk name, or `?:?:` when stripped; a stock (float) number format
+  is rejected by the chunk header; `load(..., "t")` rejects a chunk in the
+  kernel. Skips when `lunatikc` is not installed.
+
 ### monitor
 
 Regression tests for `lunatik_monitor` (spinlock + GC interaction).

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -22,7 +22,7 @@ mark_dmesg() { dmesg -C 2>/dev/null; }
 dmesg_since() { dmesg; }
 check_dmesg() {
 	local errs
-	errs=$(dmesg_since | grep -E "\.lua:[0-9]+:" || true)
+	errs=$(dmesg_since | grep -E "(\.lua:[0-9]+|\?:\?):" || true)
 	[ -z "$errs" ] && return 0
 	ktap_fail "no Lua errors in kernel"
 	echo "# $errs"

--- a/tests/luac/err.lua
+++ b/tests/luac/err.lua
@@ -1,0 +1,9 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luac test (see run.sh): a runtime error, to compare full and stripped messages.
+
+local t = nil
+local x = t.field
+

--- a/tests/luac/hello.lua
+++ b/tests/luac/hello.lua
@@ -1,0 +1,12 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luac test (see run.sh): a compiled chunk runs with integer semantics.
+
+local linux = require("linux")
+
+assert(7 / 2 == 3, "integer division")
+assert(type(linux.time()) == "number")
+print("luac: hello from bytecode")
+

--- a/tests/luac/lib.lua
+++ b/tests/luac/lib.lua
@@ -1,0 +1,14 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luac test (see run.sh): a library installed as a compiled chunk.
+
+local lib = {}
+
+function lib.answer()
+	return 42
+end
+
+return lib
+

--- a/tests/luac/run.sh
+++ b/tests/luac/run.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Tests the bytecode compiler: compiles the installed test scripts with lunatikc on the host,
+# installs the chunks under /lib/modules/lua/tests/luac and runs them in the kernel.
+#   - a compiled chunk runs, full and stripped (-s), with integer semantics
+#   - a compiled library is found by require()
+#   - errors name the chunk name given with -n; stripped errors are "?:?:"
+#   - a chunk with a stock (float) number format is rejected by the header check
+#   - load() with mode "t" rejects a chunk inside the kernel
+#
+# Usage: sudo bash tests/luac/run.sh
+
+SCRIPT="tests/luac/hello_bc"
+SCRIPTS_PATH="/lib/modules/lua"
+SRC="$SCRIPTS_PATH/tests/luac"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() {
+	rm -f "$SRC"/*_bc.lua "$SRC"/*_s.lua "$SRC"/stock.lua
+}
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 8
+
+if ! command -v lunatikc >/dev/null; then
+	for i in $(seq 8); do ktap_skip "luac: lunatikc not installed"; done
+	ktap_totals
+	exit 0
+fi
+
+# name the chunks as the kernel will see them, so that error messages point at the installed file
+compile() {
+	local name="$1" strip="$2"; shift 2
+	lunatikc $strip -n "@$SRC/$name.lua" -o "$SRC/$name.lua" "$@"
+}
+
+compile hello_bc "" "$SRC/hello.lua" || fail "luac: compile hello"
+compile hello_s -s "$SRC/hello.lua" || fail "luac: compile hello -s"
+compile lib_bc -s "$SRC/lib.lua" || fail "luac: compile lib -s"
+compile err_bc "" "$SRC/err.lua" || fail "luac: compile err"
+compile err_s -s "$SRC/err.lua" || fail "luac: compile err -s"
+ktap_pass "luac: lunatikc compiles the test scripts"
+
+mark_dmesg
+run_script "$SCRIPT"
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -q "luac: hello from bytecode" || fail "luac: compiled chunk did not run"
+ktap_pass "luac: compiled chunk runs"
+
+mark_dmesg
+run_script "tests/luac/hello_s"
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -q "luac: hello from bytecode" || fail "luac: stripped chunk did not run"
+ktap_pass "luac: stripped chunk runs"
+
+mark_dmesg
+run_script "tests/luac/user"
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -q "luac: require of a compiled library" || fail "luac: require did not load the chunk"
+ktap_pass "luac: require() loads a compiled library"
+
+output=$(lunatik run tests/luac/err_bc)
+echo "$output" | grep -q "^$SRC/err_bc.lua:8: attempt to index a nil value (local 't')" \
+	|| fail "luac: full chunk error: $output"
+ktap_pass "luac: error names the chunk name and line"
+
+output=$(lunatik run tests/luac/err_s)
+echo "$output" | grep -q "^?:?: attempt to index a nil value" || fail "luac: stripped chunk error: $output"
+ktap_pass "luac: stripped error has no source or line"
+
+# a stock luac writes lua_Number as a double: patch the header probe (last 8 bytes of the
+# 4 size+value blocks) with the IEEE-754 image of -370.5
+cp "$SRC/hello_bc.lua" "$SRC/stock.lua"
+printf '\x00\x00\x00\x00\x00\x28\x77\xc0' | dd of="$SRC/stock.lua" bs=1 seek=32 conv=notrunc status=none
+output=$(lunatik run tests/luac/stock)
+echo "$output" | grep -q "Lua number format mismatch" || fail "luac: stock chunk accepted: $output"
+ktap_pass "luac: stock number format is rejected"
+
+mark_dmesg
+run_script "tests/luac/textmode"
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -q "luac: text-only load rejects bytecode" || fail "luac: textmode did not run"
+ktap_pass "luac: load() with mode t rejects a chunk"
+
+ktap_totals
+

--- a/tests/luac/textmode.lua
+++ b/tests/luac/textmode.lua
@@ -1,0 +1,15 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luac test (see run.sh): load() with mode "t" rejects a compiled chunk.
+
+local f = assert(io.open("/lib/modules/lua/tests/luac/hello_bc.lua", "rb"))
+local chunk = f:read("a")
+f:close()
+
+local fn, err = load(chunk, "=hello", "t")
+assert(fn == nil and err:find("binary chunk", 1, true), err)
+assert(load(chunk, "=hello", "b"))
+print("luac: text-only load rejects bytecode")
+

--- a/tests/luac/user.lua
+++ b/tests/luac/user.lua
@@ -1,0 +1,11 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luac test (see run.sh): a text script requiring a compiled library.
+
+local lib = require("tests.luac.lib_bc")
+
+assert(lib.answer() == 42)
+print("luac: require of a compiled library")
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -38,6 +38,7 @@ run_suite "$DIR/bpf/run.sh"
 run_suite "$DIR/xdp/run.sh"
 run_suite "$DIR/crypto/run.sh"
 run_suite "$DIR/io/test.sh"
+run_suite "$DIR/luac/run.sh"
 run_suite "$DIR/probe/run.sh"
 run_suite "$DIR/notifier/run.sh"
 


### PR DESCRIPTION
Adds `lunatikc`, a userspace compiler that turns kernel Lua scripts into binary chunks the kernel accepts, plus the wiring to ship scripts as bytecode.

The kernel already loads binary chunks everywhere (`lunatik_loadfile` runs with mode `"bt"`, `require` included); what was missing is a way to produce one. The distribution `luac` cannot: under `_KERNEL` the fork drops the float opcodes (renumbering everything after `OP_LOADI`), compiles `/` to integer division, and checks an integer `lua_Number` in the chunk header. So `lunatikc` is built with the host compiler from the same `lua/` sources and `_KERNEL` configuration as `lunatik.ko`, which makes its output match the kernel by construction.

* `lunatik_conf: fence the kernel-only part of the configuration`: the number configuration and limits stay shared with the host build; the kernel-only material goes under `__KERNEL__`. No change for the kernel build (same `lunatik.ko`).
* `lunatikc: add the host bytecode compiler`: `lunatikc [-s] [-o output] [-n chunkname] input.lua ...`, parsing text only and dumping with optional strip; built as part of `make`, installed next to `lunatik`. `BYTECODE=1 make install` ships the kernel Lua libraries and examples as stripped chunks under their usual `.lua` names (the loader detects the signature, so nothing changes on the kernel side); the full suite passes with source and with bytecode installs, `driver.lua` included. The kernel libraries go from 12.8 KB of source to 4.0 KB of stripped chunks.
* `runner: trim only a trailing .lua`: found by the new suite; `trim()` mangled any script path containing a name, one character and `lua` (`tests/luac/x` became `testsc/x`).
* `tests: add the luac suite`: compiled chunks run via `run` and `require`, full and stripped; error messages carry the `-n` chunk name, or `?:?:` when stripped (now recognized by `check_dmesg`); a stock number format is rejected by the header; `load(..., "t")` refuses a chunk in the kernel.
* `docs: add the bytecode compiler design notes`: `doc/design/luac/` with the format analysis (what is byte-order dependent in a 5.5 chunk), bytecode trust notes, precedents, and the plan for the follow-ups (cross-endian, parser-less kernel, fixed-buffer loading).

Cross-compilation to a different byte order is the next step, on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
