### PR TITLE
lunatikc: luac built against the kernel configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ doc/*
 !doc/design
 !doc/design/**
 /lib/linux/
+bin/lunatikc
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,25 @@ MKDIR = mkdir -p -m 0755
 LN = ln -sf
 INSTALL = install -o root -g root
 
+# luac built with the host compiler from the same lua/ sources and _KERNEL configuration as lunatik.ko
+HOSTCC ?= cc
+LUNATIKC := bin/lunatikc
+LUNATIKC_CORE := luac lapi lcode lctype ldebug ldo ldump lfunc lgc llex lmem lobject lopcodes \
+	lparser lstate lstring ltable ltm lundump lvm lzio lauxlib
+LUNATIKC_SRCS := $(addprefix lua/,$(addsuffix .c,$(LUNATIKC_CORE)))
+LUNATIKC_CFLAGS := -std=gnu99 -O2 -Wall -D_KERNEL -DLUNATIKC -DLUA_USE_LINUX -I. -Ilua
+
+# BYTECODE=1 installs kernel Lua scripts as stripped chunks, under their .lua names
+ifeq ($(BYTECODE),1)
+define INSTALL_LUA
+	for f in $(1); do ${LUNATIKC} -s -o $(2)/$$(basename $$f) $$f || exit 1; done
+endef
+else
+define INSTALL_LUA
+	${INSTALL} -m 0644 $(1) $(2)
+endef
+endif
+
 CONFIG_LUNATIK ?= m
 CONFIG_LUNATIK_RUNTIME ?= y
 CONFIG_LUNATIK_RUN ?= m
@@ -62,14 +81,17 @@ AUTOGEN_KEY := $(KERNEL_RELEASE)|$(LUNATIK_MODULES)
 	tests_install tests_uninstall \
 	ebpf ebpf_install ebpf_uninstall
 
-all: lunatik_sym.h autogen
+all: lunatik_sym.h autogen ${LUNATIKC}
 	${MAKE} -C ${MODULES_BUILD_PATH} M=${PWD} $(LUNATIK_CONFIG_FLAGS)
+
+${LUNATIKC}: ${LUNATIKC_SRCS} lunatik_conf.h
+	${HOSTCC} ${LUNATIKC_CFLAGS} -o $@ ${LUNATIKC_SRCS} -lm
 
 clean:
 	${MAKE} -C ${MODULES_BUILD_PATH} M=${PWD} clean
 	${MAKE} -C ${MODULES_BUILD_PATH} M=${PWD}/autogen clean
 	${MAKE} -C examples/filter clean
-	${RM} lunatik_sym.h
+	${RM} lunatik_sym.h ${LUNATIKC}
 	${RM} -r lib/linux
 	${RM} autogen/lunatik/*.lua autogen/linux/*.lua \
 		autogen/dump_*.c autogen/dump_*.pp \
@@ -88,27 +110,28 @@ scripts_install:
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/bpf
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/linux
 	${MKDIR} ${LUA_PATH}/lunatik
-	${INSTALL} -m 0644 driver.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/class.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/mailbox.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/net.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/struct.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/netlink.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/util.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/lighten.lua ${SCRIPTS_INSTALL_PATH}/
-	${INSTALL} -m 0644 lib/lunatik/*.lua ${SCRIPTS_INSTALL_PATH}/lunatik
-	${INSTALL} -m 0644 lib/socket/*.lua ${SCRIPTS_INSTALL_PATH}/socket
-	${INSTALL} -m 0644 lib/netlink/*.lua ${SCRIPTS_INSTALL_PATH}/netlink
-	${INSTALL} -m 0644 lib/netlink/rt/*.lua ${SCRIPTS_INSTALL_PATH}/netlink/rt
-	${INSTALL} -m 0644 lib/netlink/nl80211/*.lua ${SCRIPTS_INSTALL_PATH}/netlink/nl80211
-	${INSTALL} -m 0644 lib/syscall/*.lua ${SCRIPTS_INSTALL_PATH}/syscall
-	${INSTALL} -m 0644 lib/crypto/*.lua ${SCRIPTS_INSTALL_PATH}/crypto
-	${INSTALL} -m 0644 lib/bpf/*.lua ${SCRIPTS_INSTALL_PATH}/bpf
+	$(call INSTALL_LUA,driver.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/class.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/mailbox.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/net.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/struct.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/netlink.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/util.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/lighten.lua,${SCRIPTS_INSTALL_PATH}/)
+	$(call INSTALL_LUA,lib/lunatik/*.lua,${SCRIPTS_INSTALL_PATH}/lunatik)
+	$(call INSTALL_LUA,lib/socket/*.lua,${SCRIPTS_INSTALL_PATH}/socket)
+	$(call INSTALL_LUA,lib/netlink/*.lua,${SCRIPTS_INSTALL_PATH}/netlink)
+	$(call INSTALL_LUA,lib/netlink/rt/*.lua,${SCRIPTS_INSTALL_PATH}/netlink/rt)
+	$(call INSTALL_LUA,lib/netlink/nl80211/*.lua,${SCRIPTS_INSTALL_PATH}/netlink/nl80211)
+	$(call INSTALL_LUA,lib/syscall/*.lua,${SCRIPTS_INSTALL_PATH}/syscall)
+	$(call INSTALL_LUA,lib/crypto/*.lua,${SCRIPTS_INSTALL_PATH}/crypto)
+	$(call INSTALL_LUA,lib/bpf/*.lua,${SCRIPTS_INSTALL_PATH}/bpf)
 	# NOTE: `lib/linux/` exists only as LDoc stubs (see doc-stubs); never install it.
-	${INSTALL} -m 0644 autogen/linux/*.lua ${SCRIPTS_INSTALL_PATH}/linux
+	$(call INSTALL_LUA,autogen/linux/*.lua,${SCRIPTS_INSTALL_PATH}/linux)
 	${INSTALL} -m 0644 autogen/lunatik/*.lua ${SCRIPTS_INSTALL_PATH}/lunatik
 	${LN} ${SCRIPTS_INSTALL_PATH}/lunatik/config.lua ${LUA_PATH}/lunatik/config.lua
 	${INSTALL} -D -m 0755 bin/lunatik ${LUNATIK_INSTALL_PATH}/lunatik
+	${INSTALL} -D -m 0755 ${LUNATIKC} ${LUNATIK_INSTALL_PATH}/lunatikc
 
 scripts_uninstall:
 	${RM} ${SCRIPTS_INSTALL_PATH}/driver.lua
@@ -126,7 +149,7 @@ scripts_uninstall:
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/crypto
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/bpf
 	${RM} -r ${SCRIPTS_INSTALL_PATH}/linux
-	${RM} ${LUNATIK_INSTALL_PATH}/lunatik
+	${RM} ${LUNATIK_INSTALL_PATH}/lunatik ${LUNATIK_INSTALL_PATH}/lunatikc
 	${RM} -r ${LUA_PATH}/lunatik
 
 ebpf:
@@ -143,10 +166,10 @@ EXAMPLE_DIRS := $(patsubst examples/%/,%,$(wildcard examples/*/))
 
 examples_install:
 	${MKDIR} ${SCRIPTS_INSTALL_PATH}/examples
-	${INSTALL} -m 0644 examples/*.lua ${SCRIPTS_INSTALL_PATH}/examples
+	$(call INSTALL_LUA,examples/*.lua,${SCRIPTS_INSTALL_PATH}/examples)
 	for d in $(EXAMPLE_DIRS); do \
 		${MKDIR} ${SCRIPTS_INSTALL_PATH}/examples/$$d; \
-		${INSTALL} -m 0644 examples/$$d/*.lua ${SCRIPTS_INSTALL_PATH}/examples/$$d; \
+		$(call INSTALL_LUA,examples/$$d/*.lua,${SCRIPTS_INSTALL_PATH}/examples/$$d); \
 	done
 
 examples_uninstall:

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ Install and run the test suites:
 ```sh
 sudo make install
 sudo lunatik test           # run all suites
-sudo lunatik test thread    # run a specific suite (bpf, crypto, io, monitor,
-                            # netlink, notifier, probe, rcu, runtime, set, skb,
-                            # socket, struct, thread, xdp)
+sudo lunatik test thread    # run a specific suite (bpf, crypto, io, luac,
+                            # monitor, netlink, notifier, probe, rcu, runtime,
+                            # set, skb, socket, struct, thread, xdp)
 ```
 
 `lunatik test` reloads the modules before the run and unloads them

--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [
 * `stop`: stop the runtime environment created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_
 
+### lunatikc
+
+```Shell
+usage: lunatikc [options] [filenames]
+```
+
+`lunatikc` is `luac` built with the host compiler from the same `lua/` sources and configuration
+as `lunatik.ko`, so its chunks match the kernel's opcode set and integer-only number format;
+chunks from the distribution `luac` are rejected by the kernel. The options are `luac`'s
+(`-l` list, `-o` output, `-p` parse only, `-s` strip debug information, `-v` version).
+
+A chunk is installed and run under the usual `.lua` name; the kernel detects it by its signature:
+
+```Shell
+lunatikc -s -o hello.lua hello.lua    # overwrite with the stripped chunk
+sudo cp hello.lua /lib/modules/lua/
+sudo lunatik run hello
+```
+
+`BYTECODE=1 make install` installs the kernel Lua libraries and the examples as stripped chunks
+instead of source.
+
 ### Testing
 
 Install and run the test suites:

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -26,7 +26,7 @@ local runner = {}
 -- @tparam string script script filename (e.g., "myscript.lua").
 -- @treturn string script name without the ".lua" extension (e.g., "myscript").
 local function trim(script) -- drop ".lua" file extension
-	return script:gsub("(%w+).lua", "%1")
+	return (script:gsub("%.lua$", ""))
 end
 
 local function key(script, cpu)

--- a/lunatik_conf.h
+++ b/lunatik_conf.h
@@ -6,17 +6,29 @@
 #ifndef lunatik_conf_h
 #define lunatik_conf_h
 
+/* shared by the kernel and the host compiler (bin/lunatikc): everything that shapes bytecode */
 #define LUAI_UACNUMBER		LUA_INTEGER
 #define LUA_NUMBER		LUA_INTEGER
 #define LUA_NUMBER_FMT		LUA_INTEGER_FMT
 
 #define l_randomizePivot(L)	(~0)
 
-#include <linux/random.h>
-#define luai_makeseed(L)		get_random_u32()
-
 #undef lua_getlocaledecpoint
 #define lua_getlocaledecpoint()		('.')
+
+/* frame size shouldn't be larger than 1024 bytes; thus, LUAL_BUFFERSIZE
+ * must be adjusted for the stack of functions that use luaL_Buffer */
+#undef LUAL_BUFFERSIZE
+#define LUAL_BUFFERSIZE		(256) /* {laux,load,lstr,ltab,lutf8}lib.c */
+
+#undef LUAI_MAXSTACK
+#define LUAI_MAXSTACK  200
+
+#define LUNATIK_GCCOUNT	/* LUA_GCCOUNT in bytes, instead of Kbytes */
+
+#ifdef __KERNEL__
+#include <linux/random.h>
+#define luai_makeseed(L)		get_random_u32()
 
 #define lua_writestring(s,l)		printk("%s",(s))
 #define lua_writeline()			pr_cont("\n")
@@ -24,11 +36,6 @@
 
 /* see https://www.gnu.org/software/libc/manual/html_node/Atomic-Types.html */
 #define l_signalT	int
-
-/* frame size shouldn't be larger than 1024 bytes; thus, LUAL_BUFFERSIZE
- * must be adjusted for the stack of functions that use luaL_Buffer */
-#undef LUAL_BUFFERSIZE
-#define LUAL_BUFFERSIZE		(256) /* {laux,load,lstr,ltab,lutf8}lib.c */
 
 #ifdef lauxlib_c
 #define panic	lua_panic
@@ -70,9 +77,6 @@ int lunatik_loadfile(lua_State *L, const char *filename, const char *mode);
 #undef LUA_PATH_DEFAULT
 #define LUA_PATH_DEFAULT  LUA_ROOT"?.lua;" LUA_ROOT"?/init.lua"
 
-#undef LUAI_MAXSTACK
-#define LUAI_MAXSTACK  200
-
 /* stored in L's extraspace; gates lunatik_run */
 struct lunatik_object_s;
 typedef struct lunatik_runtime_s {
@@ -89,13 +93,12 @@ unsigned int luaS_hash(const char *str, size_t l, unsigned int seed); /* require
 #define	lunatik_hash(str, l, seed)	luaS_hash((str), (l), (seed))
 #endif /* LUNATIK_RUNTIME */
 
-#define LUNATIK_GCCOUNT	/* LUA_GCCOUNT in bytes, instead of Kbytes */
-
 #if defined(lcode_c) || defined(ldebug_c) || defined(llex_c) || defined(lparser_c) || defined(lstate_c)
 #ifdef current /* defined by asm/current.h */
 #undef current /* conflicts with Lua namespace */
 #endif
 #endif
+#endif /* __KERNEL__ */
 
 #endif
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -75,6 +75,15 @@ Covers the `crypto` module: `shash`, `skcipher`, `aead`, `rng`, `hkdf`,
 - **test**: kernel `io` library (open/read/write/seek/lines/type); also
   asserts `io` is absent from softirq runtimes.
 
+### luac
+
+- **run**: the bytecode compiler `lunatikc`: compiled chunks (full and
+  stripped) run under `lunatik run` and `require`; error messages carry the
+  source path and line, or `?:?:` when stripped; `-l` lists a compiled
+  chunk; a stock (float) number format is rejected by the chunk header;
+  `load(..., "t")` rejects a chunk in the kernel. Skips when `lunatikc` is
+  not installed.
+
 ### monitor
 
 Regression tests for `lunatik_monitor` (spinlock + GC interaction).

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -22,7 +22,7 @@ mark_dmesg() { dmesg -C 2>/dev/null; }
 dmesg_since() { dmesg; }
 check_dmesg() {
 	local errs
-	errs=$(dmesg_since | grep -E "\.lua:[0-9]+:" || true)
+	errs=$(dmesg_since | grep -E "(\.lua:[0-9]+|\?:\?):" || true)
 	[ -z "$errs" ] && return 0
 	ktap_fail "no Lua errors in kernel"
 	echo "# $errs"
@@ -47,7 +47,7 @@ run_test() {
 	local output errs
 	mark_dmesg
 	output=$(lunatik run "$@" 2>&1)
-	errs=$(dmesg_since | grep -iE "^[^:]+: FAIL	|\.lua:[0-9]+:" || true)
+	errs=$(dmesg_since | grep -iE "^[^:]+: FAIL	|(\.lua:[0-9]+|\?:\?):" || true)
 	[ -z "$output" ] && [ -z "$errs" ] && return 0
 
 	[ -n "$output" ] && comment "$output"

--- a/tests/luac/err.lua
+++ b/tests/luac/err.lua
@@ -1,0 +1,9 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luac test (see run.sh): a runtime error, to compare full and stripped messages.
+
+local t = nil
+local x = t.field
+

--- a/tests/luac/hello.lua
+++ b/tests/luac/hello.lua
@@ -1,0 +1,12 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luac test (see run.sh): a compiled chunk runs with integer semantics.
+
+local linux = require("linux")
+
+assert(7 / 2 == 3, "integer division")
+assert(type(linux.time()) == "number")
+print("luac: hello from bytecode")
+

--- a/tests/luac/lib.lua
+++ b/tests/luac/lib.lua
@@ -1,0 +1,14 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luac test (see run.sh): a library installed as a compiled chunk.
+
+local lib = {}
+
+function lib.answer()
+	return 42
+end
+
+return lib
+

--- a/tests/luac/run.sh
+++ b/tests/luac/run.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Tests the bytecode compiler: compiles the installed test scripts with lunatikc on the host,
+# installs the chunks under /lib/modules/lua/tests/luac and runs them in the kernel.
+#   - a compiled chunk runs, full and stripped (-s), with integer semantics
+#   - a compiled library is found by require()
+#   - errors name the source path and line; stripped errors are "?:?:"
+#   - -l lists a compiled chunk
+#   - a chunk with a stock (float) number format is rejected by the header check
+#   - load() with mode "t" rejects a chunk inside the kernel
+#
+# Usage: sudo bash tests/luac/run.sh
+
+SCRIPT="tests/luac/hello_bc"
+SCRIPTS_PATH="/lib/modules/lua"
+SRC="$SCRIPTS_PATH/tests/luac"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() {
+	rm -f "$SRC"/*_bc.lua "$SRC"/*_s.lua "$SRC"/stock.lua
+}
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 9
+
+if ! command -v lunatikc >/dev/null; then
+	for i in $(seq 9); do ktap_skip "luac: lunatikc not installed"; done
+	ktap_totals
+	exit 0
+fi
+
+compile() {
+	local name="$1" strip="$2"; shift 2
+	lunatikc $strip -o "$SRC/$name.lua" "$@"
+}
+
+compile hello_bc "" "$SRC/hello.lua" || fail "luac: compile hello"
+compile hello_s -s "$SRC/hello.lua" || fail "luac: compile hello -s"
+compile lib_bc -s "$SRC/lib.lua" || fail "luac: compile lib -s"
+compile err_bc "" "$SRC/err.lua" || fail "luac: compile err"
+compile err_s -s "$SRC/err.lua" || fail "luac: compile err -s"
+ktap_pass "luac: lunatikc compiles the test scripts"
+
+mark_dmesg
+run_script "$SCRIPT"
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -q "luac: hello from bytecode" || fail "luac: compiled chunk did not run"
+ktap_pass "luac: compiled chunk runs"
+
+mark_dmesg
+run_script "tests/luac/hello_s"
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -q "luac: hello from bytecode" || fail "luac: stripped chunk did not run"
+ktap_pass "luac: stripped chunk runs"
+
+mark_dmesg
+run_script "tests/luac/user"
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -q "luac: require of a compiled library" || fail "luac: require did not load the chunk"
+ktap_pass "luac: require() loads a compiled library"
+
+output=$(lunatik run tests/luac/err_bc)
+echo "$output" | grep -q "^$SRC/err.lua:8: attempt to index a nil value (local 't')" \
+	|| fail "luac: full chunk error: $output"
+ktap_pass "luac: error names the source path and line"
+
+output=$(lunatik run tests/luac/err_s)
+echo "$output" | grep -q "^?:?: attempt to index a nil value" || fail "luac: stripped chunk error: $output"
+ktap_pass "luac: stripped error has no source or line"
+
+lunatikc -l "$SRC/hello_bc.lua" | grep -q "^main <" || fail "luac: -l did not list the chunk"
+ktap_pass "luac: -l lists a compiled chunk"
+
+# a stock luac writes lua_Number as a double: patch the header probe (last 8 bytes of the
+# 4 size+value blocks) with the IEEE-754 image of -370.5
+cp "$SRC/hello_bc.lua" "$SRC/stock.lua"
+printf '\x00\x00\x00\x00\x00\x28\x77\xc0' | dd of="$SRC/stock.lua" bs=1 seek=32 conv=notrunc status=none
+output=$(lunatik run tests/luac/stock)
+echo "$output" | grep -q "Lua number format mismatch" || fail "luac: stock chunk accepted: $output"
+ktap_pass "luac: stock number format is rejected"
+
+mark_dmesg
+run_script "tests/luac/textmode"
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -q "luac: text-only load rejects bytecode" || fail "luac: textmode did not run"
+ktap_pass "luac: load() with mode t rejects a chunk"
+
+ktap_totals
+

--- a/tests/luac/textmode.lua
+++ b/tests/luac/textmode.lua
@@ -1,0 +1,15 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luac test (see run.sh): load() with mode "t" rejects a compiled chunk.
+
+local f = assert(io.open("/lib/modules/lua/tests/luac/hello_bc.lua", "rb"))
+local chunk = f:read("a")
+f:close()
+
+local fn, err = load(chunk, "=hello", "t")
+assert(fn == nil and err:find("binary chunk", 1, true), err)
+assert(load(chunk, "=hello", "b"))
+print("luac: text-only load rejects bytecode")
+

--- a/tests/luac/user.lua
+++ b/tests/luac/user.lua
@@ -1,0 +1,11 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luac test (see run.sh): a text script requiring a compiled library.
+
+local lib = require("tests.luac.lib_bc")
+
+assert(lib.answer() == 42)
+print("luac: require of a compiled library")
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -38,6 +38,7 @@ run_suite "$DIR/bpf/run.sh"
 run_suite "$DIR/xdp/run.sh"
 run_suite "$DIR/crypto/run.sh"
 run_suite "$DIR/io/test.sh"
+run_suite "$DIR/luac/run.sh"
 run_suite "$DIR/probe/run.sh"
 run_suite "$DIR/notifier/run.sh"
 


### PR DESCRIPTION
Adds `lunatikc`, the `luac` bytecode compiler built against the kernel configuration, plus the wiring to ship scripts as bytecode. Alternative to #742: instead of a new driver, this reuses the upstream `luac.c`, imported into the `lua/` submodule and fenced with `_KERNEL` like the rest of the patch (branch `claude_lunatikc` of luainkernel/lua).

The kernel already loads binary chunks everywhere (`lunatik_loadfile` runs with mode `"bt"`, `require` included); what was missing is a way to produce one. The distribution `luac` cannot: under `_KERNEL` the fork drops the float opcodes (renumbering everything after `OP_LOADI`), compiles `/` to integer division, and checks an integer `lua_Number` in the chunk header. Building `luac` itself with the host compiler from the same `lua/` sources and `_KERNEL` configuration makes its output match the kernel by construction, and brings the standard CLI (`-l` listing of kernel opcodes included) for free.

* `lunatik_conf: fence the kernel-only part of the configuration`: the number configuration and limits stay shared with the host build; the kernel-only material goes under `__KERNEL__`. No change for the kernel build.
* `lua: add luac, buildable against the kernel configuration`: submodule bump; `luac.c` imported verbatim from the 5.5.0 distribution, float constants and opcodes in the listing fenced under `_KERNEL`, stock file loading kept for the `LUNATIKC` (userspace compiler) build, and the one `-Wall` warning in `llex.c` fenced.
* `lunatikc: build luac against the kernel configuration`: built as part of `make`, installed next to `lunatik` as `lunatikc`. `BYTECODE=1 make install` ships the kernel Lua libraries and examples as stripped chunks under their usual `.lua` names (the loader detects the signature, so nothing changes on the kernel side); the full suite passes with source and with bytecode installs, `driver.lua` included.
* `runner: trim only a trailing .lua`: found by the new suite; `trim()` mangled any script path containing a name, one character and `lua` (`tests/luac/x` became `testsc/x`).
* `tests: add the luac suite`: compiled chunks run via `run` and `require`, full and stripped; error messages carry the source path and line, or `?:?:` when stripped (now recognized by the harness); `-l` lists a compiled chunk; a stock number format is rejected by the header; `load(..., "t")` refuses a chunk in the kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
