### PR TITLE
tc: forward an argument buffer to the Lua callback

### DIFF
--- a/examples/sniclassify/classify.c
+++ b/examples/sniclassify/classify.c
@@ -53,7 +53,8 @@ int classify(struct __sk_buff *skb)
 	if (payload > data_end)
 		goto pass;
 
-	int action = bpf_luatc_run(runtime, sizeof(runtime), skb, NULL, 0);
+	__u32 offset = payload - data;
+	int action = bpf_luatc_run(runtime, sizeof(runtime), skb, &offset, sizeof(offset));
 	if (action < 0)
 		return TC_ACT_OK;
 

--- a/examples/sniclassify/classify.c
+++ b/examples/sniclassify/classify.c
@@ -7,7 +7,8 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_endian.h>
 
-extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb) __ksym;
+extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb,
+		void *arg, size_t arg__sz) __ksym;
 
 static char runtime[] = "examples/sniclassify/sni";
 
@@ -52,7 +53,7 @@ int classify(struct __sk_buff *skb)
 	if (payload > data_end)
 		goto pass;
 
-	int action = bpf_luatc_run(runtime, sizeof(runtime), skb);
+	int action = bpf_luatc_run(runtime, sizeof(runtime), skb, NULL, 0);
 	if (action < 0)
 		return TC_ACT_OK;
 

--- a/examples/sniclassify/sni.lua
+++ b/examples/sniclassify/sni.lua
@@ -11,14 +11,6 @@ local skbattr = require("skb.attr")
 local set     = require("set")
 local sni     = require("examples.common.sni")
 
-local ETH_HLEN    <const> = 14
-local IPPROTO_TCP <const> = 6
-local HTTPS_PORT  <const> = 443
-local IP_PROTO    <const> = 9
-local IHL_MASK    <const> = 0x0f
-local TCP_DPORT   <const> = 2
-local TCP_DOFF    <const> = 12
-
 local function TC_H_MAKE(maj, min)
 	return (maj << 16) | min
 end
@@ -32,25 +24,12 @@ local function log(host, priority)
 	print(string.format("sniclassify: %s %s", host, priority))
 end
 
--- offset of the TCP payload in an IPv4/TCP:443 frame, or nil for anything else
-local function tcp_payload(packet)
-	local version_ihl = packet:getbyte(ETH_HLEN)
-	if version_ihl >> 4 ~= 4 or packet:getbyte(ETH_HLEN + IP_PROTO) ~= IPPROTO_TCP then
-		return
-	end
-	local tcp = ETH_HLEN + (version_ihl & IHL_MASK) * 4
-	if (packet:getbyte(tcp + TCP_DPORT) << 8 | packet:getbyte(tcp + TCP_DPORT + 1)) ~= HTTPS_PORT then
-		return
-	end
-	return tcp + (packet:getbyte(tcp + TCP_DOFF) >> 4) * 4
-end
-
 local function sniclassify(ctx)
 	local raw     = ctx:skb()
 	local skb     = skbattr.new(raw)
 	local packet  = raw:data()
-	local payload = tcp_payload(packet)
-	local host    = payload and sni(packet, payload)
+	local payload = ctx:argument():getuint32(0)
+	local host    = sni(packet, payload)
 
 	if host then
 		local classid = policy:match(host)

--- a/lib/luatc.c
+++ b/lib/luatc.c
@@ -35,8 +35,11 @@ LUNATIK_EBPF_START();
 
 typedef struct luatc_ctx_s {
 	struct __sk_buff *skb;
+	void             *arg;
+	size_t            arg__sz;
 	int              *action;
 	lunatik_object_t *skb_obj;
+	lunatik_object_t *argument;
 	int              cb;
 } luatc_ctx_t;
 
@@ -64,6 +67,18 @@ static int luatc_skb(lua_State *L)
 }
 
 /***
+* Returns the argument data buffer passed from eBPF.
+* @function tc_ctx:argument
+* @treturn data argument buffer
+*/
+static int luatc_argument(lua_State *L)
+{
+	luatc_ctx_t *ctx = luatc_ctx_check(L, 1);
+	lunatik_getregistry(L, ctx->argument);
+	return 1;
+}
+
+/***
 * Sets the TC verdict action for this packet.
 * @function tc_ctx:action
 * @tparam integer action TC action constant (e.g. `TC_ACT_OK`, `TC_ACT_SHOT`, ...)
@@ -78,6 +93,7 @@ static int luatc_action(lua_State *L)
 static const luaL_Reg luatc_mt[] = {
 	{"__gc", lunatik_deleteobject},
 	{"skb", luatc_skb},
+	{"argument", luatc_argument},
 	{"action", luatc_action},
 	{NULL, NULL}
 };
@@ -87,6 +103,8 @@ static void luatc_release(void *private)
 	luatc_ctx_t *lctx = (luatc_ctx_t *)private;
 	if (lctx->skb_obj)
 		luaskb_close(lctx->skb_obj);
+	if (lctx->argument)
+		luadata_close(lctx->argument);
 }
 
 LUNATIK_OPENER(tc);
@@ -101,6 +119,7 @@ static const lunatik_class_t luatc_class = {
 static inline void luatc_handler_cleanup(luatc_ctx_t *lctx)
 {
 	luaskb_clear(lctx->skb_obj);
+	luadata_clear(lctx->argument);
 	lctx->skb = NULL;
 	lctx->action = NULL;
 }
@@ -118,19 +137,24 @@ static int luatc_handler(lua_State *L, luatc_ctx_t *ctx)
 	luaskb_reset(lctx->skb_obj, skb);
 
 	lctx->skb     = ctx->skb;
+	lctx->arg     = ctx->arg;
+	lctx->arg__sz = ctx->arg__sz;
 	lctx->action  = ctx->action;
+	luadata_reset(lctx->argument, lctx->arg, lctx->arg__sz, LUADATA_OPT_KEEP);
 
 	ret = lunatik_ebpf_invoke(L, lctx->cb);
 	luatc_handler_cleanup(lctx);
 	return ret;
 }
 
-__bpf_kfunc int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb)
+__bpf_kfunc int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb, void *arg, size_t arg__sz)
 {
 	int action = -1;
 
 	luatc_ctx_t ctx = {
 		.skb     = skb,
+		.arg     = arg,
+		.arg__sz = arg__sz,
 		.action  = &action,
 	};
 
@@ -161,6 +185,7 @@ static int luatc_detach(lua_State *L)
 
 	lunatik_ebpf_unbind(L, &lctx->cb);
 	lunatik_ebpf_detach(L, lctx, skb_obj);
+	lunatik_ebpf_detach(L, lctx, argument);
 	return 0;
 }
 
@@ -171,12 +196,14 @@ static int luatc_detach(lua_State *L)
 * The runtime invoking this function must be non-sleepable.
 *
 * The `bpf_luatc_run` kfunc is called from an eBPF program with the following signature:
-* `int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *sk_buff)`
+* `int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *sk_buff, void *arg, size_t arg__sz)`
 *
 * - `key`: A string identifying the Lunatik runtime (e.g., the script name like "examples/sniclassify/sni").
 *   This key is used to look up the runtime in Lunatik's internal table of active runtimes.
 * - `key_sz`: Length of the key string (including the null terminator).
 * - `sk_buff`: The TC metadata context (`struct __sk_buff *`).
+* - `arg`: A pointer to arbitrary data passed from eBPF to Lua.
+* - `arg_sz`: The size of the `arg` data.
 *
 * @function attach
 * @tparam function callback Lua function to call. It receives one argument:
@@ -203,8 +230,9 @@ static int luatc_detach(lua_State *L)
 *
 *   -- In eBPF C code, to call the above Lua function:
 *   -- char rt_key[] = "my_tc_handler.lua"; // Key matches the script name
-*   -- int verdict = bpf_luatc_run(rt_key, sizeof(rt_key), skb);
+*   -- int verdict = bpf_luatc_run(rt_key, sizeof(rt_key), skb, NULL, 0);
 * @see skb
+* @see data
 * @within tc
 */
 static int luatc_attach(lua_State *L)
@@ -217,6 +245,7 @@ static int luatc_attach(lua_State *L)
 	luatc_ctx_t *ctx = (luatc_ctx_t *)object->private;
 
 	lunatik_ebpf_attach(L, ctx, skb_obj, luaskb_new);
+	lunatik_ebpf_attach(L, ctx, argument, luadata_new, LUNATIK_OPT_SINGLE);
 
 	lunatik_ebpf_bind(L, 1, &ctx->cb);
 	return 0;

--- a/tests/README.md
+++ b/tests/README.md
@@ -285,7 +285,8 @@ ARP never competes with ICMP for the verdict; skipped when the module lacks
 BTF, or `bpftool`, `clang` or `tc` is unavailable.
 
 - **tc pass**: the callback inspects `ctx:skb()` (IPv4 ethertype and the
-  ICMP protocol byte of the ping) and `action.ACT_OK` lets the packet reach
+  ICMP protocol byte of the ping) and `ctx:argument()` (a magic word the
+  eBPF program passed through), and `action.ACT_OK` lets the packet reach
   its destination; the runtime is plain, covering the plain-name kfunc lookup.
 
 - **tc drop**: `action.ACT_SHOT` blocks the ping; the runtime is percpu,

--- a/tests/tc/pass.lua
+++ b/tests/tc/pass.lua
@@ -8,6 +8,7 @@ local tc      = require("tc")
 local action  = require("linux.tc")
 local skbattr = require("skb.attr")
 
+local MAGIC    <const> = 0x4C554E41 -- matches tc_pass.bpf.c
 local ETH_HI   <const> = 12 -- ethertype, then IPv4 protocol
 local ETH_LO   <const> = 13
 local IPPROTO  <const> = 23
@@ -22,7 +23,11 @@ local function test_pass(ctx)
 	if data:getuint8(ETH_HI) == 0x08 and data:getuint8(ETH_LO) == 0x00
 			and data:getuint8(IPPROTO) == ICMP
 			and skb.priority == 0x1234 and skb.mark == 0xabcd then
-		print("tc pass test pass: packet content verified")
+		if ctx:argument():getuint32(0) == MAGIC then
+			print("tc pass test pass: packet and argument content verified")
+		else
+			print("tc pass test fail: argument does not carry the magic")
+		end
 	else
 		print("tc pass test fail: packet content mismatch")
 	end

--- a/tests/tc/tc_detach.bpf.c
+++ b/tests/tc/tc_detach.bpf.c
@@ -6,7 +6,8 @@
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 
-extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb) __ksym;
+extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb,
+		void *arg, size_t arg__sz) __ksym;
 
 static char runtime[] = "tests/tc/detach";
 
@@ -16,7 +17,7 @@ SEC("classifier")
 int test_tc_detach(struct __sk_buff *skb)
 {
 	int ret;
-	ret = bpf_luatc_run(runtime, sizeof(runtime), skb);
+	ret = bpf_luatc_run(runtime, sizeof(runtime), skb, NULL, 0);
 	return ret < 0 ? TC_ACT_OK : ret;
 }
 

--- a/tests/tc/tc_drop.bpf.c
+++ b/tests/tc/tc_drop.bpf.c
@@ -6,7 +6,8 @@
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 
-extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb) __ksym;
+extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb,
+		void *arg, size_t arg__sz) __ksym;
 
 static char runtime[] = "tests/tc/drop";
 
@@ -16,7 +17,7 @@ SEC("classifier")
 int test_tc_drop(struct __sk_buff *skb)
 {
 	int ret;
-	ret = bpf_luatc_run(runtime, sizeof(runtime), skb);
+	ret = bpf_luatc_run(runtime, sizeof(runtime), skb, NULL, 0);
 	return ret < 0 ? TC_ACT_OK : ret;
 }
 

--- a/tests/tc/tc_pass.bpf.c
+++ b/tests/tc/tc_pass.bpf.c
@@ -6,7 +6,8 @@
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 
-extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb) __ksym;
+extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb,
+		void *arg, size_t arg__sz) __ksym;
 
 static char runtime[] = "tests/tc/pass";
 
@@ -15,8 +16,9 @@ int const TC_ACT_OK = 0;
 SEC("classifier")
 int test_tc_pass(struct __sk_buff *skb)
 {
+	__u32 magic = 0x4C554E41; /* "LUNA", asserted by pass.lua */
 	int ret;
-	ret = bpf_luatc_run(runtime, sizeof(runtime), skb);
+	ret = bpf_luatc_run(runtime, sizeof(runtime), skb, &magic, sizeof(magic));
 	return ret < 0 ? TC_ACT_OK : ret;
 }
 

--- a/tests/tc/tc_reattach.bpf.c
+++ b/tests/tc/tc_reattach.bpf.c
@@ -6,7 +6,8 @@
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 
-extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb) __ksym;
+extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb,
+		void *arg, size_t arg__sz) __ksym;
 
 static char runtime[] = "tests/tc/reattach";
 
@@ -16,7 +17,7 @@ SEC("classifier")
 int test_tc_reattach(struct __sk_buff *skb)
 {
 	int ret;
-	ret = bpf_luatc_run(runtime, sizeof(runtime), skb);
+	ret = bpf_luatc_run(runtime, sizeof(runtime), skb, NULL, 0);
 	return ret < 0 ? TC_ACT_OK : ret;
 }
 

--- a/tests/tc/tc_zerokey.bpf.c
+++ b/tests/tc/tc_zerokey.bpf.c
@@ -6,7 +6,8 @@
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 
-extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb) __ksym;
+extern int bpf_luatc_run(char *key, size_t key__sz, struct __sk_buff *skb,
+		void *arg, size_t arg__sz) __ksym;
 
 static char runtime[] = "tests/tc/zerokey";
 
@@ -18,7 +19,7 @@ int test_tc_zerokey(struct __sk_buff *skb)
 {
 	/* drop on rejection, so a working guard blocks the ping and proves the kfunc ran */
 	int ret;
-	ret = bpf_luatc_run(runtime, 0, skb);
+	ret = bpf_luatc_run(runtime, 0, skb, NULL, 0);
 	return ret < 0 ? TC_ACT_SHOT : TC_ACT_OK;
 }
 

--- a/tests/tc/test_tc.sh
+++ b/tests/tc/test_tc.sh
@@ -163,7 +163,7 @@ zerokey_case()
 }
 
 run_case tc_pass.bpf.o pass.lua yes "tc pass" \
-	"tc pass test pass: packet content verified" softirq
+	"tc pass test pass: packet and argument content verified" softirq
 run_case tc_drop.bpf.o drop.lua no "tc drop" \
 	"tc drop test pass: verdict set to drop" softirq percpu
 run_case tc_reattach.bpf.o reattach.lua yes "tc reattach" \


### PR DESCRIPTION
`bpf_luatc_run` now takes an `(arg, arg_sz)` pair, exposed to the Lua callback as `tc_ctx:argument()` (a `data` buffer) — mirroring the existing `xdp` mechanism.

**1. The channel** (`lib/luatc.c`): the argument object lifecycle (attach/detach/release/reset), the `tc_ctx:argument()` accessor, and the extended kfunc signature. The tc suite's `pass` case now writes a magic word from eBPF and reads it back through `ctx:argument()`.

**2. A real consumer** (`examples/sniclassify`): `classify.c` already computed the TCP payload offset and discarded it (it passed `NULL, 0`); `sni.lua`'s `tcp_payload` re-derived the identical value. Now `classify` hands the offset through the argument and `sni.lua` reads `ctx:argument():getuint32(0)`, dropping the re-parse — a function and seven constants gone. This is the redundancy the feature exists to remove, in the example that motivated it.

## Test
- `sudo lunatik test tc` → 6/6 (pass verifies the argument round-trip); `sudo lunatik test xdp` → 5/5.
- End-to-end (veth + a real TLS ClientHello): `SNI=netflix.com` is classified (`sniclassify: netflix.com 65584`); `SNI=example.com`, not in the policy, is not — so `sni.lua` reads the SNI at the handed-over offset, not a fixed path.
