### PR TITLE
ebpf: clearer log when a resolved runtime has no callback attached

### DIFF
--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -58,7 +58,7 @@ static inline void *lunatik_ebpf_getctx(lua_State *L)
 	lunatik_object_t *obj;
 	if (lunatik_getregistry(L, &lunatik_ebpf_env_key) != LUA_TUSERDATA) {
 		lua_pop(L, 1);
-		pr_err_ratelimited("couldn't find the context object\n");
+		pr_err_ratelimited("no callback attached (cpu %d)\n", lunatik_getcpu(L));
 		return NULL;
 	}
 	obj = (lunatik_object_t *)lunatik_toobject(L, -1);


### PR DESCRIPTION
The kfuncs (`bpf_luatc_run`/`bpf_luaxdp_run`) logged a bare `couldn't find the context object` when the runtime they resolved to had no callback attached. It read like an internal error. This names the condition and the cpu instead:

```
no callback attached (cpu %d)
```

A plain runtime reports `cpu -1`; a percpu instance reports its cpu. Log clarity only — the code path is unchanged. Not a behaviour or cleanup change.

## Test plan
- Triggered the path deterministically (a runtime that loads `tc` but never attaches, plus a probe calling the kfunc on it): the new message fires with the cpu.
- `sudo lunatik test tc` → 6/6, `sudo lunatik test xdp` → 5/5.