### PR TITLE
docs: a log message is one terse line, not a sentence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,10 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
   says what `cpu >= 0` only implies, and ties the definition, the default and every test of it.
 * For every raise after acquiring a resource, know what is already held and who releases it; validate
   before acquiring whenever the check does not need the resource.
+* A log or error message is one terse line naming the condition, in the tree's voice — `couldn't find
+  X`, lowercase, no trailing period — not a sentence spelling out the cause and its caveats. The
+  reasoning behind a failure belongs in a code comment or the commit message, not the runtime log; a
+  `pr_err` that reads as a paragraph is the smell.
 
 ## Lua style
 


### PR DESCRIPTION
A `pr_err`/`pr_info` names the condition in the tree's voice — lowercase, no trailing period, like the existing `couldn't find _ENV.runtimes or _ENV.percpu` — not a sentence spelling out the cause and its caveats. The reasoning behind a failure belongs in a code comment or the commit message, not the runtime log.

From this session: a kfunc error message was introduced as a full sentence (`no eBPF callback on the resolved runtime (cpu %d): it was not attached, or a stale runtime shadowed the attached one`) and had to be cut down to `no callback attached (cpu %d)`. This records the convention so it is not relearned.
