### PR TITLE
docs: review your own change against the conventions before showing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,6 +352,22 @@ old factory — kept building and broke at the first packet.
 * Copyright years: a new file carries the current year; a modified file extends its range to include
   it.
 
+## Reviewing your own change
+
+The conventions in this document are a checklist to run against your own diff before showing it, not
+reference to reach for after a reviewer objects. Code shown without that pass makes the reader the
+reviewer, and the deviations they then find — a prefix nothing else in the file uses, a comment on a
+body the file leaves bare, a handle closed by hand where the file uses `<close>` — were already rules
+here. The failure is not the missing rule; it is not running the ones that exist.
+
+Before presenting a change to an existing file, read the file as the authority and measure the
+addition against it — naming, comment density, idioms, resource handling, duplication — then prove
+the behaviour on the operation in isolation, not a round trip that hides a partial result: `unload`
+reaching zero, not `reload` returning to a full set. The pass covers the prose the change ships with,
+too: after any rewrite or force-push, re-read the commit message and the pull request body against
+the final code, as *Patches and commits* requires — a description of a version the branch no longer
+contains is the same failure as unreviewed code. A change shown without that pass is not done.
+
 ## Before opening a pull request
 
 1. `make` is clean, with no new warnings;


### PR DESCRIPTION
Adds a short `## Reviewing your own change` section between *Patches and commits* and *Before opening a pull request*.

The conventions in this document are a checklist to run against your own diff before presenting it, not reference to cite once a reviewer objects. Skipping that pass makes the reader the reviewer — they find the prefix nothing else in the file uses, the comment on a bare-bodied helper, the handle closed by hand where the file uses `<close>`, the duplication a helper removes — every one of which is already a rule here.

The section **references** the existing conventions (naming, comment density, idioms, DRY, test-discrimination) rather than restating them — per this document's own *"enumerate in one place only"* — and adds the one thing missing: running them, plus proving behaviour on the operation in isolation (`unload`→0) rather than a round trip that masks a partial result (`reload`→full set).

The pass also covers the prose the change ships with: after a rewrite or force-push, the commit message and PR body are re-read against the final code (referencing *Patches and commits*), so a description of a version the branch no longer contains is caught by the same pass rather than by the reviewer.
