### PR TITLE
docs: verify runtime kernel interfaces across the supported range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,12 @@ Lunatik runs Lua inside the Linux kernel. A mistake here does not raise an excep
 machine. Two rules follow from that and outrank everything else in this document:
 
 1. **Verify, do not assume.** Before using a kernel API, read its declaration in
-   `/usr/src/linux-headers-$(uname -r)/include` and confirm it is exported in `Module.symvers`.
-   Signatures change between releases. If you have not checked, say so instead of asserting.
+   `/usr/src/linux-headers-$(uname -r)/include` and confirm it is exported in `Module.symvers`. A
+   kernel interface read at runtime rather than linked — a `/sys` or `/proc` path and the format it
+   returns, the `/dev/lunatik` protocol — is held to the same rule: confirm it against the source
+   across the supported kernel range (5.15 and later), not from the one kernel you happen to run.
+   Signatures and formats change between releases. If you have not checked, say so instead of
+   asserting.
 2. **Know your execution context.** Code that may sleep must not run from softirq or hardirq context.
    See "Execution contexts" below.
 


### PR DESCRIPTION
Extends rule 1 (*Verify, do not assume*) to cover kernel interfaces read at runtime, not just linked C APIs.

Rule 1's mechanism — read the declaration in the headers, confirm it in `Module.symvers` — only reaches a linked C API. A `/sys` or `/proc` path, or the `/dev/lunatik` protocol, is just as much a kernel dependency but falls through that check, so it can be switched or relied on from whatever kernel happens to be on the dev box without confirming it holds across the supported range.

That is a real gap: `bin/lunatik`'s unload moved from parsing `/proc/modules` to reading `/sys/module/<m>/holders` and `refcnt`, and the new dependency went unverified against 5.15–6.12 until asked. The addition holds runtime interfaces to the same rule — confirm against the source across the supported kernel range, not from the one kernel you run.
