### PR TITLE
docs: check the prose through the review pass, not by asserting it matches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,9 +368,11 @@ Before presenting a change to an existing file, read the file as the authority a
 addition against it — naming, comment density, idioms, resource handling, duplication — then prove
 the behaviour on the operation in isolation, not a round trip that hides a partial result: `unload`
 reaching zero, not `reload` returning to a full set. The pass covers the prose the change ships with,
-too: after any rewrite or force-push, re-read the commit message and the pull request body against
-the final code, as *Patches and commits* requires — a description of a version the branch no longer
-contains is the same failure as unreviewed code. A change shown without that pass is not done.
+too: after any rewrite or force-push, the commit message and the pull request body go through the
+same review against the final code — a claim the code does not support, a mechanism the branch
+dropped or a rationale its call sites contradict, is caught there, as *Patches and commits* requires.
+Saying the prose matches is not the check; showing the claim-to-code mapping is. A change shown
+without that pass is not done.
 
 ## Before opening a pull request
 


### PR DESCRIPTION
Sharpens the `Reviewing your own change` gate: the prose check — commit message and PR body against the final code — is done by the same review pass that emits findings, not by a hand re-read that can be reported done without being run.

**Why.** A self-enforced rule to "re-read the prose" is fakeable by self-report — the exact failure it exists to prevent. On #736 the PR body was asserted to match the code but carried an overgeneralized claim: it called `skb_vlan_tag_get_id(skb)` a NULL-deref alongside the two real ones, when the `skb` is guaranteed non-NULL (`luaskb_check`), so evaluating it unguarded is a safe, meaningless read, not a crash. Nothing in the gate caught it; the reviewer asking "did you re-verify?" did.

**Verified, not asserted.** Routing that same commit message and PR body through the adversarial review that checks the code was tried against the flawed text: it caught the `skb_vlan_tag_get_id` claim with `include/linux/if_vlan.h` evidence, and passed the accurate commit message with no false positive. So the rule now ties the prose to the artifact — it goes through that review, and *saying* the prose matches is not the check; *showing* the claim-to-code mapping is.
