### PR TITLE
tests/tc: skip all six cases when skipping, not five

### DIFF
--- a/tests/tc/test_tc.sh
+++ b/tests/tc/test_tc.sh
@@ -45,6 +45,7 @@ skip_all()
 	echo "# SKIP: $1"
 	ktap_skip "tc pass: verdict enforced, packet and argument content verified"
 	ktap_skip "tc drop: verdict enforced correctly"
+	ktap_skip "tc reattach: re-attach installs the last callback"
 	ktap_skip "tc detach: callback stops firing and traffic resumes"
 	ktap_skip "tc attach: refuses a sleepable runtime"
 	ktap_skip "tc zero-key: a zero-sized key is rejected without a crash"


### PR DESCRIPTION
`skip_all` in `tests/tc/test_tc.sh` emitted five `ktap_skip` while `ktap_plan` declares six — it omitted the `reattach` case. So on a config-skip (luatc not loaded, no BTF, no bpftool) KTAP saw six planned results but only five reported, one short of the plan; a real run reports six.

Adds the missing `tc reattach` skip, in run order.

**Verified:** with luatc unloaded, `bash tests/tc/test_tc.sh` now emits `1..6` and six SKIP lines (`# Totals: ... skip:6`), matching the plan.
