### PR TITLE
luathread: return a task object from task()

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -82,6 +82,7 @@ config LUNATIK_TASK
 config LUNATIK_THREAD
 	tristate "Lunatik Thread Support"
 	default m
+	select LUNATIK_TASK
 	help
 	  Kernel thread management from Lua.
 

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -13,6 +13,8 @@
 
 #include <lunatik.h>
 
+#include "luatask.h"
+
 /***
 * Represents a kernel thread object.
 * @type thread
@@ -113,35 +115,21 @@ static int luathread_stop(lua_State *L)
 }
 
 /***
-* Retrieves information about the kernel task associated with the thread.
+* Returns a task object for the kernel task associated with the thread.
+* Once the thread has exited the object has no task and its methods raise.
 * @function task
 * @tparam thread self thread object.
-* @treturn table A table with fields: `cpu` (SMP only), `command`, `pid`, `tgid`.
+* @treturn task
 * @usage
-* local info = my_thread:task()
+* local t = my_thread:task()
+* print(t:pid(), t:comm())
 */
 static int luathread_task(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_toobject(L, 1);
 	luathread_t *thread = (luathread_t *)object->private;
-	struct task_struct *task = thread->task;
 
-	lua_createtable(L, 0, 4);
-	int table = lua_gettop(L);
-
-#ifdef CONFIG_SMP
-	lua_pushinteger(L, task->on_cpu);
-	lua_setfield(L, table, "cpu");
-#endif
-
-	lua_pushstring(L, task->comm);
-	lua_setfield(L, table, "command");
-
-	lua_pushinteger(L, task->pid);
-	lua_setfield(L, table, "pid");
-
-	lua_pushinteger(L, task->tgid);
-	lua_setfield(L, table, "tgid");
+	luatask_new(L, thread->task);
 	return 1;
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -338,6 +338,12 @@ Regression tests for `luathread`.
 - **run_during_load**: `runner.spawn()` called from a script's top-level
   code must error instead of hanging the kernel.
 
+- **task**: `thread:task()` returns a `task` object: a usable one for
+  `thread.current()` (`pid`, `comm`, `tgid`); for a spawned thread, reached
+  through `lunatik._ENV.threads`, one reporting that thread (its `comm` is the
+  thread name, its `pid` is not the caller's); for a thread whose body has
+  returned, one whose methods raise instead of dereferencing the gone task.
+
 ### xdp
 
 Regression tests for `luaxdp`. The suite builds real XDP programs that call

--- a/tests/thread/exit.lua
+++ b/tests/thread/exit.lua
@@ -1,0 +1,9 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel thread body that returns at once, so the thread exits on its own (see task.sh).
+--
+
+return function() end
+

--- a/tests/thread/run.sh
+++ b/tests/thread/run.sh
@@ -11,7 +11,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
 SEP=""
-for t in "$DIR"/shouldstop.sh "$DIR"/run_during_load.sh "$DIR"/foreign_object.sh; do
+for t in "$DIR"/shouldstop.sh "$DIR"/run_during_load.sh "$DIR"/foreign_object.sh "$DIR"/task.sh; do
 	echo "${SEP}# --- $(basename "$t") ---"
 	SEP=$'\n'
 	bash "$t" || FAILED=$((FAILED+1))

--- a/tests/thread/task.lua
+++ b/tests/thread/task.lua
@@ -1,0 +1,14 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luathread:task() test (see task.sh).
+--
+
+local thread = require("thread")
+
+local t = thread.current():task()
+assert(t:pid() > 0, "current():task():pid() should be positive")
+assert(type(t:comm()) == "string", "current():task():comm() should be a string")
+assert(t:pid() == t:tgid(), "current is single-threaded: pid should equal tgid")
+

--- a/tests/thread/task.sh
+++ b/tests/thread/task.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Tests luathread:task(), which returns a task object for the thread's kernel task.
+#
+# Case 1 (current): thread.current():task() is a usable task object (pid, comm, tgid).
+# Case 2 (running): the object of a spawned thread, reached through lunatik._ENV.threads,
+#   reports that thread: its comm is the thread name and its pid is not the caller's.
+# Case 3 (exited): once the thread body has returned, thread->task is NULL and the
+#   methods of the returned object raise instead of dereferencing it.
+#
+# Usage: sudo bash tests/thread/task.sh
+
+SCRIPT_CURRENT="tests/thread/task"
+SCRIPT_SPAWNED="tests/thread/task_spawned"
+SCRIPT_EXITED="tests/thread/task_exited"
+DUMMY="tests/thread/dummy"
+EXIT="tests/thread/exit"
+SLEEP=1
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() {
+	lunatik stop "$SCRIPT_CURRENT" 2>/dev/null
+	lunatik stop "$SCRIPT_SPAWNED" 2>/dev/null
+	lunatik stop "$SCRIPT_EXITED"  2>/dev/null
+	lunatik stop "$DUMMY"          2>/dev/null
+	lunatik stop "$EXIT"           2>/dev/null
+}
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 3
+
+# Case 1: the current task
+mark_dmesg
+run_script "$SCRIPT_CURRENT"
+check_dmesg || { ktap_totals; exit 1; }
+ktap_pass "thread.current():task() returns a usable task object"
+
+# Case 2: a running thread
+mark_dmesg
+output=$(lunatik spawn "$DUMMY" 2>&1)
+[ -n "$output" ] && fail "spawn failed: $output"
+run_script "$SCRIPT_SPAWNED"
+check_dmesg || { ktap_totals; exit 1; }
+ktap_pass "task() of a running thread reports that thread"
+
+# Case 3: a thread whose body has returned
+mark_dmesg
+output=$(lunatik spawn "$EXIT" 2>&1)
+[ -n "$output" ] && fail "spawn failed: $output"
+sleep $SLEEP
+run_script "$SCRIPT_EXITED"
+check_dmesg || { ktap_totals; exit 1; }
+ktap_pass "task() of an exited thread raises on use"
+
+ktap_totals
+

--- a/tests/thread/task_exited.lua
+++ b/tests/thread/task_exited.lua
@@ -1,0 +1,16 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luathread:task() test, exited thread case (see task.sh).
+--
+
+local lunatik = require("lunatik")
+
+local SCRIPT <const> = "tests/thread/exit"
+
+local t = lunatik._ENV.threads[SCRIPT]:task()
+local ok, err = pcall(t.pid, t)
+assert(not ok, "task():pid() of an exited thread should raise")
+assert(err:match("null pointer dereference"), "task():pid() of an exited thread raised something else: " .. err)
+

--- a/tests/thread/task_spawned.lua
+++ b/tests/thread/task_spawned.lua
@@ -1,0 +1,18 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the luathread:task() test, running thread case (see task.sh).
+--
+
+local thread  = require("thread")
+local lunatik = require("lunatik")
+
+local SCRIPT <const> = "tests/thread/dummy"
+local NAME <const> = "thread/dummy"
+
+local t = lunatik._ENV.threads[SCRIPT]:task()
+assert(t:comm() == NAME, "task():comm() should be the spawned thread's name")
+assert(t:pid() ~= thread.current():task():pid(), "task():pid() should not be the caller's pid")
+assert(t:pid() == t:tgid(), "a kernel thread leads its own group: pid should equal tgid")
+


### PR DESCRIPTION
`thread:task()` built an ad-hoc table `{cpu, command, pid, tgid}`, duplicating what the `task` module exposes. It now returns a `task` object, so task introspection lives in one place and `thread:task()` gains `:prio()` and the rest for free.

It also drops a latent NULL dereference: the old code read `thread->task->comm` and friends without checking `thread->task`, which is NULL once the thread has exited. `luatask_new(NULL)` yields an object whose methods raise instead. And the old `cpu` field read `task->on_cpu`, the running flag, not a CPU index; `task:cpu()` reads `task_cpu()`.

No table consumers exist in the tree, so nothing else changes. The thread suite covers the current task, a running spawned thread (reached through `lunatik._ENV.threads`) and an exited one.

