### PR TITLE
ebpf: factor ctx registry getters into a macro

### DIFF
--- a/lib/luatc.c
+++ b/lib/luatc.c
@@ -59,24 +59,14 @@ LUNATIK_PRIVATECHECKER(luatc_ctx_check, luatc_ctx_t *,
 * @function tc_ctx:skb
 * @treturn skb
 */
-static int luatc_skb(lua_State *L)
-{
-	luatc_ctx_t *ctx = luatc_ctx_check(L, 1);
-	lunatik_getregistry(L, ctx->skb_obj);
-	return 1;
-}
+LUNATIK_EBPF_GETTER(luatc_skb, luatc_ctx_check, skb_obj)
 
 /***
 * Returns the argument data buffer passed from eBPF.
 * @function tc_ctx:argument
 * @treturn data argument buffer
 */
-static int luatc_argument(lua_State *L)
-{
-	luatc_ctx_t *ctx = luatc_ctx_check(L, 1);
-	lunatik_getregistry(L, ctx->argument);
-	return 1;
-}
+LUNATIK_EBPF_GETTER(luatc_argument, luatc_ctx_check, argument)
 
 /***
 * Sets the TC verdict action for this packet.

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -57,24 +57,14 @@ LUNATIK_PRIVATECHECKER(luaxdp_ctx_check, luaxdp_ctx_t *,
 * @function xdp_ctx:packet
 * @treturn data packet buffer
 */
-static int luaxdp_packet(lua_State *L)
-{
-	luaxdp_ctx_t *ctx = luaxdp_ctx_check(L, 1);
-	lunatik_getregistry(L, ctx->packet);
-	return 1;
-}
+LUNATIK_EBPF_GETTER(luaxdp_packet, luaxdp_ctx_check, packet)
 
 /***
 * Returns the argument data buffer passed from eBPF.
 * @function xdp_ctx:argument
 * @treturn data argument buffer
 */
-static int luaxdp_argument(lua_State *L)
-{
-	luaxdp_ctx_t *ctx = luaxdp_ctx_check(L, 1);
-	lunatik_getregistry(L, ctx->argument);
-	return 1;
-}
+LUNATIK_EBPF_GETTER(luaxdp_argument, luaxdp_ctx_check, argument)
 
 /***
 * Sets the XDP verdict action for this packet.

--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -87,6 +87,13 @@ do {								\
 
 #define lunatik_ebpf_detach(L, obj, field)	lunatik_unregister((L), obj->field)
 
+#define LUNATIK_EBPF_GETTER(name, checker, field)	\
+static int name(lua_State *L)				\
+{							\
+	lunatik_getregistry(L, checker(L, 1)->field);	\
+	return 1;					\
+}
+
 static inline void lunatik_ebpf_bind(lua_State *L, int ix, int *cb)
 {
 	lua_pushvalue(L, ix);


### PR DESCRIPTION
The tc and xdp eBPF contexts each expose their registered objects through
identical accessors: check the ctx userdata, `lunatik_getregistry` the
field, return it. That is four copies (tc `skb`/`argument`, xdp
`packet`/`argument`).

`LUNATIK_EBPF_GETTER(name, checker, field)` generates one, alongside the
existing `lunatik_ebpf_attach`/`detach` ctx-object macros.

Stacked on #744, which adds the tc `argument` getter, so this unifies all
four at once; it rebases onto master when #744 merges.

**Test plan:** `tests/tc` 6/6 and `tests/xdp` 5/5 green on 6.8.0-136; the
macro-generated getters return skb/packet/argument correctly end-to-end.
