### PR TITLE
tools/checks: guard gh review posts in the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,13 @@ Install the commit gate with:
 
     ln -s ../../tools/checks/pre-commit .git/hooks/pre-commit
 
+Two guards read the tool command on stdin instead of a file, for an assistant wired to run them
+before a shell call (`PreToolUse`): `check-review-comment.sh` rejects a fixup reference given as a
+backtick'd SHA, which renders as code and does not link, and `review-post-guard.sh` blocks a `gh`
+write to reviews or comments unless the command carries the `REVIEW_POST_OK` marker, set once the
+exact text has been shown to the maintainer and approved. The marker forces the show-then-post
+step; it cannot check that the text was shown, only that it was set on purpose.
+
 ### Skills
 
 `.agents/skills/` packages the recurring workflows — the build/test cycle, a new binding, a new

--- a/tools/checks/check-review-comment.sh
+++ b/tools/checks/check-review-comment.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PreToolUse (Bash) hook: guard GitHub review/comment posts against a fixup
+# reference given as a backtick'd SHA instead of a full commit URL. A backtick'd
+# SHA renders as code on GitHub and does not link. Blocks (exit 2) only that
+# specific, mechanical mistake; silent (exit 0) on everything else.
+# Matches on the raw hook input: the command string is embedded in it verbatim
+# (JSON escaping does not touch backticks or hex).
+
+input=$(cat)
+
+case "$input" in
+	*"gh api"*reviews* | *"gh api"*comments*) ;;
+	*) exit 0 ;;
+esac
+
+if printf '%s' "$input" | grep -Eq '`[0-9a-f]{7,40}'; then
+	echo "check-review-comment: a fixup reference is a backtick'd SHA — GitHub renders it as code, not a link. Use a full commit URL instead: https://github.com/<owner>/<repo>/commit/<sha>" >&2
+	exit 2
+fi
+exit 0
+
+

--- a/tools/checks/review-post-guard.sh
+++ b/tools/checks/review-post-guard.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# PreToolUse (Bash) hook: a GitHub review, a review body, or a PR comment is
+# posted only after its exact text was shown to the maintainer and approved.
+# This blocks (exit 2) a gh write to reviews/comments unless the command carries
+# the REVIEW_POST_OK marker, set by hand once the text has an OK; silent (exit 0)
+# on everything else. It forces the show-then-post step; it cannot check that the
+# text was shown, only that the marker was set on purpose.
+# Matches the raw hook input, which embeds the command verbatim.
+
+input=$(cat)
+
+case "$input" in
+	*"gh api"*reviews*|*"gh api"*comments*|*"gh pr review"*|*"gh pr comment"*) ;;
+	*) exit 0 ;;
+esac
+
+# a read carries no body, field, or method flag; only a write is guarded
+case "$input" in
+	*"-X POST"*|*"-X PATCH"*|*"-X PUT"*|*"--method"*|*"-f "*|*"-F "*|*"--field"*|*"--raw-field"*|*"--input"*|*"gh pr review"*|*"gh pr comment"*) ;;
+	*) exit 0 ;;
+esac
+
+case "$input" in
+	*REVIEW_POST_OK=1*) exit 0 ;;
+esac
+
+echo "review-post-guard: show the exact text, get the maintainer's OK, then re-run with REVIEW_POST_OK=1 as a command prefix." >&2
+exit 2
+


### PR DESCRIPTION
The reviewing conventions say a review or comment is shown to the maintainer and approved before it is posted. This adds a mechanical guard for that step.

`tools/checks/review-post-guard.sh` is a PreToolUse command guard: it blocks a `gh` write to reviews or comments unless the command carries the `REVIEW_POST_OK` marker, set by hand once the exact text has an OK. It forces the show-then-post step. It cannot check that the text was shown, only that the marker was set on purpose, so it breaks the reflex post, not the intent.

Documented in the Checks section. Wiring it as a `PreToolUse` hook is machine-local, like the edit-time checks.
