### PR TITLE
lunatik: share the close body between the Lua stop and lunatik_stop

### DIFF
--- a/lunatik.h
+++ b/lunatik.h
@@ -239,6 +239,7 @@ lunatik_object_t *lunatik_newobject(lua_State *L, const lunatik_class_t *class, 
 lunatik_object_t *lunatik_createobject(const lunatik_class_t *class, size_t size, lunatik_opt_t opt);
 void lunatik_cloneobject(lua_State *L, lunatik_object_t *object);
 void lunatik_releaseobject(struct kref *kref);
+void lunatik_closeprivate(lunatik_object_t *object);
 int lunatik_closeobject(lua_State *L);
 int lunatik_deleteobject(lua_State *L);
 void lunatik_monitorobject(lua_State *L, const lunatik_class_t *class);

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -82,14 +82,7 @@ static void lunatik_releaseruntime(void *private)
 
 int lunatik_stop(lunatik_object_t *runtime)
 {
-	void *private;
-
-	lunatik_lock(runtime);
-	private = runtime->private;
-	runtime->private = NULL;
-	lunatik_unlock(runtime);
-
-	lunatik_releaseruntime(private);
+	lunatik_closeprivate(runtime);
 	return lunatik_putobject(runtime);
 }
 EXPORT_SYMBOL(lunatik_stop);

--- a/lunatik_obj.c
+++ b/lunatik_obj.c
@@ -77,9 +77,8 @@ static inline void lunatik_releaseprivate(const lunatik_class_t *class, void *pr
 		lunatik_free(private);
 }
 
-int lunatik_closeobject(lua_State *L)
+void lunatik_closeprivate(lunatik_object_t *object)
 {
-	lunatik_object_t *object = lunatik_checkobject(L, 1);
 	void *private;
 
 	lunatik_lock(object);
@@ -89,6 +88,12 @@ int lunatik_closeobject(lua_State *L)
 
 	if (private != NULL)
 		lunatik_releaseprivate(object->class, private);
+}
+EXPORT_SYMBOL(lunatik_closeprivate);
+
+int lunatik_closeobject(lua_State *L)
+{
+	lunatik_closeprivate(lunatik_checkobject(L, 1));
 	return 0;
 }
 EXPORT_SYMBOL(lunatik_closeobject);


### PR DESCRIPTION
Split out of #762, stacked on #764.

`lunatik_stop` repeated the body of `lunatik_closeobject`, detaching the private under the lock and releasing it outside, minus the guard on a private already detached. The body moves to `lunatik_closeprivate`, so a C caller closes an object the way the Lua `stop` does, and `lunatik_stop` is that plus the reference drop. The percpu object (#762) is the second C caller: its `stop` closes each instance's state without dropping the reference, since the instances stay in place until the object's last reference.

Tested on 6.8.0-136 (aarch64): runtime 17/17, clean dmesg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
