### PR TITLE
ebpf: dispatch only to interrupt-context runtimes

### DIFF
--- a/lunatik_ebpf.h
+++ b/lunatik_ebpf.h
@@ -50,7 +50,12 @@ static inline lunatik_object_t *lunatik_ebpf_lookupruntime(char *key, size_t key
 		size_t cpulen = scnprintf(cpu_key, sizeof(cpu_key), "%s:%d", key, cpuid);
 		runtime = luarcu_getobject(lunatik_ebpf_percpu, cpu_key, cpulen);
 	}
-	return runtime;
+	if (runtime == NULL || likely(lunatik_isirq(runtime->opt)))
+		return runtime;
+
+	pr_err_ratelimited("'%s' is a process-context runtime, not dispatched\n", key);
+	lunatik_putobject(runtime);
+	return NULL;
 }
 
 static inline void *lunatik_ebpf_getctx(lua_State *L)

--- a/tests/README.md
+++ b/tests/README.md
@@ -373,6 +373,10 @@ BTF, or `bpftool` or `clang` is unavailable.
   drops on rejection, so a working guard blocks the ping, proving the
   kfunc ran and returned without crashing.
 
+- **xdp process**: a process-context runtime registered under the key of an
+  eBPF program is refused by the kfunc, which logs it and leaves the verdict
+  to the program, instead of taking the runtime's mutex in softirq.
+
 - **xdp percpu**: with the ping pinned to the last online CPU, which is where
   the veth runs the receive softirq, the callback of a percpu script reports
   that CPU as its instance id, and no other; skipped on a single CPU.

--- a/tests/xdp/Makefile
+++ b/tests/xdp/Makefile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: (c) 2026 Ashwani Kumar Kamal <ashwanikamal.im421@gmail.com>
 # SPDX-License-Identifier: MIT OR GPL-2.0-only
 
-all: xdp_pass.bpf.o xdp_drop.bpf.o xdp_detach.bpf.o xdp_zerokey.bpf.o xdp_percpu.bpf.o
+all: xdp_pass.bpf.o xdp_drop.bpf.o xdp_detach.bpf.o xdp_zerokey.bpf.o xdp_process.bpf.o xdp_percpu.bpf.o
 
 vmlinux.h:
 	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $@
@@ -18,9 +18,12 @@ xdp_detach.bpf.o: xdp_detach.bpf.c vmlinux.h
 xdp_zerokey.bpf.o: xdp_zerokey.bpf.c vmlinux.h
 	clang -target bpf -Wall -O2 -c -g $<
 
+xdp_process.bpf.o: xdp_process.bpf.c vmlinux.h
+	clang -target bpf -Wall -O2 -c -g $<
+
 xdp_percpu.bpf.o: xdp_percpu.bpf.c vmlinux.h
 	clang -target bpf -Wall -O2 -c -g $<
 
 clean:
-	rm -f vmlinux.h xdp_pass.bpf.o xdp_drop.bpf.o xdp_detach.bpf.o xdp_zerokey.bpf.o xdp_percpu.bpf.o
+	rm -f vmlinux.h xdp_pass.bpf.o xdp_drop.bpf.o xdp_detach.bpf.o xdp_zerokey.bpf.o xdp_process.bpf.o xdp_percpu.bpf.o
 

--- a/tests/xdp/process.lua
+++ b/tests/xdp/process.lua
@@ -1,0 +1,7 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the xdp process-context test (see test_xdp.sh):
+-- a process runtime under the key of the eBPF program, with nothing attached.
+

--- a/tests/xdp/test_xdp.sh
+++ b/tests/xdp/test_xdp.sh
@@ -21,7 +21,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 source "$DIR/../lib.sh"
 
 ktap_header
-ktap_plan 6
+ktap_plan 7
 
 skip_all()
 {
@@ -31,6 +31,7 @@ skip_all()
 	ktap_skip "xdp detach: callback stops firing and traffic resumes"
 	ktap_skip "xdp attach: refuses a sleepable runtime"
 	ktap_skip "xdp zero-key: a zero-sized key is rejected without a crash"
+	ktap_skip "xdp process: a process-context runtime under the key is not dispatched"
 	ktap_skip "xdp percpu: the callback runs on the instance of the receiving CPU"
 	ktap_totals
 	exit 0
@@ -44,11 +45,12 @@ command -v clang > /dev/null 2>&1 || skip_all "clang not available"
 cleanup()
 {
 	bpftool net detach xdp dev "$IFACE" 2>/dev/null
-	rm -f "${PIN}_pass" "${PIN}_drop" "${PIN}_detach" "${PIN}_zerokey" "${PIN}_percpu"
+	rm -f "${PIN}_pass" "${PIN}_drop" "${PIN}_detach" "${PIN}_zerokey" "${PIN}_process" "${PIN}_percpu"
 	lunatik stop tests/xdp/pass > /dev/null 2>&1
 	lunatik stop tests/xdp/drop > /dev/null 2>&1
 	lunatik stop tests/xdp/detach > /dev/null 2>&1
 	lunatik stop tests/xdp/attach_sleepable > /dev/null 2>&1
+	lunatik stop tests/xdp/process > /dev/null 2>&1
 	lunatik stop tests/xdp/percpu > /dev/null 2>&1
 	ip netns del "$NETNS" 2>/dev/null
 	ip link del "$IFACE" 2>/dev/null
@@ -152,6 +154,28 @@ zerokey_case()
 	ktap_pass "xdp zero-key: a zero-sized key is rejected without a crash"
 }
 
+process_case()
+{
+	bpftool prog load "$DIR/xdp_process.bpf.o" "${PIN}_process" type xdp ||
+		{ ktap_fail "xdp process: failed to load XDP program"; return 1; }
+	bpftool net attach xdp pinned "${PIN}_process" dev "$IFACE" ||
+		{ ktap_fail "xdp process: failed to attach XDP program"; bpftool prog unpin "${PIN}_process"; return 1; }
+
+	mark_dmesg
+	run_script "tests/xdp/process"
+	ip netns exec "$NETNS" ping -c 1 -W 2 "$TARGET" > /dev/null 2>&1
+
+	bpftool net detach xdp dev "$IFACE" 2>/dev/null
+	rm -f "${PIN}_process"
+	lunatik stop tests/xdp/process > /dev/null 2>&1
+
+	# the kfunc must refuse the runtime before taking its lock: reaching the handler
+	# would take a mutex in softirq, which the missing-callback log betrays
+	dmesg_since | grep -qF "no callback attached" && { ktap_fail "xdp process: the runtime was dispatched"; return 1; }
+	dmesg_since | grep -qF "process-context runtime" || { ktap_fail "xdp process: the kfunc did not refuse the runtime"; return 1; }
+	ktap_pass "xdp process: a process-context runtime under the key is not dispatched"
+}
+
 # the veth runs the receive softirq on the sending CPU, so the pinned ping picks the instance
 percpu_case()
 {
@@ -195,6 +219,7 @@ lunatik stop tests/xdp/attach_sleepable > /dev/null 2>&1
 ktap_pass "xdp attach: refuses a sleepable runtime"
 
 zerokey_case
+process_case
 percpu_case
 
 ktap_totals

--- a/tests/xdp/xdp_process.bpf.c
+++ b/tests/xdp/xdp_process.bpf.c
@@ -1,0 +1,23 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+extern int bpf_luaxdp_run(char *key, size_t key__sz, struct xdp_md *ctx,
+		void *arg, size_t arg__sz) __ksym;
+
+static char runtime[] = "tests/xdp/process";
+
+SEC("xdp")
+int test_xdp_process(struct xdp_md *ctx)
+{
+	int ret;
+	ret = bpf_luaxdp_run(runtime, sizeof(runtime), ctx, NULL, 0);
+	return ret < 0 ? XDP_PASS : ret;
+}
+
+char _license[] SEC("license") = "Dual MIT/GPL";
+


### PR DESCRIPTION
Split out of #762, on top of #765.

The kfunc looked the key up and ran whatever it found, so a process-context runtime registered under an eBPF program's key had its mutex taken from softirq on every packet; contended, by a stop closing the state while traffic flows, that schedules while atomic. The lookup now refuses the runtime, with a ratelimited log, and leaves the verdict to the program. With the percpu object (#762) the refusal keeps the kfunc off process-context instances; the object's release path, which the refusal's own put can trigger from softirq, drops the instances without taking their locks.

Test: a `tests/xdp` case runs a process-context runtime under the program's key and checks the kfunc refuses it; validated by disabling the check and watching the runtime get dispatched.

Tested on 6.8.0-136 (aarch64): xdp 7/7, clean dmesg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

