### PR TITLE
docs: reclaim two rules from an older instructions file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,9 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
   says what `cpu >= 0` only implies, and ties the definition, the default and every test of it.
 * For every raise after acquiring a resource, know what is already held and who releases it; validate
   before acquiring whenever the check does not need the resource.
+* The minimal representation: a raw pointer where a struct would wrap one field, a fresh allocation
+  where a cache would need invalidating, a function where a macro is not clearer. A structure earns
+  its place by what it buys, not by looking more complete.
 * A log or error message is one terse line naming the condition, in the tree's voice — `couldn't find
   X`, lowercase, no trailing period — not a sentence spelling out the cause and its caveats. The
   reasoning behind a failure belongs in a code comment or the commit message, not the runtime log; a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,6 +372,9 @@ old factory — kept building and broke at the first packet.
 * A commit is one change and everything that change entails, even across modules: a new core check
   adopted by four bindings is one commit. Independent fixes are separate commits, even when a single
   review finding uncovered them all; the finding is the reviewer's unit, not the committer's.
+* A change to a function is read against the whole function, not the lines it touches: re-read it
+  and take the simplification the change enables. A guard left standing that the new shape made
+  redundant — `!cond || check(cond)` where the call now sits inside `if (cond)` — is a partial fix.
 * Change only what the task requires. Do not reformat untouched lines, do not move code, do not
   rename variables in passing. Compare `git diff` against `git diff -w` before committing to catch
   stray whitespace.


### PR DESCRIPTION
Two rules that lived in an older, machine-local instructions file and never made it into `AGENTS.md`: the minimal representation for data and control flow, and re-reading a whole function when a change touches part of it. Everything else in that file is already here or in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
