### PR TITLE
ci: run the convention checks over a pull request's diff

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,30 @@
+name: Checks
+on:
+  pull_request:
+    branches:
+    - master
+jobs:
+  checks:
+    name: Convention checks
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Install dependencies
+      run: sudo apt-get install -yq cppcheck
+    - name: Stage the pull request's diff
+      # pre-commit reads the index, so the diff against the base is staged as a commit would be
+      run: git reset -q --soft "origin/${{ github.base_ref }}"
+    - name: Trailing blank line
+      run: bash tools/checks/pre-commit
+    - name: Advisory checks
+      # heuristics that nudge a review; they annotate the run and do not fail it
+      run: |
+        files=$(git diff --cached --name-only --diff-filter=ACM)
+        for check in module-conventions test-harness cppcheck-tests; do
+          out=$(bash "tools/checks/$check.sh" $files 2>&1) || true
+          test -n "$out" && echo "::warning title=$check::$(printf '%s' "$out" | sed ':a;N;$!ba;s/\n/%0A/g')"
+        done
+        true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,8 @@ the last one.
 (`module-conventions.sh`), test scripts that cannot detect a failed load (`test-harness.sh`),
 cppcheck on userspace test C (`cppcheck-tests.sh`), and the trailing blank line rule (`pre-commit`).
 Each takes file paths and skips what does not apply, so any editor, assistant, or CI can run them.
-Install the commit gate with:
+The `Checks` workflow runs them over a pull request's diff: the trailing blank line rule fails the
+run, the heuristic checks annotate it. Install the commit gate with:
 
     ln -s ../../tools/checks/pre-commit .git/hooks/pre-commit
 


### PR DESCRIPTION
The checks in `tools/checks` ran only where an editor or an assistant was wired to call them. This runs them on every pull request: the diff against the base is staged, which is what `pre-commit` reads, so the trailing blank line rule fails the run and needs no second implementation; the heuristic checks annotate the run, since they nudge a review rather than state a rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
