### PR TITLE
luatask: drop the dead NULL check in luatask_check

### DIFF
--- a/lib/luatask.c
+++ b/lib/luatask.c
@@ -15,9 +15,7 @@
 
 #include "luatask.h"
 
-LUNATIK_PRIVATECHECKER(luatask_check, struct task_struct *,
-	luaL_argcheck(L, private != NULL, ix, "task is not set");
-);
+LUNATIK_PRIVATECHECKER(luatask_check, struct task_struct *);
 
 /* Getters read task fields locklessly; task_lock can't be held in the softirq/hardirq contexts
  * this class serves. A scalar reads as a coherent old-or-new value; comm is copied with


### PR DESCRIPTION
`luatask_check` carries a `luaL_argcheck` for a NULL task with the message `task is not set`, but `LUNATIK_PRIVATECHECKER` already raises `null pointer dereference` on a NULL private before the vararg body runs, so that check never fires. Drop it; the checker is the bare macro, as the other single-pointer classes write it.

Found while reviewing #757, whose exited-thread test asserts the message that actually reaches Lua.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
