### PR TITLE
claude: stop appending the session link to commits and pull requests

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,9 @@
         ]
       }
     ]
+  },
+  "attribution": {
+    "sessionUrl": false
   }
 }
 


### PR DESCRIPTION
Sets `attribution.sessionUrl` to `false` in the project settings, so Claude Code no longer appends the `Claude-Session` trailer to commits or the session link to pull request bodies. The `Co-Authored-By` trailer stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)