### PR TITLE
lunatik: add percpu, one object owning one runtime per CPU id

### DIFF
--- a/doc/capi.md
+++ b/doc/capi.md
@@ -114,6 +114,9 @@ passing the associated Lua state as the first argument followed by the variadic 
 If the Lua state has been closed, `ret` is set with `-ENXIO`;
 otherwise, `ret` is set with the result of `handler(L, ...)` call.
 Then, it restores the Lua stack and unlocks the `runtime` environment.
+A `percpu` object, which the caller keeps referenced across the call, is resolved first
+to the instance of the CPU the caller runs on, and the caller stays on that CPU until the
+call returns.
 It is defined as a macro.
 
 #### Example

--- a/lunatik.h
+++ b/lunatik.h
@@ -53,7 +53,7 @@ do {									\
 #define lunatik_toruntime(L)	(lunatik_extra(L)->runtime)
 #define LUNATIK_CPU_NONE	(-1)
 #define lunatik_getcpu(L)	(lunatik_extra(L)->cpu)
-#define lunatik_ispercpu(L)	(lunatik_getcpu(L) != LUNATIK_CPU_NONE)
+#define lunatik_hascpu(L)	(lunatik_getcpu(L) != LUNATIK_CPU_NONE)
 
 #define lunatik_cannotsleep(L, s)	((s) && lunatik_isirq(lunatik_toruntime(L)->opt))
 
@@ -193,7 +193,7 @@ static inline void lunatik_checkfield(lua_State *L, int idx, const char *field, 
 
 static inline void lunatik_checkpercpu(lua_State *L)
 {
-	if (lunatik_ispercpu(L))
+	if (lunatik_hascpu(L))
 		luaL_error(L, LUNATIK_ERR_PERCPU);
 }
 

--- a/lunatik.h
+++ b/lunatik.h
@@ -7,6 +7,8 @@
 #define lunatik_h
 
 #include <linux/mutex.h>
+#include <linux/percpu.h>
+#include <linux/preempt.h>
 #include <linux/spinlock.h>
 #include <linux/slab.h>
 #include <linux/mm.h>
@@ -25,6 +27,7 @@ typedef u8 __bitwise lunatik_opt_t;
 #define LUNATIK_OPT_MONITOR	((__force lunatik_opt_t)(1U << 3))
 #define LUNATIK_OPT_SINGLE	((__force lunatik_opt_t)(1U << 4))
 #define LUNATIK_OPT_EXTERNAL	((__force lunatik_opt_t)(1U << 5))
+#define LUNATIK_OPT_PERCPU	((__force lunatik_opt_t)(1U << 6))
 #define LUNATIK_OPT_NONE	((__force lunatik_opt_t)0)
 
 #define lunatik_isirq(opt)		((opt) & LUNATIK_OPT_IRQ)
@@ -33,6 +36,7 @@ typedef u8 __bitwise lunatik_opt_t;
 #define lunatik_ismonitor(opt)		((opt) & LUNATIK_OPT_MONITOR)
 #define lunatik_issingle(opt)		((opt) & LUNATIK_OPT_SINGLE)
 #define lunatik_isexternal(opt)		((opt) & LUNATIK_OPT_EXTERNAL)
+#define lunatik_ispercpu(opt)		((opt) & LUNATIK_OPT_PERCPU)
 
 #define lunatik_locker(o, mutex_op, softirq_op, hardirq_op, ...)	\
 do {									\
@@ -69,14 +73,17 @@ do {							\
 	lua_settop(L, n);				\
 } while (0)
 
-#define lunatik_run(runtime, handler, ret, ...)				\
-do {									\
-	lunatik_lock(runtime);						\
-	if (unlikely(!lunatik_isready(runtime)))			\
-		ret = -ENXIO;						\
-	else								\
-		lunatik_handle(runtime, handler, ret, ## __VA_ARGS__);	\
-	lunatik_unlock(runtime);					\
+#define lunatik_run(object, handler, ret, ...)					\
+do {										\
+	lunatik_object_t *_object = (object);					\
+	lunatik_object_t *_runtime = lunatik_pin(_object);			\
+	lunatik_lock(_runtime);							\
+	if (unlikely(!lunatik_isready(_runtime)))				\
+		ret = -ENXIO;							\
+	else									\
+		lunatik_handle(_runtime, handler, ret, ## __VA_ARGS__);		\
+	lunatik_unlock(_runtime);						\
+	lunatik_unpin(_object);							\
 } while(0)
 
 typedef struct lunatik_class_s {
@@ -99,6 +106,31 @@ typedef struct lunatik_object_s {
 	gfp_t gfp;
 	unsigned long flags;
 } lunatik_object_t;
+
+#define lunatik_percpuruntimes(p)	((lunatik_object_t * __percpu __force *)(p))
+
+static inline lunatik_object_t *lunatik_pin(lunatik_object_t *object)
+{
+	if (likely(!lunatik_ispercpu(object->opt)))
+		return object;
+
+	if (lunatik_isirq(object->opt))
+		preempt_disable();
+	else /* a process instance may sleep */
+		migrate_disable();
+	return *this_cpu_ptr(lunatik_percpuruntimes(object->private));
+}
+
+static inline void lunatik_unpin(lunatik_object_t *object)
+{
+	if (likely(!lunatik_ispercpu(object->opt)))
+		return;
+
+	if (lunatik_isirq(object->opt))
+		preempt_enable();
+	else
+		migrate_enable();
+}
 
 extern lunatik_object_t *lunatik_env;
 extern const lunatik_class_t lunatik_class;

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -163,8 +163,11 @@ static int lunatik_cpu(lua_State *L)
 	return 1;
 }
 
+static int lunatik_percpu(lua_State *L);
+
 static const luaL_Reg lunatik_lib[] = {
 	{"runtime", lunatik_lruntime},
+	{"percpu", lunatik_percpu},
 	{"cpu", lunatik_cpu},
 	{NULL, NULL}
 };
@@ -285,6 +288,14 @@ int lunatik_runtime(lunatik_object_t **pruntime, const char *script, lunatik_opt
 }
 EXPORT_SYMBOL(lunatik_runtime);
 
+static inline lunatik_opt_t lunatik_checkcontext(lua_State *L, int ix)
+{
+	static const char *const contexts[] = {"process", "softirq", "hardirq", NULL};
+	static const lunatik_opt_t opts[] = {LUNATIK_OPT_NONE, LUNATIK_OPT_SOFTIRQ, LUNATIK_OPT_HARDIRQ};
+
+	return opts[luaL_checkoption(L, ix, "process", contexts)];
+}
+
 /***
 * Creates a new Lunatik runtime executing the given script.
 * @function runtime
@@ -303,12 +314,9 @@ EXPORT_SYMBOL(lunatik_runtime);
 */
 static int lunatik_lruntime(lua_State *L)
 {
-	static const char *const contexts[] = {"process", "softirq", "hardirq", NULL};
-	static const lunatik_opt_t opts[] = {LUNATIK_OPT_NONE, LUNATIK_OPT_SOFTIRQ, LUNATIK_OPT_HARDIRQ};
 	const char *script = luaL_checkstring(L, 1);
-	int context = luaL_checkoption(L, 2, "process", contexts);
+	lunatik_opt_t opt = lunatik_checkcontext(L, 2);
 	int cpu = luaL_optinteger(L, 3, LUNATIK_CPU_NONE);
-	lunatik_opt_t opt = opts[context];
 
 	luaL_argcheck(L, cpu >= LUNATIK_CPU_NONE && cpu < (int)nr_cpu_ids, 3, "invalid cpu");
 
@@ -319,7 +327,100 @@ static int lunatik_lruntime(lua_State *L)
 	return 1;
 }
 
-static const lunatik_class_t *lunatik_classes[] = { &lunatik_class, NULL };
+/***
+* Set of runtimes, one per CPU id, running the same script. A callback dispatched
+* through it reaches the instance of the CPU it fired on.
+* @type percpu
+*/
+static void lunatik_releasepercpu(void *private)
+{
+	lunatik_object_t * __percpu *runtimes = lunatik_percpuruntimes(private);
+	int cpu;
+
+	for_each_possible_cpu(cpu) {
+		lunatik_object_t *runtime = *per_cpu_ptr(runtimes, cpu);
+		if (runtime != NULL) /* last reference: a stop would lock, and this can run in softirq */
+			lunatik_putobject(runtime);
+	}
+	free_percpu(runtimes);
+}
+
+static const lunatik_class_t lunatik_percpu_class;
+
+static inline lunatik_object_t * __percpu *lunatik_checkruntimes(lua_State *L, int ix)
+{
+	lunatik_object_t *object = lunatik_checkobject(L, ix);
+	lunatik_argcheckclass(L, ix, &lunatik_percpu_class, "percpu");
+	return lunatik_percpuruntimes(object->private);
+}
+
+/***
+* Closes every instance, releasing their Lua states.
+* @function stop
+*/
+static int lunatik_stoppercpu(lua_State *L)
+{
+	lunatik_object_t * __percpu *runtimes = lunatik_checkruntimes(L, 1);
+	int cpu;
+
+	for_each_possible_cpu(cpu) {
+		lunatik_object_t *runtime = *per_cpu_ptr(runtimes, cpu);
+		if (runtime != NULL)
+			lunatik_closeprivate(runtime);
+	}
+	return 0;
+}
+
+static const luaL_Reg lunatik_percpu_mt[] = {
+	{"__gc", lunatik_deleteobject},
+	{"__close", lunatik_stoppercpu},
+	{"stop", lunatik_stoppercpu},
+	{NULL, NULL}
+};
+
+static const lunatik_class_t lunatik_percpu_class = {
+	.name = "percpu",
+	.methods = lunatik_percpu_mt,
+	.release = lunatik_releasepercpu,
+	.opener = luaopen_lunatik,
+	.opt = LUNATIK_OPT_PERCPU | LUNATIK_OPT_EXTERNAL,
+};
+
+/***
+* Creates one runtime per CPU id, each loading the given script in the calling context.
+* The instances are dispatched by CPU: see `lunatik.cpu` and `runner.run`.
+* @function percpu
+* @tparam string script script name (e.g., `"mymod"` loads `/lib/modules/lua/mymod.lua`)
+* @tparam[opt="process"] string context execution context, as in `lunatik.runtime`
+* @treturn percpu
+* @raise if allocation fails or the script errors on load, after releasing the instances
+*   already created
+* @within lunatik
+*/
+static int lunatik_percpu(lua_State *L)
+{
+	const char *script = luaL_checkstring(L, 1);
+	lunatik_opt_t opt = lunatik_checkcontext(L, 2);
+	int cpu;
+
+	lunatik_object_t *object = lunatik_newobject(L, &lunatik_percpu_class, 0, opt);
+	lunatik_object_t * __percpu *runtimes = alloc_percpu(lunatik_object_t *);
+
+	if (runtimes == NULL)
+		lunatik_enomem(L);
+	object->private = runtimes;
+
+	for_each_possible_cpu(cpu) {
+		if (lunatik_newruntime(per_cpu_ptr(runtimes, cpu), L, script, opt, cpu) != 0) {
+			object->private = NULL;
+			lunatik_releasepercpu(runtimes); /* release the instances now, not on collection */
+			lua_error(L);
+		}
+	}
+	return 1;
+}
+
+static const lunatik_class_t *lunatik_classes[] = { &lunatik_class, &lunatik_percpu_class, NULL };
 
 LUNATIK_NEWLIB(lunatik, lunatik_lib, lunatik_classes);
 LUNATIK_NEWLIB(lunatik_stub, lunatik_stub_lib, NULL);

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -159,7 +159,7 @@ static int lunatik_lresume(lua_State *L)
 */
 static int lunatik_cpu(lua_State *L)
 {
-	lunatik_pushoptinteger(L, lunatik_ispercpu(L), lunatik_getcpu(L));
+	lunatik_pushoptinteger(L, lunatik_hascpu(L), lunatik_getcpu(L));
 	return 1;
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -230,6 +230,12 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   stop; and each instance sees its own id via `lunatik.cpu()`, which a
   plain runtime sees as `nil`.
 
+- **percpu_object**: `lunatik.percpu()` runs the script once per possible
+  CPU id, each instance stamping its own id; `stop` closes every instance
+  and the object can be created again; `stop` refuses an object of another
+  class; a script that fails on one instance raises with its error instead of
+  returning an object.
+
 - **percpu_refuse**: a registration a percpu instance cannot own fails
   at load, naming percpu, with a clean rollback, and the same script
   runs as a plain runtime: `device.new`, whose registration is global,

--- a/tests/runtime/percpu_object.lua
+++ b/tests/runtime/percpu_object.lua
@@ -1,0 +1,54 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu object test (see percpu_object.sh).
+
+local lunatik = require("lunatik")
+local linux   = require("linux")
+local test    = require("util").test
+
+local body    <const> = "tests/runtime/percpu"
+local failing <const> = "tests/runtime/percpu_fail"
+local stamp   <const> = "percpu_cpu:"
+
+local env = lunatik._ENV
+
+local function stamped()
+	assert(env[stamp .. linux.numcpus()] == nil, "an instance ran beyond the last CPU id")
+	for cpu = 0, linux.numcpus() - 1 do
+		assert(env[stamp .. cpu], "no instance stamped CPU " .. cpu)
+		env[stamp .. cpu] = nil
+	end
+end
+
+test("percpu runs the script once per possible CPU id", function()
+	local percpu <close> = lunatik.percpu(body)
+	stamped()
+end)
+
+test("stop closes every instance and the script runs again", function()
+	local percpu = lunatik.percpu(body)
+	percpu:stop()
+	stamped()
+	percpu = lunatik.percpu(body)
+	stamped()
+	percpu:stop()
+end)
+
+test("stop refuses an object of another class", function()
+	local percpu <close> = lunatik.percpu(body)
+	local runtime <close> = lunatik.runtime(failing)
+	local ok, err = pcall(getmetatable(percpu).stop, runtime)
+	assert(not ok, "stop accepted a runtime")
+	assert(err:match("percpu expected"), "stop raised something else: " .. err)
+end)
+
+if linux.numcpus() > 1 then
+	test("a failing instance raises with its error", function()
+		local ok, err = pcall(lunatik.percpu, failing)
+		assert(not ok, "percpu returned an object for a failing script")
+		assert(err:match("intentional error on the second instance"), "unexpected error: " .. err)
+	end)
+end
+

--- a/tests/runtime/percpu_object.sh
+++ b/tests/runtime/percpu_object.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for the percpu object: lunatik.percpu() runs the script once per
+# possible CPU id, each instance seeing its own id; stop closes every instance and
+# the object can be created again; stop refuses an object of another class; and a
+# script that fails on one instance raises with its error instead of returning an object.
+#
+# Usage: sudo bash tests/runtime/percpu_object.sh
+
+SCRIPT="tests/runtime/percpu_object"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+mark_dmesg
+run_script "$SCRIPT"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "lunatik.percpu runs the script per CPU id, stops, reruns, checks its class and rolls back"
+
+ktap_totals
+

--- a/tests/runtime/run.sh
+++ b/tests/runtime/run.sh
@@ -19,6 +19,7 @@ TESTS=(
 	opt_skb_single.sh
 	require_cloneobject.sh
 	percpu.sh
+	percpu_object.sh
 	percpu_refuse.sh
 )
 


### PR DESCRIPTION
First of three, split out of #762: the percpu object alone, with nothing using it yet.

A percpu script becomes one object owning one runtime per possible CPU id, allocated with `alloc_percpu` as the object's private, and `lunatik_run` resolves it to the instance of the CPU the callback fired on: a plain runtime pays one bit test, so a binding gains dispatch without changing a line. The caller stays on that CPU across the call: preemption off for IRQ instances, whose locks never sleep, migration off for process instances, which may. `stop` closes the states and leaves the instances in place, since the dispatch reads them without the object's lock; the last reference drops them, without taking their locks, because no registration a percpu instance may own holds one.

The first commit frees the name: `lunatik_ispercpu(L)` tested the CPU id and is `lunatik_hascpu(L)` now; `lunatik_ispercpu(opt)` is the object's bit.

Test: `tests/runtime/percpu_object` builds the object from a script, checks every CPU id ran, stops and rebuilds it, checks `stop` refuses an object of another class, and checks a failing instance raises; with the instances all given id 0 it fails.

Tested on 6.8.0-136 (aarch64): runtime 18/18, xdp 7/7, tc 6/6, clean dmesg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

