### PR TITLE
docs: what the percpu review round taught

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -8,8 +8,10 @@ comments, after a round. Follow it whole; this card is only the GitHub mechanics
 
 # Reading and driving the branch
 
-- `git fetch origin pull/<N>/head:review/<N>` brings the author's head; build and run it with
-  the lunatik-cycle skill.
+- `git fetch origin pull/<N>/head:review/<N>` brings the author's head; check it out in a worktree
+  of its own (`git worktree add <scratch>/w<N> review/<N>`, then `git submodule update --init`),
+  since a worktree named for a task may be another session's; build and run it with the
+  lunatik-cycle skill.
 - Read the pull request through the REST API, which needs no `read:org` scope:
   `gh api repos/luainkernel/lunatik/pulls/<N>` for the PR,
   `gh api repos/.../issues/<N>/comments` and `gh api repos/.../pulls/<N>/comments` for the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,10 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
   kernel crash reachable from Lua: `getmetatable(a).method(b)` is one line of script. The check is
   `lunatik_argcheckclass` in the checker's body, or in a hand written checker when the cast needs
   `__force`.
+* A per-CPU access names the guarantee it has: `this_cpu_ptr` where preemption is off, `per_cpu_ptr`
+  with an explicit id, and `raw_cpu_ptr` never to silence the check a preemptible caller would trip.
+  A cast into an annotated address space or type, `__percpu` or `__bitwise`, carries `__force`, as
+  the `opt` constants do.
 * `/*** @section name */` separates logical sections in a merged C file and groups them in the docs.
 * Two short mutually exclusive calls read better as a ternary than a four line if/else; void arms are
   fine. This does not transpose to Lua (see Lua style).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,6 +483,12 @@ A review produces two things: the comments, and a branch showing what the commen
 is posted before the maintainer has seen both, and the checklist below is the reviewer's own — a
 review that fails it is not ready, whatever the code looks like.
 
+The checklist runs whole on every pull request, whoever wrote it: the maintainer's own, another
+session's, or this session's earlier work. Authorship shortens nothing. A change that arrives with
+a rationale attached — a comment beside the line, a body that explains the choice, a prior session
+that "already reviewed it" — is reviewed against the code, not against the rationale; reading the
+rationale as the review is how a mutex in softirq and a crash reachable from Lua were passed.
+
 ### Before the verdict
 
 1. Check out the author's branch, build it, and run the suite. Reading the diff misses what the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,6 +410,10 @@ old factory — kept building and broke at the first packet.
   not say: a new API, a behaviour change, a non obvious rationale. No bullet list of every detail.
 * A pull request title and body follow the same rule: what and why, nothing the commits already say.
   No "Test plan" section, and no em dashes.
+* A pull request is one mechanism, read in one screen of diff and one paragraph of body. A body that
+  needs a section per mechanism describes several pull requests: stack them, each on the one below.
+* No session links or assistant footers in a commit or a pull request beyond the `Co-Authored-By`
+  trailer. The project settings turn the link off; one that slipped in is removed with a reword.
 * A root cause named in a commit body or a pull request rests on a captured stack or a source-traced
   chain, not a correlated log line or a plausible mechanism. Until it is traced it is a hypothesis,
   labelled as one; a fix may land on the observed behaviour without naming a cause it has not proven.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -585,6 +585,9 @@ rationale as the review is how a mutex in softirq and a crash reachable from Lua
   and shown, and is the review half-done. The prose points at the fixup and says why; the fixup is the
   change. A code finding with no commit behind it is not ready to post, and a review posted as comments
   with no branch is the lazy half of the two the review owes.
+* A fixup is the reviewer's code with no reviewer, so it gets the pass the author's code got:
+  only what the pull request introduced, said in one place. A design note under `doc/design/` that
+  mentions the old shape is a snapshot of a plan, not the API's documentation, and stays out.
 * One fixup per finding, `git commit --fixup=<the author's commit>` — not one per file, and not one
   per target commit: a comment pointing at a commit that does three unrelated things cannot be accepted
   in parts, and the author is the one who autosquashes what they accept. A fixup touches only what the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,15 @@ before the next `reload`.
 Never run two `lunatik` operations at once. Concurrent operations wedge `/dev/lunatik` and leave
 processes in D state. Check with `ps` before starting one.
 
+A worktree named for a task may belong to another session on the same machine. Check
+`git worktree list` and the branch a worktree holds before a checkout or a reset there, and never
+reset a branch checked out elsewhere. A review, or a build of a branch not your own, runs in a
+worktree created for it (`git worktree add`, then `git submodule update --init`) and removed at the
+end.
+
+A tree with a conflict pending (`git status` showing `UU`) is not a test subject: a suite run over a
+half-applied rebase or cherry-pick measures neither side. Resolve and commit, then build.
+
 `lunatik reload` unloads only the modules the installed CLI lists. A module loaded from another
 branch's install escapes it and pins the core: `rmmod` reports `Module lunatik is in use by ...`
 while `lunatik list` is empty. Diff `lsmod` against the installed `lunatik/config.lua` to find the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,7 +347,9 @@ Tests are shell scripts emitting KTAP plus a kernel side Lua script.
   first, since restoring is a `git checkout --` that takes any uncommitted work with it;
 * a test for an exactly once property runs on the path where that property is structural, and the
   header says which path and why. The same assertion on a path that can migrate CPUs mid way passes
-  for the wrong reason.
+  for the wrong reason;
+* a test that guards a kernel crash is not proved by removing the guard. Say that its discrimination
+  rests on the message it asserts, and prove the rest of the suite the usual way.
 
 A test is not done until `tests/README.md` describes it, the suite's `run.sh` runs it, and, for a new
 suite, the top level `README.md` lists it. Same commit, or a fixup of it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,6 +488,11 @@ A review produces two things: the comments, and a branch showing what the commen
 is posted before the maintainer has seen both, and the checklist below is the reviewer's own — a
 review that fails it is not ready, whatever the code looks like.
 
+"The tree does it" is a fact about the tree, not a reason. A choice is defended by what it buys
+and what it costs; prevalence says whether it is common, never whether it is right, and a tree can
+be wrong in a hundred places. When the only support for a line is a precedent, say so and judge it
+again.
+
 The checklist runs whole on every pull request, whoever wrote it: the maintainer's own, another
 session's, or this session's earlier work. Authorship shortens nothing. A change that arrives with
 a rationale attached — a comment beside the line, a body that explains the choice, a prior session

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,11 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
 * A secondary check that must always follow a `LUNATIK_PRIVATECHECKER` (a field that must be set,
   the class identity of the object) goes in the macro's vararg body, in the mold of `luaskb_check`;
   `L` and `ix` are in scope there. A hand written checker only when the macro's shape does not fit.
+* A method that reads `private` as its own type checks the class first. `lunatik_checkobject`
+  accepts any Lunatik object, so a foreign object's private read through this class's pointer is a
+  kernel crash reachable from Lua: `getmetatable(a).method(b)` is one line of script. The check is
+  `lunatik_argcheckclass` in the checker's body, or in a hand written checker when the cast needs
+  `__force`.
 * `/*** @section name */` separates logical sections in a merged C file and groups them in the docs.
 * Two short mutually exclusive calls read better as a ternary than a four line if/else; void arms are
   fine. This does not transpose to Lua (see Lua style).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -553,6 +553,12 @@ review that fails it is not ready, whatever the code looks like.
   `tc`'s BPF programs were right to declare `Dual MIT/GPL`; the `xdp` ones still on `GPL` are what a
   separate cleanup fixes.
 * Missing tests are a finding of their own, written as such, not a remark appended to another comment.
+* A comment is not a trace. A rationale left on the weaker primitive, `raw_cpu_ptr` justified by a
+  preemptible caller that does not exist, is a finding to run to ground against the kernel's own
+  idiom, not a reason to pass the line.
+* A contract the author documented is not redesigned by the review. An ergonomics preference, `nil`
+  against an object whose methods raise, is stated with its trade-off and left to the maintainer;
+  shipped as a fixup, it asks the author to un-decide.
 
 ### Fixups
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -632,6 +632,9 @@ rationale as the review is how a mutex in softirq and a crash reachable from Lua
   closed and there is more to say, comment. And feedback lives in one artifact: when you fall back to a
   comment, or correct or move a comment, edit or supersede the one that carries it — never leave two
   copies to drift.
+* A stacked pull request is merged after its base, never before: GitHub merges it into the base
+  branch, the base pull request grows a commit nobody reviewed there, and the stacked one closes
+  as merged with nothing on `master`. A verdict on a stacked pull request says "after #N".
 * Approving is the reviewer's to state; merging is the maintainer's to trigger. Even a clean, approved
   PR is not merged on the reviewer's initiative — pushing or merging to `master` is irreversible and
   public, and the click is the maintainer's alone. A question about state — "can we merge?", "is it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,11 @@ Never `require("foo").method()`.
 * A comment is one line carrying the reason the code is not obvious, nothing the code below already
   says. State the why; the what and the how are the code's job.
 * A comment about a specific call goes on that call's line, not above the function signature.
+* When the surprise is the call itself, a `put` where the tree would `stop`, the comment on the
+  call's line gives the one reason it is not the expected call, `/* last reference: a stop would
+  lock here */`; when the alternative is the other arm of the same `if`, the reason alone,
+  `else /* this arm may sleep */`. The comment states the choice, not the world behind it; the
+  invariant the choice rests on is the commit body's.
 * Reaching for a comment is a signal to reconsider the code's clarity first: a name that states the
   intent, a helper that names the step, an enum instead of a bare constant. Comment what the code
   cannot be made to say, not what a clearer shape would.

--- a/tools/checks/module-conventions.sh
+++ b/tools/checks/module-conventions.sh
@@ -39,6 +39,19 @@ check() {
 		add "has } else on the same line; else goes on its own line"
 	[ "$(tail -c2 "$file" | tr '\n' 'N')" = "NN" ] || \
 		add "does not end with a trailing blank line"
+	grep -nE '\braw_cpu_ptr\(' "$file" >/dev/null 2>&1 && \
+		add "uses raw_cpu_ptr; a per-CPU access names its guarantee: this_cpu_ptr where preemption is off, per_cpu_ptr with an explicit id"
+	grep -nE '__percpu[[:space:]]+\*[[:space:]]*\)' "$file" 2>/dev/null | grep -v '__force' | grep -q . && \
+		add "casts into __percpu without __force; a cast into an annotated address space carries __force, as the opt constants do"
+	# a method that reads private as its own type right after lunatik_checkobject, which
+	# accepts any Lunatik object, skips the class check; a checker adds lunatik_argcheckclass.
+	awk '
+		/lunatik_checkobject\(L, [0-9]+\)/ { hold=NR }
+		hold && /argcheckclass/ { hold=0 }
+		hold && NR<=hold+3 && /->private/ { print NR; found=1; hold=0 }
+		END { exit !found }
+	' "$file" >/dev/null 2>&1 && \
+		add "reads ->private right after lunatik_checkobject, which accepts any Lunatik object; check the class first (LUNATIK_PRIVATECHECKER with lunatik_argcheckclass, or a hand written checker)"
 
 	# over-comment nudges. Heuristic, so advisory.
 	# (a) a comment right after a preprocessor branch usually restates the condition.

--- a/tools/checks/module-conventions.sh
+++ b/tools/checks/module-conventions.sh
@@ -43,6 +43,8 @@ check() {
 		add "uses raw_cpu_ptr; a per-CPU access names its guarantee: this_cpu_ptr where preemption is off, per_cpu_ptr with an explicit id"
 	grep -nE '__percpu[[:space:]]+\*[[:space:]]*\)' "$file" 2>/dev/null | grep -v '__force' | grep -q . && \
 		add "casts into __percpu without __force; a cast into an annotated address space carries __force, as the opt constants do"
+	grep -nE 'lunatik_toobject\(L, *(-?[0-9]+|ix)\)->private' "$file" 2>/dev/null | grep -vE 'lunatik_getregistry|_key\)' | grep -q . && \
+		add "reads ->private through lunatik_toobject on an argument; lunatik_toobject returns NULL for a non-userdata, so a checker (lunatik_checkobject) goes first"
 	# a method that reads private as its own type right after lunatik_checkobject, which
 	# accepts any Lunatik object, skips the class check; a checker adds lunatik_argcheckclass.
 	awk '


### PR DESCRIPTION
Eight rules, one per commit, each from a mistake in the review of the percpu stack: the review runs whole on every pull request, whoever wrote it, and a rationale attached to a change is not the review of it; a build or review runs in a worktree of its own and never over a tree with a conflict pending; a method checks the class before reading private as its own type; a per-CPU access names its guarantee and an annotated cast carries __force; a pull request is one mechanism and carries no session link; a comment on the weaker primitive is a finding, not a rationale, and a review does not redesign a documented contract; a test guarding a kernel crash is not proved by removing the guard. The review skill card gains the worktree step, and `module-conventions.sh`, which the edit hook runs on every C file written, flags `raw_cpu_ptr`, a `__percpu` cast without `__force`, a `->private` read through `lunatik_toobject` on an argument (`LUNATIK_PRIVATECHECKER` itself on master, fixed in #776) and a `->private` read right after `lunatik_checkobject`: on the percpu commit as first sent it names the first two; on master it names `device:stop`, `notifier:stop`, `probe:stop` and `probe:enable`, fixed in #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


