### PR TITLE
lunatik: a private checker proves its object, its class and its private

### DIFF
--- a/doc/capi.md
+++ b/doc/capi.md
@@ -17,7 +17,9 @@ typedef struct lunatik_class_s {
 ```
 Describes a Lunatik object class.
 
-- `name`: class name; used as the argument to `require` and to identify the class.
+- `name`: the class's type name, quoted by type errors and `__name`; `lunatik_require` also
+  registers the library under it when an object of the class enters another state, so a script's
+  own `require` of the library may open it a second time, which keeps the classes already opened.
 - `methods`: `NULL`-terminated array of Lua methods registered in the metatable.
 - `release`: called when the object's reference counter reaches zero; may be `NULL`.
 - `opt`: bitmask of `LUNATIK_OPT_*` flags controlling class behaviour. Flags are inherited by
@@ -273,21 +275,27 @@ lunatik_object_t *lunatik_toobject(lua_State *L, int i);
 Returns the Lunatik object at stack position `i` without type checking. Returns `NULL` if
 the value is not a userdata. Defined as a macro.
 
-### LUNATIK\_OBJECTCHECKER
-```C
-#define LUNATIK_OBJECTCHECKER(checker, T)
-```
-Generates a `static inline` function `T checker(lua_State *L, int ix)` that returns
-`object->private` cast to `T`. Performs a full object check; raises a Lua error if the
-value at `ix` is not a valid Lunatik object.
-
 ### LUNATIK\_PRIVATECHECKER
 ```C
-#define LUNATIK_PRIVATECHECKER(checker, T, ...)
+#define LUNATIK_PRIVATECHECKER(checker, T, cls, ...)
+#define LUNATIK_PRIVATECHECKERS(checker, T, tname, ...)
 ```
-Like `LUNATIK_OBJECTCHECKER`, but also guards against use-after-free by checking that
-`private != NULL` before returning. The optional `...` may include additional validation
-statements (e.g., checking a secondary field) that are executed before `return private`.
+Generates a `static inline` function `T checker(lua_State *L, int ix)` that returns
+`object->private` cast to `T`, after proving three things about the value at `ix`, each with a
+Lua error: it is a Lunatik object (`lunatik_checkobject`), it is of the class `cls`, whose
+`name` the type error quotes, and its private is set, which rules out a closed object. The
+second form is for a family of classes sharing one checker: `...` lists the classes it accepts,
+and `tname` is the name the type error quotes. The first form's optional `...` are further
+validation statements, run with `L`, `ix`, `object` and `private` in scope, before `return
+private`.
+
+### lunatik\_argcheckclass
+```C
+void lunatik_argcheckclass(lua_State *L, int ix, lunatik_object_t *object, const lunatik_class_t *cls);
+```
+Raises a type error naming `cls->name` unless `object`, the Lunatik object at `ix`, is of that
+class. For a method that needs the object itself, not only its private: `lunatik_checkobject`
+followed by this check is what the checkers above do. Defined as a macro.
 
 ---
 

--- a/lib/luabpf.c
+++ b/lib/luabpf.c
@@ -30,7 +30,10 @@
 
 #include <lunatik.h>
 
-LUNATIK_PRIVATECHECKER(luabpf_map_check, struct bpf_map *);
+static const lunatik_class_t luabpf_hash_class;
+static const lunatik_class_t luabpf_queue_class;
+
+LUNATIK_PRIVATECHECKERS(luabpf_map_check, struct bpf_map *, "bpf.map", &luabpf_hash_class, &luabpf_queue_class);
 
 #define luabpf_map_istype(map, type)	((map) != NULL && (map)->map_type == (type))
 

--- a/lib/luacompletion.c
+++ b/lib/luacompletion.c
@@ -21,7 +21,9 @@
 
 #include <lunatik.h>
 
-LUNATIK_OBJECTCHECKER(luacompletion_check, struct completion *);
+static const lunatik_class_t luacompletion_class;
+
+LUNATIK_PRIVATECHECKER(luacompletion_check, struct completion *, &luacompletion_class);
 
 /***
 * Represents a kernel completion object.

--- a/lib/luacrypto.h
+++ b/lib/luacrypto.h
@@ -40,7 +40,7 @@ typedef struct luacrypto_ctx_s {
 
 /* checkctx returns the context; check returns ctx->tfm for tfm-only methods. */
 #define LUACRYPTO_CHECKER(name, T)							\
-LUNATIK_PRIVATECHECKER(luacrypto_##name##_checkctx, luacrypto_ctx_t *)			\
+LUNATIK_PRIVATECHECKER(luacrypto_##name##_checkctx, luacrypto_ctx_t *, &luacrypto_##name##_class)	\
 static inline T *luacrypto_##name##_check(lua_State *L, int idx)				\
 {											\
 	return (T *)luacrypto_##name##_checkctx(L, idx)->tfm;				\

--- a/lib/luacrypto_comp.c
+++ b/lib/luacrypto_comp.c
@@ -20,7 +20,7 @@
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
 #warning "crypto_comp API was removed in Linux 6.15, skip COMP module"
 #else
-LUNATIK_PRIVATECHECKER(luacrypto_comp_check, struct crypto_comp *);
+LUNATIK_PRIVATECHECKER(luacrypto_comp_check, struct crypto_comp *, &luacrypto_comp_class);
 
 LUACRYPTO_RELEASER(comp, struct crypto_comp, crypto_free_comp);
 

--- a/lib/luacrypto_rng.c
+++ b/lib/luacrypto_rng.c
@@ -17,7 +17,7 @@
 
 #include "luacrypto.h"
 
-LUNATIK_PRIVATECHECKER(luacrypto_rng_check, struct crypto_rng *);
+LUNATIK_PRIVATECHECKER(luacrypto_rng_check, struct crypto_rng *, &luacrypto_rng_class);
 
 LUACRYPTO_RELEASER(rng, struct crypto_rng, crypto_free_rng);
 

--- a/lib/luacrypto_shash.c
+++ b/lib/luacrypto_shash.c
@@ -16,7 +16,7 @@
 
 #include "luacrypto.h"
 
-LUNATIK_PRIVATECHECKER(luacrypto_shash_check, struct shash_desc *);
+LUNATIK_PRIVATECHECKER(luacrypto_shash_check, struct shash_desc *, &luacrypto_shash_class);
 
 static void luacrypto_shash_release(void *private)
 {

--- a/lib/luadata.c
+++ b/lib/luadata.c
@@ -27,7 +27,9 @@ typedef struct luadata_s {
 
 static int luadata_lnew(lua_State *L);
 
-LUNATIK_PRIVATECHECKER(luadata_check, luadata_t *);
+static const lunatik_class_t luadata_class;
+
+LUNATIK_PRIVATECHECKER(luadata_check, luadata_t *, &luadata_class);
 
 static inline void *luadata_checkbounds(lua_State *L, int ix, luadata_t *data, lua_Integer offset, lua_Integer length)
 {

--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -256,9 +256,12 @@ static void luadevice_release(void *private)
 *   dev:stop()
 * @see device.new
 */
+static const lunatik_class_t luadevice_class;
+
 static int luadevice_stop(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_checkobject(L, 1);
+	lunatik_argcheckclass(L, 1, object, &luadevice_class);
 	luadevice_t *luadev = (luadevice_t *)object->private;
 
 	lunatik_lock(object);

--- a/lib/luafifo.c
+++ b/lib/luafifo.c
@@ -16,7 +16,9 @@
 
 #include <lunatik.h>
 
-LUNATIK_PRIVATECHECKER(luafifo_check, struct kfifo *);
+static const lunatik_class_t luafifo_class;
+
+LUNATIK_PRIVATECHECKER(luafifo_check, struct kfifo *, &luafifo_class);
 
 /***
 * Pushes data into the FIFO.

--- a/lib/luanetlink.c
+++ b/lib/luanetlink.c
@@ -30,7 +30,9 @@ typedef struct luanetlink_channel_s {
 	bool                        registered;
 } luanetlink_channel_t;
 
-LUNATIK_PRIVATECHECKER(luanetlink_channel_check, luanetlink_channel_t *);
+static const lunatik_class_t luanetlink_channel_class;
+
+LUNATIK_PRIVATECHECKER(luanetlink_channel_check, luanetlink_channel_t *, &luanetlink_channel_class);
 
 static void luanetlink_channel_release(void *private)
 {

--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -40,6 +40,12 @@ typedef struct luanotifier_s {
 	luanotifier_register_t unregister;
 } luanotifier_t;
 
+static const lunatik_class_t luanotifier_process_class;
+static const lunatik_class_t luanotifier_hardirq_class;
+
+LUNATIK_PRIVATECHECKERS(luanotifier_check, luanotifier_t *, "notifier", &luanotifier_process_class,
+	&luanotifier_hardirq_class);
+
 static int luanotifier_handler(lua_State *L, luanotifier_t *notifier, unsigned long event, void *data)
 {
 	int nargs = 1; /* event */
@@ -96,8 +102,7 @@ static void luanotifier_release(void *private)
 */
 static int luanotifier_stop(lua_State *L)
 {
-	lunatik_object_t *object = lunatik_checkobject(L, 1);
-	luanotifier_t *notifier = (luanotifier_t *)object->private;
+	luanotifier_t *notifier = luanotifier_check(L, 1);
 
 	lunatik_unregister(L, notifier); /* clear callback; handler becomes no-op */
 	return 0;
@@ -113,9 +118,6 @@ static int luanotifier_##name(lua_State *L)					\
 		unregister_##name##_notifier, luanotifier_##name##_handler,	\
 		(class));							\
 }
-
-static const lunatik_class_t luanotifier_process_class;
-static const lunatik_class_t luanotifier_hardirq_class;
 
 static int luanotifier_netdevice_handler(lua_State *L, void *data)
 {

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -116,9 +116,12 @@ static void luaprobe_release(void *private)
 * Unregisters and stops the probe.
 * @function stop
 */
+static const lunatik_class_t luaprobe_class;
+
 static int luaprobe_stop(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_checkobject(L, 1);
+	lunatik_argcheckclass(L, 1, object, &luaprobe_class);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
 
 	luaprobe_delete(probe);
@@ -137,6 +140,7 @@ static int luaprobe_stop(lua_State *L)
 static int luaprobe_enable(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_checkobject(L, 1);
+	lunatik_argcheckclass(L, 1, object, &luaprobe_class);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
 	struct kprobe *kp = &probe->kp;
 	bool enable = lua_toboolean(L, 2);

--- a/lib/luarcu.c
+++ b/lib/luarcu.c
@@ -163,6 +163,7 @@ EXPORT_SYMBOL(luarcu_setvalue);
 static int luarcu_index(lua_State *L)
 {
 	lunatik_object_t *table = lunatik_checkobject(L, 1);
+	lunatik_argcheckclass(L, 1, table, &luarcu_class);
 	size_t keylen;
 	const char *key = luaL_checklstring(L, 2, &keylen);
 	lunatik_value_t value;
@@ -183,6 +184,7 @@ static int luarcu_index(lua_State *L)
 static int luarcu_newindex(lua_State *L)
 {
 	lunatik_object_t *table = lunatik_checkobject(L, 1);
+	lunatik_argcheckclass(L, 1, table, &luarcu_class);
 	size_t keylen;
 	const char *key = luaL_checklstring(L, 2, &keylen);
 

--- a/lib/luarcu.c
+++ b/lib/luarcu.c
@@ -99,9 +99,7 @@ static inline void luarcu_free(luarcu_entry_t *entry)
 
 static const lunatik_class_t luarcu_class;
 
-LUNATIK_PRIVATECHECKER(luarcu_checktable, luarcu_table_t *,
-	lunatik_argcheckclass(L, ix, &luarcu_class, "rcu.table");
-);
+LUNATIK_PRIVATECHECKER(luarcu_checktable, luarcu_table_t *, &luarcu_class);
 
 void luarcu_getvalue(lunatik_object_t *table, const char *key, size_t keylen, lunatik_value_t *value)
 {
@@ -291,7 +289,7 @@ static const struct luaL_Reg luarcu_mt[] = {
 
 LUNATIK_OPENER(rcu);
 static const lunatik_class_t luarcu_class = {
-	.name = "rcu",
+	.name = "rcu.table",
 	.methods = luarcu_mt,
 	.release = luarcu_release,
 	.opener = luaopen_rcu,

--- a/lib/luaset.c
+++ b/lib/luaset.c
@@ -43,7 +43,7 @@ static int luaset_labeled(lua_State *L);
 static const lunatik_class_t luaset_class;
 static const lunatik_class_t luaset_labeled_class;
 
-LUNATIK_PRIVATECHECKER(luaset_check, luaset_t *);
+LUNATIK_PRIVATECHECKERS(luaset_check, luaset_t *, "set", &luaset_class, &luaset_labeled_class);
 
 static inline int luaset_keycmp(const char *a, uint32_t alen, const char *b, uint32_t blen)
 {

--- a/lib/luaskb.c
+++ b/lib/luaskb.c
@@ -22,7 +22,9 @@
 
 #include "luaskb.h"
 
-LUNATIK_PRIVATECHECKER(luaskb_check, luaskb_t *,
+static const lunatik_class_t luaskb_class;
+
+LUNATIK_PRIVATECHECKER(luaskb_check, luaskb_t *, &luaskb_class,
 	luaL_argcheck(L, private->skb != NULL, ix, "skb is not set");
 );
 

--- a/lib/luaskel.c
+++ b/lib/luaskel.c
@@ -20,7 +20,9 @@ typedef struct luaskel_s {
 	int unused;
 } luaskel_t;
 
-LUNATIK_PRIVATECHECKER(luaskel_check, luaskel_t *);
+static const lunatik_class_t luaskel_class;
+
+LUNATIK_PRIVATECHECKER(luaskel_check, luaskel_t *, &luaskel_class);
 
 /***
 * Does nothing.

--- a/lib/luasocket.c
+++ b/lib/luasocket.c
@@ -123,7 +123,9 @@ static int luasocket_pushaddr(lua_State *L, struct sockaddr_storage *addr)
 	return n;
 }
 
-LUNATIK_PRIVATECHECKER(luasocket_check, struct socket *);
+static const lunatik_class_t luasocket_class;
+
+LUNATIK_PRIVATECHECKER(luasocket_check, struct socket *, &luasocket_class);
 
 #define luasocket_setmsg(m)		memset(&(m), 0, sizeof(m))
 

--- a/lib/luatask.c
+++ b/lib/luatask.c
@@ -15,7 +15,9 @@
 
 #include "luatask.h"
 
-LUNATIK_PRIVATECHECKER(luatask_check, struct task_struct *);
+static const lunatik_class_t luatask_class;
+
+LUNATIK_PRIVATECHECKER(luatask_check, struct task_struct *, &luatask_class);
 
 /* Getters read task fields locklessly; task_lock can't be held in the softirq/hardirq contexts
  * this class serves. A scalar reads as a coherent old-or-new value; comm is copied with

--- a/lib/luatc.c
+++ b/lib/luatc.c
@@ -43,7 +43,9 @@ typedef struct luatc_ctx_s {
 	int              cb;
 } luatc_ctx_t;
 
-LUNATIK_PRIVATECHECKER(luatc_ctx_check, luatc_ctx_t *,
+static const lunatik_class_t luatc_class;
+
+LUNATIK_PRIVATECHECKER(luatc_ctx_check, luatc_ctx_t *, &luatc_class,
 	luaL_argcheck(L, private->skb != NULL, ix, "ctx is not set");
 );
 

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -172,7 +172,7 @@ static int luathread_run(lua_State *L)
 {
 	luaL_argcheck(L, lunatik_isready(lunatik_toruntime(L)), 1, "not allowed during module load");
 	lunatik_object_t *runtime = lunatik_checkobject(L, 1);
-	lunatik_argcheckclass(L, 1, &lunatik_class, "runtime");
+	lunatik_argcheckclass(L, 1, runtime, &lunatik_class);
 	luaL_argcheck(L, !lunatik_isirq(runtime->opt), 1, "IRQ runtime cannot spawn threads");
 	const char *name = luaL_checkstring(L, 2);
 	lunatik_object_t *object = luathread_new(L);

--- a/lib/luaxdp.c
+++ b/lib/luaxdp.c
@@ -41,7 +41,9 @@ typedef struct luaxdp_ctx_s {
 	int              cb;
 } luaxdp_ctx_t;
 
-LUNATIK_PRIVATECHECKER(luaxdp_ctx_check, luaxdp_ctx_t *,
+static const lunatik_class_t luaxdp_class;
+
+LUNATIK_PRIVATECHECKER(luaxdp_ctx_check, luaxdp_ctx_t *, &luaxdp_class,
 	luaL_argcheck(L, private->xdp != NULL, ix, "ctx is not set");
 );
 

--- a/lunatik.h
+++ b/lunatik.h
@@ -278,8 +278,8 @@ void lunatik_monitorobject(lua_State *L, const lunatik_class_t *class);
 
 #define lunatik_newpobject(L, n)	(lunatik_object_t **)lua_newuserdatauv((L), sizeof(lunatik_object_t *), (n))
 #define lunatik_argchecknull(L, o, i)	luaL_argcheck((L), (o) != NULL, (i), LUNATIK_ERR_NULLPTR)
-#define lunatik_argcheckclass(L, ix, cls, tname)	\
-	luaL_argexpected((L), lunatik_toobject((L), (ix))->class == (cls), (ix), (tname))
+#define lunatik_argcheckclass(L, ix, object, cls)	\
+	luaL_argexpected((L), (object)->class == (cls), (ix), (cls)->name)
 #define lunatik_checkobject(L, i)	(*lunatik_checkpobject((L), (i)))
 #define lunatik_toobject(L, i)		(*(lunatik_object_t **)lua_touserdata((L), (i)))
 #define lunatik_getobject(o)		kref_get(&(o)->kref)
@@ -311,6 +311,8 @@ static inline void lunatik_newclass(lua_State *L, const lunatik_class_t *class, 
 	lua_pushlightuserdata(L, lunatik_monitormt(class, monitored));
 	lua_newtable(L); /* mt = {} */
 	luaL_setfuncs(L, class->methods, 0);
+	lua_pushstring(L, class->name);
+	lua_setfield(L, -2, "__name"); /* names the class in type errors and tostring */
 	if (monitored)
 		lunatik_monitorobject(L, class);
 	if (!lunatik_hasindex(L, -1)) {
@@ -322,7 +324,7 @@ static inline void lunatik_newclass(lua_State *L, const lunatik_class_t *class, 
 
 static inline lunatik_class_t *lunatik_getclass(lua_State *L, int ix)
 {
-	if (lua_isuserdata(L, ix) && lua_getiuservalue(L, ix, 1) != LUA_TNONE) {
+	if (lua_type(L, ix) == LUA_TUSERDATA && lua_getiuservalue(L, ix, 1) != LUA_TNONE) {
 		lunatik_class_t *class = (lunatik_class_t *)lua_touserdata(L, -1);
 		lua_pop(L, 1); /* class */
 		return class;
@@ -352,10 +354,19 @@ static inline lunatik_object_t **lunatik_checkpobject(lua_State *L, int ix)
 #define LUNATIK_CLASSES(name, ...)	\
 static const lunatik_class_t *lua##name##_classes[] = { __VA_ARGS__, NULL }
 
+static inline bool lunatik_hasclass(lua_State *L, const lunatik_class_t *class)
+{
+	int type = lua_rawgetp(L, LUA_REGISTRYINDEX, lunatik_monitormt(class, false));
+	lua_pop(L, 1); /* mt or nil */
+	return type != LUA_TNIL;
+}
+
 static inline void lunatik_newclasses(lua_State *L, const lunatik_class_t **classes)
 {
 	for (; *classes; classes++) {
 		const lunatik_class_t *cls = *classes;
+		if (lunatik_hasclass(L, cls)) /* opened again under another name */
+			continue;
 		if (lunatik_ismonitor(cls->opt))
 			lunatik_newclass(L, cls, true);
 		lunatik_newclass(L, cls, false);
@@ -376,22 +387,31 @@ int luaopen_##libname(lua_State *L)						\
 }										\
 EXPORT_SYMBOL_GPL(luaopen_##libname)
 
-#define LUNATIK_OBJECTCHECKER(checker, T)			\
+#define LUNATIK_CHECKER(checker, T, argcheckclass, ...)		\
 static inline T checker(lua_State *L, int ix)			\
 {								\
 	lunatik_object_t *object = lunatik_checkobject(L, ix);	\
-	return (T)object->private;				\
-}
-
-#define LUNATIK_PRIVATECHECKER(checker, T, ...)			\
-static inline T checker(lua_State *L, int ix)			\
-{								\
-	T private = (T)lunatik_toobject(L, ix)->private;	\
-	/* avoid use-after-free */				\
-	lunatik_argchecknull(L, private, ix);			\
+	argcheckclass;						\
+	T private = (T)object->private;				\
+	lunatik_argchecknull(L, private, ix); /* closed */	\
 	__VA_ARGS__						\
 	return private;						\
 }
+
+#define LUNATIK_PRIVATECHECKER(checker, T, cls, ...)	\
+	LUNATIK_CHECKER(checker, T, lunatik_argcheckclass(L, ix, object, cls), ##__VA_ARGS__)
+
+static inline bool lunatik_isoneof(const lunatik_class_t *class, const lunatik_class_t *const *classes)
+{
+	for (; *classes != NULL; classes++)
+		if (*classes == class)
+			return true;
+	return false;
+}
+
+#define LUNATIK_PRIVATECHECKERS(checker, T, tname, ...)						\
+static const lunatik_class_t *const checker##_classes[] = { __VA_ARGS__, NULL };		\
+LUNATIK_CHECKER(checker, T, luaL_argexpected(L, lunatik_isoneof(object->class, checker##_classes), ix, tname))
 
 #define lunatik_getregistry(L, key)	lua_rawgetp((L), LUA_REGISTRYINDEX, (key))
 

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -89,7 +89,7 @@ EXPORT_SYMBOL(lunatik_stop);
 
 static int lunatik_lruntime(lua_State *L);
 
-LUNATIK_PRIVATECHECKER(lunatik_check, lua_State *);
+LUNATIK_PRIVATECHECKER(lunatik_check, lua_State *, &lunatik_class);
 
 static int lunatik_lcopyobjects(lua_State *L)
 {
@@ -192,7 +192,7 @@ static const luaL_Reg lunatik_mt[] = {
 LUNATIK_OPENER(lunatik);
 LUNATIK_OPENER(lunatik_stub);
 const lunatik_class_t lunatik_class = {
-	.name = "lunatik",
+	.name = "runtime",
 	.methods = lunatik_mt,
 	.release = lunatik_releaseruntime,
 	.opener = luaopen_lunatik,
@@ -344,7 +344,7 @@ static const lunatik_class_t lunatik_percpu_class;
 static inline lunatik_object_t * __percpu *lunatik_checkruntimes(lua_State *L, int ix)
 {
 	lunatik_object_t *object = lunatik_checkobject(L, ix);
-	lunatik_argcheckclass(L, ix, &lunatik_percpu_class, "percpu");
+	lunatik_argcheckclass(L, ix, object, &lunatik_percpu_class);
 	return lunatik_percpuruntimes(object->private);
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -203,6 +203,20 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   across runtime boundaries. Push into a shared `fifo`, resume a
   sub-runtime with it, assert the value pops on the other side.
 
+- **resume_foreign**: `runtime:resume()` refuses an object of another class
+  instead of reading its private data as a Lua state.
+
+- **foreign_method**: `device:stop`, `notifier:stop`, `probe:stop`,
+  `probe:enable` and the `rcu.table` index metamethods refuse an object of
+  another class instead of reading its private data as their own.
+
+- **foreign_checker**: a method of every class a process runtime can
+  construct (`data`, `fifo`, `completion`, `set`, `crypto_shash`, `task`,
+  `runtime`), called through the class's metatable, refuses an object of
+  another class naming both classes, refuses `nil` and refuses a userdata
+  of another library; `rcu.map` refuses `nil`; and a method on a closed
+  runtime or fifo is refused instead of dereferencing its NULL private.
+
 - **resume_mailbox**: `completion` objects pass through `runtime:resume()`
   to enable the mailbox pattern. Sub-runtime sends via `fifo` +
   `completion`; main runtime receives.
@@ -220,6 +234,10 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
 - **require_cloneobject**: `lunatik_cloneobject` loads the class into
   the receiving runtime via `class->opener` (`luaL_requiref`), even when
   that runtime never called `require()` for the module.
+
+- **require_reopen**: a library opened again under another name (the
+  `_ENV` object registers `luarcu` as `rcu.table`, the script's `require`
+  as `rcu`) keeps the class metatables the first open created.
 
 - **percpu**: `run <script> percpu` registers one object holding a
   runtime per possible CPU id, and runs the script once per instance,

--- a/tests/runtime/foreign_checker.lua
+++ b/tests/runtime/foreign_checker.lua
@@ -1,0 +1,75 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the checker matrix test (see foreign_checker.sh).
+
+local lunatik    = require("lunatik")
+local data       = require("data")
+local fifo       = require("fifo")
+local completion = require("completion")
+local set        = require("set")
+local crypto     = require("crypto")
+local thread     = require("thread")
+local rcu        = require("rcu")
+local test       = require("util").test
+
+local SCRIPT <const> = "tests/runtime/resume_shared_recv"
+
+local cases = {
+	{name = "data",         object = data.new(8),                 foreign = fifo.new(16), method = "getuint8",   args = {0},
+		got = "fifo"},
+	{name = "fifo",         object = fifo.new(16),                foreign = data.new(8),  method = "push",       args = {"x"}},
+	{name = "completion",   object = completion.new(),            foreign = data.new(8),  method = "complete",   args = {}},
+	{name = "set",          object = set.new{"a"},                foreign = data.new(8),  method = "has",        args = {"a"}},
+	{name = "crypto_shash", object = crypto.shash("sha256"),  foreign = data.new(8),  method = "digestsize", args = {}},
+	{name = "task",         object = thread.current():task(),     foreign = data.new(8),  method = "pid",        args = {}},
+	{name = "runtime",      object = lunatik.runtime(SCRIPT),     foreign = data.new(8),  method = "resume",     args = {1}},
+}
+
+local function refused(what, method, object, ...)
+	local ok, err = pcall(method, object, ...)
+	assert(not ok, what .. " was accepted")
+	return err
+end
+
+for _, case in ipairs(cases) do
+	local method = getmetatable(case.object)[case.method]
+	local what = case.name .. ":" .. case.method
+	test(what .. " refuses an object of another class", function()
+		local err = refused(what, method, case.foreign, table.unpack(case.args))
+		assert(err:match(case.name .. " expected, got " .. (case.got or "data")), what .. " raised something else: " .. err)
+	end)
+	test(what .. " refuses a value that is no object", function()
+		local err = refused(what, method, nil, table.unpack(case.args))
+		assert(err:match("invalid object"), what .. " raised something else: " .. err)
+	end)
+	test(what .. " refuses a userdata of another library", function()
+		local err = refused(what, method, io.stdout, table.unpack(case.args))
+		assert(err:match("invalid object"), what .. " raised something else: " .. err)
+	end)
+end
+
+test("fifo:push refuses a closed fifo", function()
+	local queue = fifo.new(16)
+	queue:close()
+	local err = refused("fifo:push", getmetatable(queue).push, queue, "x")
+	assert(err:match("null pointer"), "push raised something else: " .. err)
+end)
+
+test("rcu.map refuses nil", function()
+	local err = refused("rcu.map", rcu.map, nil, function() end)
+	assert(err:match("invalid object"), "rcu.map raised something else: " .. err)
+end)
+
+test("runtime:resume refuses a closed runtime", function()
+	local runtime = lunatik.runtime(SCRIPT)
+	runtime:stop()
+	local err = refused("runtime:resume", getmetatable(runtime).resume, runtime, 1)
+	assert(err:match("null pointer"), "resume raised something else: " .. err)
+end)
+
+for _, case in ipairs(cases) do
+	if case.name == "runtime" then case.object:stop() end
+end
+

--- a/tests/runtime/foreign_checker.sh
+++ b/tests/runtime/foreign_checker.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for the checker matrix: a method of every class a process
+# runtime can construct (data, fifo, completion, set, crypto_shash, task,
+# runtime), called through the class's metatable, refuses an object of another
+# class naming both classes, which proves the metatables carry __name, refuses
+# nil and a userdata of another library (io's) as no object at all; rcu.map
+# refuses nil the same way; and a method on a closed runtime or fifo, whose
+# private is gone, is refused instead of dereferencing NULL.
+#
+# Usage: sudo bash tests/runtime/foreign_checker.sh
+
+SCRIPT="tests/runtime/foreign_checker"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+mark_dmesg
+run_script "$SCRIPT"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "every checker refuses another class, nil, a foreign userdata and a closed object"
+
+ktap_totals
+

--- a/tests/runtime/foreign_method.lua
+++ b/tests/runtime/foreign_method.lua
@@ -1,0 +1,42 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the method class check test (see foreign_method.sh).
+
+local device   = require("device")
+local notifier = require("notifier")
+local rcu      = require("rcu")
+local data     = require("data")
+local stat     = require("linux.stat")
+local test     = require("util").test
+
+local foreign = data.new(8)
+
+local function refused(name, method, ...)
+	local ok, err = pcall(method, foreign, ...)
+	assert(not ok, name .. " accepted a data object")
+	assert(err:match("expected"), name .. " raised something else: " .. err)
+end
+
+local function nop() end
+
+test("device:stop refuses an object of another class", function()
+	local driver = {name = "foreign_method", mode = stat.IRUGO, read = function() return "" end}
+	local dev = device.new(driver)
+	refused("device:stop", getmetatable(dev).stop)
+	dev:stop()
+end)
+
+test("notifier:stop refuses an object of another class", function()
+	local n = notifier.netdevice(nop)
+	refused("notifier:stop", getmetatable(n).stop)
+	n:stop()
+end)
+
+test("rcu.table index and newindex refuse an object of another class", function()
+	local t = rcu.table()
+	refused("rcu.table.__index", getmetatable(t).__index, "key")
+	refused("rcu.table.__newindex", getmetatable(t).__newindex, "key", 1)
+end)
+

--- a/tests/runtime/foreign_method.sh
+++ b/tests/runtime/foreign_method.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for the class check in methods that read private as their own
+# type: device:stop, notifier:stop, probe:stop, probe:enable and the rcu.table
+# index and newindex metamethods, each called on a data object through the
+# class's metatable, must be refused instead of reading the buffer as the class.
+# The probe methods run in their own hardirq script, the context probe.new requires.
+#
+# Usage: sudo bash tests/runtime/foreign_method.sh
+
+SCRIPT="tests/runtime/foreign_method"
+PROBE="tests/runtime/foreign_method_probe"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+	lunatik stop "$PROBE" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 2
+
+mark_dmesg
+run_script "$SCRIPT"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "the methods of device, notifier and rcu.table refuse an object of another class"
+
+mark_dmesg
+run_script "$PROBE" hardirq
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$PROBE" > /dev/null 2>&1
+ktap_pass "the probe methods refuse an object of another class"
+
+ktap_totals
+

--- a/tests/runtime/foreign_method_probe.lua
+++ b/tests/runtime/foreign_method_probe.lua
@@ -1,0 +1,29 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the method class check test, probe methods (see foreign_method.sh).
+
+local probe  = require("probe")
+local data   = require("data")
+local systab = require("syscall.table")
+local test   = require("util").test
+
+local foreign = data.new(8)
+
+local function refused(name, method, ...)
+	local ok, err = pcall(method, foreign, ...)
+	assert(not ok, name .. " accepted a data object")
+	assert(err:match("expected"), name .. " raised something else: " .. err)
+end
+
+local function nop() end
+
+test("probe methods refuse an object of another class", function()
+	local address = next(systab)
+	local p = probe.new(systab[address], {pre = nop})
+	refused("probe:stop", getmetatable(p).stop)
+	refused("probe:enable", getmetatable(p).enable, false)
+	p:stop()
+end)
+

--- a/tests/runtime/require_reopen.lua
+++ b/tests/runtime/require_reopen.lua
@@ -1,0 +1,15 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the library reopen test (see require_reopen.sh).
+
+local lunatik = require("lunatik")
+local rcu     = require("rcu")
+local test    = require("util").test
+
+test("a library opened again under another name keeps its classes", function()
+	assert(package.loaded["rcu.table"], "_ENV did not register the library under its class name")
+	assert(getmetatable(lunatik._ENV) == getmetatable(rcu.table()), "the second open replaced the class metatable")
+end)
+

--- a/tests/runtime/require_reopen.sh
+++ b/tests/runtime/require_reopen.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for a library opened twice in one state: the _ENV object
+# every runtime receives registers luarcu under its class name, rcu.table,
+# and the script's own require("rcu") opens it again under the module name.
+# The second open must keep the class metatables the first created, so an
+# object made before it and one made after share their metatable.
+#
+# Usage: sudo bash tests/runtime/require_reopen.sh
+
+SCRIPT="tests/runtime/require_reopen"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+mark_dmesg
+run_script "$SCRIPT"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "a library opened again under another name keeps its classes"
+
+ktap_totals
+

--- a/tests/runtime/resume_foreign.lua
+++ b/tests/runtime/resume_foreign.lua
@@ -1,0 +1,19 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the runtime class check test (see resume_foreign.sh).
+
+local lunatik = require("lunatik")
+local data    = require("data")
+local test    = require("util").test
+
+local SCRIPT <const> = "tests/runtime/resume_shared_recv"
+
+test("resume refuses an object of another class", function()
+	local runtime <close> = lunatik.runtime(SCRIPT)
+	local ok, err = pcall(getmetatable(runtime).resume, data.new(8))
+	assert(not ok, "resume accepted a data object")
+	assert(err:match("runtime expected"), "resume raised something else: " .. err)
+end)
+

--- a/tests/runtime/resume_foreign.sh
+++ b/tests/runtime/resume_foreign.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for the runtime class check: runtime:resume() called on an
+# object of another class (a data buffer here) must be refused, instead of
+# having its private data used as a Lua state.
+#
+# Usage: sudo bash tests/runtime/resume_foreign.sh
+
+SCRIPT="tests/runtime/resume_foreign"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+mark_dmesg
+run_script "$SCRIPT"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "runtime:resume refuses an object of another class"
+
+ktap_totals
+

--- a/tests/runtime/run.sh
+++ b/tests/runtime/run.sh
@@ -13,11 +13,15 @@ FAILED=0
 TESTS=(
 	refcnt_leak.sh
 	resume_shared.sh
+	resume_foreign.sh
+	foreign_method.sh
+	foreign_checker.sh
 	resume_mailbox.sh
 	rcu_shared.sh
 	opt_guards.sh
 	opt_skb_single.sh
 	require_cloneobject.sh
+	require_reopen.sh
 	percpu.sh
 	percpu_object.sh
 	percpu_refuse.sh


### PR DESCRIPTION
Today a Lua script crashes the kernel in two lines: `getmetatable(a).method(b)` makes the method read b's private as a's struct, and `rcu.map(nil, f)` dereferences NULL. The checkers tested `private != NULL` and never the class; the monitor covers eight of the fifteen classes and no SINGLE object.

Every checker now proves object, class and private in one place: `LUNATIK_PRIVATECHECKER(checker, T, &class)`, `LUNATIK_PRIVATECHECKERS` for a family of classes, `lunatik_argcheckclass(L, ix, object, &class)` where a method needs the object too. Type errors quote the class name; `runtime` and `rcu.table` get theirs, and a library opened twice under two names keeps its classes. Tests: `foreign_checker` (every class a process runtime constructs, with another class, `nil` and a closed object), `foreign_method`, `resume_foreign`, `require_reopen`.

Conflicts with #782 in `lunatik_checkruntimes`; rebased after it.
