### PR TITLE
harness: what to do before asking for a reboot, and after it

### DIFF
--- a/.agents/skills/lunatik-cycle/SKILL.md
+++ b/.agents/skills/lunatik-cycle/SKILL.md
@@ -41,3 +41,28 @@ idle system is the driver runtime's require-pins (a kernel `require()` pins the 
 until that state's `lua_close`). `/sys/module/X/holders` lists only symbol dependencies, not
 require-pins; `refcnt` is the complete in-degree.
 
+# A wedged device: before and after the reboot
+
+A `lunatik` process in D state does not come back, and the reboot that clears it is the
+maintainer's call (AGENTS.md, "Build, install, test"). Before asking for it:
+
+    ps -eo pid,stat,etime,cmd | awk '$2 ~ /D/'          # confirm, and note the PID
+    tools/oops.sh > scratch/oops-$(date +%F).txt         # dmesg block, faulting instructions, D-state processes
+
+Then write down (memory or scratch) which tree `make install` last ran from and its HEAD, the
+suites not yet run, and the branches whose tests were interrupted. Run no further `lunatik`
+command; the D-state child cannot be killed and every new one queues behind it.
+
+After the reboot, in this order:
+
+    uname -r                                             # a kernel upgrade may have come with it
+    sudo apt install linux-headers-$(uname -r) linux-tools-$(uname -r)
+    git worktree prune                                   # scratch worktrees under /tmp are gone
+    git worktree add <scratch>/w<name> <ref> && git -C <scratch>/w<name> submodule update --init
+    make clean && sudo make btf_install && make && sudo make install && sudo lunatik reload
+    sudo lunatik test <the suite that oopsed>            # twice
+
+A second oops is the bug, traced from `scratch/oops-*.txt`; a clean pair means the trigger
+was state the reboot cleared, reported as untraced. Then the pending list, in the order the
+branches stack.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,19 @@ Use `sudo make install`, not the partial `*_install` targets. Use `sudo lunatik 
 
 After a kernel upgrade the installed modules were built for the previous kernel and fail to load with
 `Exec format error` (a vermagic mismatch). Reinstall the headers, `make clean && make`, and reinstall
-before the next `reload`.
+before the next `reload`. The eBPF modules also need the running kernel's BTF at build time,
+`sudo make btf_install` before `make`, or they log `missing module BTF, cannot register kfuncs` and
+do not load; and the `bpftool` wrapper needs `linux-tools-$(uname -r)`, or every BPF program fails
+to load.
+
+A wedged device — a `lunatik` process in D state, usually below an oops in `dmesg` — is cleared only
+by a reboot, and the reboot is the maintainer's to trigger: other sessions share the host. Before
+asking, capture what the reboot erases with `tools/oops.sh > scratch/oops-<date>.txt` (`dmesg` and
+`/tmp` do not survive it), write down which suites were pending and which build was installed, and
+run nothing else against the device. After it, the kernel may have changed, `/tmp` scratch worktrees
+are gone (`git worktree prune`), and every tree is rebuilt from clean; the lunatik-cycle skill
+orders both halves. The suite that oopsed runs twice: a second oops is a bug to trace, a clean pair
+is a symptom without its cause, said as such.
 
 Never run two `lunatik` operations at once. Concurrent operations wedge `/dev/lunatik` and leave
 processes in D state. Check with `ps` before starting one.

--- a/tests/tc/Makefile
+++ b/tests/tc/Makefile
@@ -3,7 +3,7 @@
 
 all: tc_pass.bpf.o tc_drop.bpf.o tc_detach.bpf.o tc_zerokey.bpf.o tc_reattach.bpf.o
 
-vmlinux.h:
+vmlinux.h: /sys/kernel/btf/vmlinux
 	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $@
 
 tc_pass.bpf.o: tc_pass.bpf.c vmlinux.h

--- a/tests/xdp/Makefile
+++ b/tests/xdp/Makefile
@@ -3,7 +3,7 @@
 
 all: xdp_pass.bpf.o xdp_drop.bpf.o xdp_detach.bpf.o xdp_zerokey.bpf.o xdp_process.bpf.o xdp_percpu.bpf.o
 
-vmlinux.h:
+vmlinux.h: /sys/kernel/btf/vmlinux
 	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $@
 
 xdp_pass.bpf.o: xdp_pass.bpf.c vmlinux.h

--- a/tools/oops.sh
+++ b/tools/oops.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Captures the last kernel oops before a reboot takes it away: the dmesg block from the fault
+# to "end trace", the instructions around the faulting one in the installed module, and the
+# processes left in D state. Prints to stdout; keep it under scratch/, not /tmp, which the
+# reboot clears too.
+# Usage: tools/oops.sh [dmesg-dump] > scratch/oops-$(date +%F).txt
+
+src="$1"
+
+dump() {
+	if [ -n "$src" ]; then cat "$src"; else dmesg; fi
+}
+
+block=$(dump | awk '/Unable to handle|BUG: |Internal error/ { f=1 } f { print } /end trace/ { f=0 }')
+[ -n "$block" ] || { echo "no oops in dmesg" >&2; exit 1; }
+echo "$block"
+
+pc=$(echo "$block" | sed -n 's/.*pc : \([A-Za-z0-9_]*\)+0x\([0-9a-f]*\)\/0x[0-9a-f]* \[\([A-Za-z0-9_]*\)\].*/\1 \2 \3/p' | head -1)
+if [ -n "$pc" ]; then
+	read -r sym off mod <<< "$pc"
+	ko=$(modinfo -n "$mod" 2>/dev/null)
+	if [ -n "$ko" ] && command -v objdump > /dev/null 2>&1; then
+		echo
+		echo "== $mod: $sym+0x$off in $ko (the installed build; it must be the one that crashed)"
+		listing=$(objdump -d --no-show-raw-insn "$ko" | awk -v s="<$sym>:" '$0 ~ s { f=1 } f && /^$/ { exit } f')
+		base=$(echo "$listing" | head -1 | cut -d' ' -f1)
+		target=$(printf '%x' $((16#$base + 16#$off)))
+		echo "$listing" | grep -n -E "^ *$target:" | cut -d: -f1 | head -1 | while read -r n; do
+			echo "$listing" | sed -n "$((n > 8 ? n - 8 : 1)),$((n + 4))p" | sed "s/^ *$target:/=> &/"
+		done
+	fi
+fi
+
+echo
+echo "== processes in D state"
+ps -eo pid,stat,etime,cmd | awk '$2 ~ /D/'
+


### PR DESCRIPTION
On top of #775. A kernel oops left the device with a process in D state, and the protocol around it was improvised: the dmesg block read by hand, the faulting instruction found by disassembling the module afterwards, and the reboot brought a kernel upgrade whose headers, BTF and bpftool surfaced as three separate failures (`Exec format error`, `missing module BTF, cannot register kfuncs`, every BPF program refusing to load until `linux-tools-$(uname -r)` was installed).

`tools/oops.sh` captures the dmesg block, the instructions around the fault in the installed module and the D-state processes in one go, before the reboot erases `dmesg` and `/tmp`; `AGENTS.md` carries the rule, the reboot being the maintainer's call, and the lunatik-cycle skill orders both halves. The second commit makes the test `vmlinux.h` depend on `/sys/kernel/btf/vmlinux`, stamped at boot, so a reboot into another kernel regenerates it.

Checked here: the script on the saved trace of the oops finds `luarcu_map+0x40` and prints the `ldr x0, [x0]` after `lua_touserdata` returned NULL; the header rebuilds when older than the BTF and stays put otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
