### PR TITLE
tests: the tc and xdp callbacks act only on the ping

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -307,9 +307,9 @@ BTF, or `bpftool`, `clang` or `tc` is unavailable.
 - **tc pass**: the callback inspects `ctx:skb()` (IPv4 ethertype and the
   ICMP protocol byte of the ping) and `ctx:argument()` (a magic word the
   eBPF program passed through), and `action.ACT_OK` lets the packet reach
-  its destination; only the ping is verified, since the namespace emits
-  autoconf traffic of its own; the runtime is plain, covering the plain-name
-  kfunc lookup.
+  its destination; the runtime is plain, covering the plain-name kfunc lookup.
+  Every callback that reads the packet acts only on the ping, through the
+  suite's `packet.isping`, since the namespace emits autoconf traffic of its own.
 
 - **tc drop**: `action.ACT_SHOT` blocks the ping; the runtime is percpu,
   covering the dispatch to a percpu instance.
@@ -319,8 +319,9 @@ BTF, or `bpftool`, `clang` or `tc` is unavailable.
   the re-attach path.
 
 - **tc detach**: the callback drops the first ping and calls `tc.detach()`
-  from inside the callback; traffic resumes because `bpf_luatc_run` then
-  returns `-1` and the eBPF program falls back to `TC_ACT_OK`.
+  from inside the callback, letting other traffic through; traffic resumes
+  because `bpf_luatc_run` then returns `-1` and the eBPF program falls back
+  to `TC_ACT_OK`.
 
 - **tc attach**: `tc.attach` refuses a sleepable runtime with "runtime
   context mismatch".
@@ -368,8 +369,9 @@ BTF, or `bpftool` or `clang` is unavailable.
   covering the dispatch to a percpu instance.
 
 - **xdp detach**: the callback drops the first ping and calls `xdp.detach()`
-  from inside the callback; traffic resumes because `bpf_luaxdp_run` then
-  returns `-1` and the eBPF program falls back to `XDP_PASS`.
+  from inside the callback, letting other traffic through; traffic resumes
+  because `bpf_luaxdp_run` then returns `-1` and the eBPF program falls back
+  to `XDP_PASS`.
 
 - **xdp attach**: `xdp.attach` refuses a sleepable runtime with "runtime
   context mismatch".

--- a/tests/tc/detach.lua
+++ b/tests/tc/detach.lua
@@ -4,10 +4,15 @@
 --
 -- Kernel-side script for the tc verdict test (see test_tc.sh).
 
-local tc    = require("tc")
+local tc     = require("tc")
 local action = require("linux.tc")
+local packet = require("tests.tc.packet")
 
 local function drop_then_detach(ctx)
+	if not packet.isping(ctx:skb():data()) then
+		ctx:action(action.ACT_OK)
+		return
+	end
 	ctx:action(action.ACT_SHOT)
 	tc.detach()
 	print("tc detach test pass: verdict set and callback detached")

--- a/tests/tc/packet.lua
+++ b/tests/tc/packet.lua
@@ -1,0 +1,23 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Packet predicates for the tc test callbacks: the namespace emits IPv6 autoconf traffic of
+-- its own, so a callback acts only on the ping, which the host's egress carries as the echo reply.
+
+local ETH_HI    <const> = 12 -- ethertype, then IPv4 protocol, then ICMP type
+local ETH_LO    <const> = 13
+local IPPROTO   <const> = 23
+local ICMPTYPE  <const> = 34
+local ICMP      <const> = 1
+local ECHOREPLY <const> = 0
+
+local packet = {}
+
+function packet.isping(data)
+	return data:getuint8(ETH_HI) == 0x08 and data:getuint8(ETH_LO) == 0x00 and data:getuint8(IPPROTO) == ICMP and
+		data:getuint8(ICMPTYPE) == ECHOREPLY
+end
+
+return packet
+

--- a/tests/tc/pass.lua
+++ b/tests/tc/pass.lua
@@ -7,19 +7,13 @@
 local tc      = require("tc")
 local action  = require("linux.tc")
 local skbattr = require("skb.attr")
+local packet  = require("tests.tc.packet")
 
-local MAGIC    <const> = 0x4C554E41 -- matches tc_pass.bpf.c
-local ETH_HI   <const> = 12 -- ethertype, then IPv4 protocol
-local ETH_LO   <const> = 13
-local IPPROTO  <const> = 23
-local ICMP     <const> = 1
+local MAGIC <const> = 0x4C554E41 -- matches tc_pass.bpf.c
 
 local function test_pass(ctx)
-	local raw  = ctx:skb()
-	local data = raw:data()
-	-- the namespace also emits IPv6 autoconf traffic, from a context the test does not control
-	if data:getuint8(ETH_HI) == 0x08 and data:getuint8(ETH_LO) == 0x00
-			and data:getuint8(IPPROTO) == ICMP then
+	local raw = ctx:skb()
+	if packet.isping(raw:data()) then
 		local skb = skbattr.new(raw)
 		skb.priority = 0x1234 -- exercise the attribute accessors
 		skb.mark = 0xabcd

--- a/tests/tc/test_tc.sh
+++ b/tests/tc/test_tc.sh
@@ -101,7 +101,6 @@ run_case()
 
 	mark_dmesg
 	run_script "tests/tc/$script" "$@"
-	check_dmesg || { ktap_fail "$label: script raised an error"; return 1; }
 
 	# egress from the host toward the namespaced peer is what the classifier sees
 	ip netns exec "$NETNS" ping -c 1 -W 2 "$HOST" > /dev/null 2>&1
@@ -110,6 +109,7 @@ run_case()
 	tc_unload
 	lunatik stop "tests/tc/${script%.lua}" > /dev/null 2>&1
 
+	check_dmesg || { ktap_fail "$label: script raised an error"; return 1; }
 	dmesg_since | grep -qF "$label test fail" && { ktap_fail "$label: callback reported a failure"; return 1; }
 	dmesg_since | grep -qF "$label test pass" || { ktap_fail "$label: verdict callback did not run"; return 1; }
 
@@ -130,16 +130,18 @@ detach_case()
 
 	mark_dmesg
 	run_script "tests/tc/detach" softirq
-	check_dmesg || { ktap_fail "tc detach: script raised an error"; return 1; }
 
-	ip netns exec "$NETNS" ping -c 1 -W 2 "$HOST" > /dev/null 2>&1 &&
-		{ ktap_fail "tc detach: the first ping should have been dropped"; return 1; }
-	ip netns exec "$NETNS" ping -c 1 -W 2 "$HOST" > /dev/null 2>&1 ||
-		{ ktap_fail "tc detach: traffic did not resume after detach"; return 1; }
+	ip netns exec "$NETNS" ping -c 1 -W 2 "$HOST" > /dev/null 2>&1
+	local dropped=$?
+	ip netns exec "$NETNS" ping -c 1 -W 2 "$HOST" > /dev/null 2>&1
+	local resumed=$?
 
 	tc_unload
 	lunatik stop tests/tc/detach > /dev/null 2>&1
 
+	check_dmesg || { ktap_fail "tc detach: script raised an error"; return 1; }
+	[ "$dropped" -ne 0 ] || { ktap_fail "tc detach: the first ping should have been dropped"; return 1; }
+	[ "$resumed" -eq 0 ] || { ktap_fail "tc detach: traffic did not resume after detach"; return 1; }
 	dmesg_since | grep -qF "tc detach test pass" || { ktap_fail "tc detach: callback did not run"; return 1; }
 	ktap_pass "tc detach: callback stops firing and traffic resumes"
 }

--- a/tests/xdp/detach.lua
+++ b/tests/xdp/detach.lua
@@ -6,8 +6,13 @@
 
 local xdp    = require("xdp")
 local action = require("linux.xdp")
+local packet = require("tests.xdp.packet")
 
 local function drop_then_detach(ctx)
+	if not packet.isping(ctx:packet()) then
+		ctx:action(action.PASS)
+		return
+	end
 	ctx:action(action.DROP)
 	xdp.detach()
 	print("xdp detach test pass: verdict set and callback detached")

--- a/tests/xdp/packet.lua
+++ b/tests/xdp/packet.lua
@@ -1,0 +1,23 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Packet predicates for the xdp test callbacks: the namespace emits IPv6 autoconf traffic of
+-- its own, so a callback acts only on the ping.
+
+local ETH_HI   <const> = 12 -- ethertype, then IPv4 protocol, then ICMP type
+local ETH_LO   <const> = 13
+local IPPROTO  <const> = 23
+local ICMPTYPE <const> = 34
+local ICMP     <const> = 1
+local ECHO     <const> = 8
+
+local packet = {}
+
+function packet.isping(data)
+	return data:getuint8(ETH_HI) == 0x08 and data:getuint8(ETH_LO) == 0x00 and data:getuint8(IPPROTO) == ICMP and
+		data:getuint8(ICMPTYPE) == ECHO
+end
+
+return packet
+

--- a/tests/xdp/pass.lua
+++ b/tests/xdp/pass.lua
@@ -6,17 +6,12 @@
 
 local xdp    = require("xdp")
 local action = require("linux.xdp")
+local packet = require("tests.xdp.packet")
 
-local MAGIC    <const> = 0x4C554E41 -- matches xdp_pass.bpf.c
-local ETH_HI   <const> = 12 -- ethertype, then IPv4 protocol
-local ETH_LO   <const> = 13
-local IPPROTO  <const> = 23
-local ICMP     <const> = 1
+local MAGIC <const> = 0x4C554E41 -- matches xdp_pass.bpf.c
 
 local function test_pass(ctx)
-	local packet = ctx:packet()
-	if packet:getuint8(ETH_HI) == 0x08 and packet:getuint8(ETH_LO) == 0x00
-			and packet:getuint8(IPPROTO) == ICMP then
+	if packet.isping(ctx:packet()) then
 		if ctx:argument():getuint32(0) == MAGIC then
 			print("xdp pass test pass: packet and argument content verified")
 		else

--- a/tests/xdp/percpu.lua
+++ b/tests/xdp/percpu.lua
@@ -7,19 +7,12 @@
 local lunatik = require("lunatik")
 local xdp     = require("xdp")
 local action  = require("linux.xdp")
-
-local ETH_HI  <const> = 12 -- ethertype, then IPv4 protocol
-local ETH_LO  <const> = 13
-local IPPROTO <const> = 23
-local ICMP    <const> = 1
+local packet  = require("tests.xdp.packet")
 
 local cpu = lunatik.cpu()
 
 local function test_percpu(ctx)
-	local packet = ctx:packet()
-	-- the namespace also emits IPv6 autoconf traffic, from a context the test does not pin
-	if packet:getuint8(ETH_HI) == 0x08 and packet:getuint8(ETH_LO) == 0x00
-			and packet:getuint8(IPPROTO) == ICMP then
+	if packet.isping(ctx:packet()) then
 		print("xdp percpu test hit: cpu " .. cpu)
 	end
 	ctx:action(action.PASS)

--- a/tests/xdp/test_xdp.sh
+++ b/tests/xdp/test_xdp.sh
@@ -87,7 +87,6 @@ run_case()
 
 	mark_dmesg
 	run_script "tests/xdp/$script" "$@"
-	check_dmesg || { ktap_fail "$label: script raised an error"; return 1; }
 
 	ip netns exec "$NETNS" ping -c 1 -W 2 "$TARGET" > /dev/null 2>&1
 	local reached=$?
@@ -96,6 +95,7 @@ run_case()
 	rm -f "$pin"
 	lunatik stop "tests/xdp/${script%.lua}" > /dev/null 2>&1
 
+	check_dmesg || { ktap_fail "$label: script raised an error"; return 1; }
 	dmesg_since | grep -qF "$label test fail" && { ktap_fail "$label: callback reported a failure"; return 1; }
 	dmesg_since | grep -qF "$label test pass" || { ktap_fail "$label: verdict callback did not run"; return 1; }
 
@@ -118,17 +118,19 @@ detach_case()
 
 	mark_dmesg
 	run_script "tests/xdp/detach" softirq
-	check_dmesg || { ktap_fail "xdp detach: script raised an error"; return 1; }
 
-	ip netns exec "$NETNS" ping -c 1 -W 2 "$TARGET" > /dev/null 2>&1 &&
-		{ ktap_fail "xdp detach: the first ping should have been dropped"; return 1; }
-	ip netns exec "$NETNS" ping -c 1 -W 2 "$TARGET" > /dev/null 2>&1 ||
-		{ ktap_fail "xdp detach: traffic did not resume after detach"; return 1; }
+	ip netns exec "$NETNS" ping -c 1 -W 2 "$TARGET" > /dev/null 2>&1
+	local dropped=$?
+	ip netns exec "$NETNS" ping -c 1 -W 2 "$TARGET" > /dev/null 2>&1
+	local resumed=$?
 
 	bpftool net detach xdp dev "$IFACE" 2>/dev/null
 	rm -f "${PIN}_detach"
 	lunatik stop tests/xdp/detach > /dev/null 2>&1
 
+	check_dmesg || { ktap_fail "xdp detach: script raised an error"; return 1; }
+	[ "$dropped" -ne 0 ] || { ktap_fail "xdp detach: the first ping should have been dropped"; return 1; }
+	[ "$resumed" -eq 0 ] || { ktap_fail "xdp detach: traffic did not resume after detach"; return 1; }
 	dmesg_since | grep -qF "xdp detach test pass" || { ktap_fail "xdp detach: callback did not run"; return 1; }
 	ktap_pass "xdp detach: callback stops firing and traffic resumes"
 }
@@ -192,13 +194,13 @@ percpu_case()
 
 	mark_dmesg
 	run_script "tests/xdp/percpu" softirq percpu
-	check_dmesg || { ktap_fail "xdp percpu: script raised an error"; return 1; }
 	taskset -c "$cpu" ip netns exec "$NETNS" ping -c 3 -W 2 "$TARGET" > /dev/null 2>&1
 
 	bpftool net detach xdp dev "$IFACE" 2>/dev/null
 	rm -f "${PIN}_percpu"
 	lunatik stop tests/xdp/percpu > /dev/null 2>&1
 
+	check_dmesg || { ktap_fail "xdp percpu: script raised an error"; return 1; }
 	hits=$(dmesg_since | grep -o "xdp percpu test hit: cpu [0-9]*" | sort -u)
 	[ -n "$hits" ] || { ktap_fail "xdp percpu: the callback did not run"; return 1; }
 	[ "$hits" = "xdp percpu test hit: cpu $cpu" ] ||


### PR DESCRIPTION
Follows #774, which landed the tc pass case only. The namespace peer emits neighbor solicitations, MLD reports and router solicitations on its own during the first seconds after link up (captured here at about 0, 0.3, 1.1 and 2.0 s), and the `detach` cases of both suites spend their one detach on whatever arrives first. Each suite gets a `packet.isping` predicate and every callback that reads the packet acts only on the ping: `tc pass`, `tc detach`, `xdp pass`, `xdp percpu`, `xdp detach`. The predicate reads the ICMP type as well, echo request on the xdp receive path and echo reply on the tc egress path, so a reply the namespace sends to host traffic does not count either.

A case that failed between attaching its program and its teardown also returned with the program still attached and its script still running, and every case after it failed to attach: one stray packet became four failures. Each case now tears down before it reads its result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
