### PR TITLE
percpu: the instances share data the object tears down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,11 @@ does — the socket layer does not check `kthread_should_stop()`. To wait indefi
 * Objects a C module pre allocates but exposes to Lua use `lunatik_createobject` plus
   `lunatik_cloneobject`, which requires `.shared = true`.
 
+A registration a percpu script makes once for all its instances, a hook or a kernel thread, lives
+in the private of an object from `lunatik_percpudata`, of a class the binding declares for it, whose
+`release` the percpu object runs before closing the instances. A binding that keeps a global list
+or a use count of its own to find what the other instances registered is doing the object's job.
+
 The registry pattern for a reusable per hook object (`lunatik_getregistry`, reset, pass to Lua, clear
 afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than inventing a variant.
 

--- a/Kbuild
+++ b/Kbuild
@@ -33,7 +33,7 @@ lunatik-objs += lua/lapi.o lua/lcode.o lua/lctype.o lua/ldebug.o lua/ldo.o \
 	lua/lcorolib.o lua/ldblib.o lua/lstrlib.o \
 	lua/ltablib.o lua/lutf8lib.o lua/lmathlib.o lua/liolib.o lua/linit.o \
 	lua/loadlib.o $(KLIBC_USR)/klibc/arch/$(KLIBC_ARCH)/setjmp.o \
-	lunatik_aux.o lunatik_obj.o lunatik_val.o lunatik_core.o
+	lunatik_aux.o lunatik_obj.o lunatik_val.o lunatik_core.o lunatik_percpu.o
 
 ifeq ($(CONFIG_64BIT),)
 lunatik-objs += $(KLIBC_LIBGCC)/__udivmoddi4.o	\

--- a/config.ld
+++ b/config.ld
@@ -33,6 +33,7 @@ file = {
 	'./lib/luahid.c',
 	'./lib/lighten.lua',
 	'./lunatik_core.c',
+	'./lunatik_percpu.c',
 	'./lib/lunatik/runner.lua',
 	'./lib/lualinux.c',
 	'./lib/linux',

--- a/doc/capi.md
+++ b/doc/capi.md
@@ -312,8 +312,15 @@ private`.
 void lunatik_argcheckclass(lua_State *L, int ix, lunatik_object_t *object, const lunatik_class_t *cls);
 ```
 Raises a type error naming `cls->name` unless `object`, the Lunatik object at `ix`, is of that
-class. For a method that needs the object itself, not only its private: `lunatik_checkobject`
-followed by this check is what the checkers above do. Defined as a macro.
+class. Defined as a macro.
+
+### lunatik\_checkobjectclass
+```C
+lunatik_object_t *lunatik_checkobjectclass(lua_State *L, int ix, const lunatik_class_t *cls);
+```
+Returns the Lunatik object at `ix` after proving it is one and is of the class `cls`, raising a
+Lua error otherwise: the checkers above, for a method that needs the object itself, not only its
+private.
 
 ---
 

--- a/doc/capi.md
+++ b/doc/capi.md
@@ -8,11 +8,13 @@
 
 ### lunatik\_class\_t
 ```C
+typedef void (*lunatik_release_t)(void *);
+
 typedef struct lunatik_class_s {
-	const char     *name;
-	const luaL_Reg *methods;
-	void          (*release)(void *);
-	lunatik_opt_t   opt;
+	const char        *name;
+	const luaL_Reg    *methods;
+	lunatik_release_t  release;
+	lunatik_opt_t      opt;
 } lunatik_class_t;
 ```
 Describes a Lunatik object class.
@@ -187,6 +189,22 @@ Returns the runtime associated with `L` and raises a Lua error if its context do
 `softirq` runtime, a HARDIRQ class in a `hardirq` runtime, and a process-context class in a
 process runtime. Typically called from `lunatik_new*` functions to enforce that a class is
 only instantiated in a compatible runtime.
+
+### lunatik\_percpudata
+```C
+lunatik_object_t *lunatik_percpudata(lua_State *L, const lunatik_class_t *class, size_t size);
+```
+Returns the object of `class` a `percpu` object holds for its instances: the first instance to ask
+creates it, as `lunatik_createobject(class, size, LUNATIK_OPT_NONE)` does, with its private zeroed;
+the following ones get the same object, so every instance sees one. The `percpu` object owns it:
+`percpu:stop()` closes it (`lunatik_closeprivate`, which runs the class's `release` in process
+context) before closing the instances, then drops it, and an object with such data outstanding is
+released by `stop`, never by collection. A registration a script makes once for all its instances,
+a netfilter hook, say, lives in the private of such an object, with the class's `release`
+unregistering it. Only the script body may ask, while the instance loads; it raises a Lua error
+afterwards. Returns `NULL` on a plain runtime, which has no instances to share with;
+`lunatik_getpercpu(L)` tells the two apart, returning the `percpu` object owning the instance `L`,
+or `NULL`.
 
 ---
 

--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -260,8 +260,7 @@ static const lunatik_class_t luadevice_class;
 
 static int luadevice_stop(lua_State *L)
 {
-	lunatik_object_t *object = lunatik_checkobject(L, 1);
-	lunatik_argcheckclass(L, 1, object, &luadevice_class);
+	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luadevice_class);
 	luadevice_t *luadev = (luadevice_t *)object->private;
 
 	lunatik_lock(object);

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -120,8 +120,7 @@ static const lunatik_class_t luaprobe_class;
 
 static int luaprobe_stop(lua_State *L)
 {
-	lunatik_object_t *object = lunatik_checkobject(L, 1);
-	lunatik_argcheckclass(L, 1, object, &luaprobe_class);
+	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luaprobe_class);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
 
 	luaprobe_delete(probe);
@@ -139,8 +138,7 @@ static int luaprobe_stop(lua_State *L)
 */
 static int luaprobe_enable(lua_State *L)
 {
-	lunatik_object_t *object = lunatik_checkobject(L, 1);
-	lunatik_argcheckclass(L, 1, object, &luaprobe_class);
+	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luaprobe_class);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
 	struct kprobe *kp = &probe->kp;
 	bool enable = lua_toboolean(L, 2);

--- a/lib/luarcu.c
+++ b/lib/luarcu.c
@@ -162,8 +162,7 @@ EXPORT_SYMBOL(luarcu_setvalue);
 */
 static int luarcu_index(lua_State *L)
 {
-	lunatik_object_t *table = lunatik_checkobject(L, 1);
-	lunatik_argcheckclass(L, 1, table, &luarcu_class);
+	lunatik_object_t *table = lunatik_checkobjectclass(L, 1, &luarcu_class);
 	size_t keylen;
 	const char *key = luaL_checklstring(L, 2, &keylen);
 	lunatik_value_t value;
@@ -183,8 +182,7 @@ static int luarcu_index(lua_State *L)
 */
 static int luarcu_newindex(lua_State *L)
 {
-	lunatik_object_t *table = lunatik_checkobject(L, 1);
-	lunatik_argcheckclass(L, 1, table, &luarcu_class);
+	lunatik_object_t *table = lunatik_checkobjectclass(L, 1, &luarcu_class);
 	size_t keylen;
 	const char *key = luaL_checklstring(L, 2, &keylen);
 

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -171,8 +171,7 @@ static const lunatik_class_t luathread_class = {
 static int luathread_run(lua_State *L)
 {
 	luaL_argcheck(L, lunatik_isready(lunatik_toruntime(L)), 1, "not allowed during module load");
-	lunatik_object_t *runtime = lunatik_checkobject(L, 1);
-	lunatik_argcheckclass(L, 1, runtime, &lunatik_class);
+	lunatik_object_t *runtime = lunatik_checkobjectclass(L, 1, &lunatik_class);
 	luaL_argcheck(L, !lunatik_isirq(runtime->opt), 1, "IRQ runtime cannot spawn threads");
 	const char *name = luaL_checkstring(L, 2);
 	lunatik_object_t *object = luathread_new(L);

--- a/lunatik.h
+++ b/lunatik.h
@@ -322,7 +322,7 @@ static inline lunatik_object_t **lunatik_testobject(lua_State *L, int ix)
 static inline lunatik_object_t **lunatik_checkpobject(lua_State *L, int ix)
 {
 	lunatik_object_t **pobject = lunatik_testobject(L, ix);
-	luaL_argcheck(L, pobject, ix, "invalid object");
+	luaL_argcheck(L, pobject != NULL, ix, "invalid object");
 	return pobject;
 }
 

--- a/lunatik.h
+++ b/lunatik.h
@@ -255,6 +255,7 @@ void lunatik_monitorobject(lua_State *L, const lunatik_class_t *class);
 #define lunatik_argchecknull(L, o, i)	luaL_argcheck((L), (o) != NULL, (i), LUNATIK_ERR_NULLPTR)
 #define lunatik_argcheckclass(L, ix, object, cls)	\
 	luaL_argexpected((L), (object)->class == (cls), (ix), (cls)->name)
+
 #define lunatik_checkobject(L, i)	(*lunatik_checkpobject((L), (i)))
 #define lunatik_toobject(L, i)		(*(lunatik_object_t **)lua_touserdata((L), (i)))
 #define lunatik_getobject(o)		kref_get(&(o)->kref)
@@ -324,6 +325,13 @@ static inline lunatik_object_t **lunatik_checkpobject(lua_State *L, int ix)
 	lunatik_object_t **pobject = lunatik_testobject(L, ix);
 	luaL_argcheck(L, pobject != NULL, ix, "invalid object");
 	return pobject;
+}
+
+static inline lunatik_object_t *lunatik_checkobjectclass(lua_State *L, int ix, const lunatik_class_t *cls)
+{
+	lunatik_object_t *object = lunatik_checkobject(L, ix);
+	lunatik_argcheckclass(L, ix, object, cls);
+	return object;
 }
 
 #define LUNATIK_CLASSES(name, ...)	\

--- a/lunatik.h
+++ b/lunatik.h
@@ -7,8 +7,6 @@
 #define lunatik_h
 
 #include <linux/mutex.h>
-#include <linux/percpu.h>
-#include <linux/preempt.h>
 #include <linux/spinlock.h>
 #include <linux/slab.h>
 #include <linux/mm.h>
@@ -55,9 +53,6 @@ do {									\
 
 #define lunatik_extra(L)	((lunatik_runtime_t *)lua_getextraspace(L))
 #define lunatik_toruntime(L)	(lunatik_extra(L)->runtime)
-#define LUNATIK_CPU_NONE	(-1)
-#define lunatik_getcpu(L)	(lunatik_extra(L)->cpu)
-#define lunatik_hascpu(L)	(lunatik_getcpu(L) != LUNATIK_CPU_NONE)
 
 #define lunatik_cannotsleep(L, s)	((s) && lunatik_isirq(lunatik_toruntime(L)->opt))
 
@@ -107,31 +102,6 @@ typedef struct lunatik_object_s {
 	unsigned long flags;
 } lunatik_object_t;
 
-#define lunatik_percpuruntimes(p)	((lunatik_object_t * __percpu __force *)(p))
-
-static inline lunatik_object_t *lunatik_pin(lunatik_object_t *object)
-{
-	if (likely(!lunatik_ispercpu(object->opt)))
-		return object;
-
-	if (lunatik_isirq(object->opt))
-		preempt_disable();
-	else /* a process instance may sleep */
-		migrate_disable();
-	return *this_cpu_ptr(lunatik_percpuruntimes(object->private));
-}
-
-static inline void lunatik_unpin(lunatik_object_t *object)
-{
-	if (likely(!lunatik_ispercpu(object->opt)))
-		return;
-
-	if (lunatik_isirq(object->opt))
-		preempt_enable();
-	else
-		migrate_enable();
-}
-
 extern lunatik_object_t *lunatik_env;
 extern const lunatik_class_t lunatik_class;
 
@@ -147,6 +117,7 @@ static inline int lunatik_trylock(lunatik_object_t *object)
 }
 
 int lunatik_runtime(lunatik_object_t **pruntime, const char *script, lunatik_opt_t opt);
+int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt, int cpu);
 int lunatik_stop(lunatik_object_t *runtime);
 
 static inline int lunatik_nop(lua_State *L)
@@ -219,15 +190,8 @@ static inline void lunatik_checkfield(lua_State *L, int idx, const char *field, 
 #define LUNATIK_ERR_METATABLE	"metatable not found"
 #define LUNATIK_ERR_CONTEXT	"process-context class in interrupt-context runtime"
 #define LUNATIK_ERR_RUNTIME	"runtime context mismatch"
-#define LUNATIK_ERR_PERCPU	"not allowed in a percpu runtime"
 
 #define lunatik_context(opt)	((opt) & (LUNATIK_OPT_SOFTIRQ | LUNATIK_OPT_HARDIRQ))
-
-static inline void lunatik_checkpercpu(lua_State *L)
-{
-	if (lunatik_hascpu(L))
-		luaL_error(L, LUNATIK_ERR_PERCPU);
-}
 
 static inline lunatik_object_t *lunatik_checkruntime(lua_State *L, lunatik_opt_t opt)
 {
@@ -235,6 +199,14 @@ static inline lunatik_object_t *lunatik_checkruntime(lua_State *L, lunatik_opt_t
 	if (lunatik_context(runtime->opt) != lunatik_context(opt))
 		luaL_error(L, LUNATIK_ERR_RUNTIME);
 	return runtime;
+}
+
+static inline lunatik_opt_t lunatik_checkcontext(lua_State *L, int ix)
+{
+	static const char *const contexts[] = {"process", "softirq", "hardirq", NULL};
+	static const lunatik_opt_t opts[] = {LUNATIK_OPT_NONE, LUNATIK_OPT_SOFTIRQ, LUNATIK_OPT_HARDIRQ};
+
+	return opts[luaL_checkoption(L, ix, "process", contexts)];
 }
 
 #define lunatik_setruntime(L, libname, priv)	((priv)->runtime = lunatik_checkruntime((L), lua##libname##_class.opt))
@@ -498,6 +470,7 @@ do {								\
 } while (0)
 
 #include "lunatik_val.h"
+#include "lunatik_percpu.h"
 
 #endif
 

--- a/lunatik.h
+++ b/lunatik.h
@@ -81,10 +81,12 @@ do {										\
 	lunatik_unpin(_object);							\
 } while(0)
 
+typedef void (*lunatik_release_t)(void *);
+
 typedef struct lunatik_class_s {
 	const char *name;
 	const luaL_Reg *methods;
-	void (*release)(void *);
+	lunatik_release_t release;
 	lua_CFunction opener;
 	lunatik_opt_t opt;
 } lunatik_class_t;
@@ -117,7 +119,8 @@ static inline int lunatik_trylock(lunatik_object_t *object)
 }
 
 int lunatik_runtime(lunatik_object_t **pruntime, const char *script, lunatik_opt_t opt);
-int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt, int cpu);
+int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt,
+	lunatik_object_t *percpu, int cpu);
 int lunatik_stop(lunatik_object_t *runtime);
 
 static inline int lunatik_nop(lua_State *L)

--- a/lunatik_conf.h
+++ b/lunatik_conf.h
@@ -79,6 +79,7 @@ typedef struct lunatik_runtime_s {
 	struct lunatik_object_s *runtime;
 	bool ready;
 	int cpu;	/* percpu instance id; LUNATIK_CPU_NONE on a plain runtime */
+	struct lunatik_object_s *percpu;	/* the object owning a percpu instance; NULL on a plain runtime */
 } lunatik_runtime_t;
 
 #undef LUA_EXTRASPACE

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -101,7 +101,7 @@ static int lunatik_lcopyobjects(lua_State *L)
 	for (i = 0; i < nobjects; i++) {
 		lunatik_object_t **pobject = lunatik_testobject(Lfrom, ixfrom + i);
 
-		luaL_argcheck(L, pobject, i + 1, "invalid object");
+		luaL_argcheck(L, pobject != NULL, i + 1, "invalid object");
 		lunatik_pushobject(L, *pobject);
 	}
 	return nobjects;

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -163,8 +163,6 @@ static int lunatik_cpu(lua_State *L)
 	return 1;
 }
 
-static int lunatik_percpu(lua_State *L);
-
 static const luaL_Reg lunatik_lib[] = {
 	{"runtime", lunatik_lruntime},
 	{"percpu", lunatik_percpu},
@@ -237,7 +235,7 @@ static int lunatik_runscript(lua_State *L)
 	return 1; /* callback */
 }
 
-static int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt, int cpu)
+int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt, int cpu)
 {
 	lunatik_object_t *runtime;
 	lua_State *L;
@@ -288,14 +286,6 @@ int lunatik_runtime(lunatik_object_t **pruntime, const char *script, lunatik_opt
 }
 EXPORT_SYMBOL(lunatik_runtime);
 
-static inline lunatik_opt_t lunatik_checkcontext(lua_State *L, int ix)
-{
-	static const char *const contexts[] = {"process", "softirq", "hardirq", NULL};
-	static const lunatik_opt_t opts[] = {LUNATIK_OPT_NONE, LUNATIK_OPT_SOFTIRQ, LUNATIK_OPT_HARDIRQ};
-
-	return opts[luaL_checkoption(L, ix, "process", contexts)];
-}
-
 /***
 * Creates a new Lunatik runtime executing the given script.
 * @function runtime
@@ -318,99 +308,6 @@ static int lunatik_lruntime(lua_State *L)
 	if (lunatik_newruntime(pruntime, L, script, opt, LUNATIK_CPU_NONE) != 0)
 		lua_error(L);
 	lunatik_setclass(L, &lunatik_class, true);
-	return 1;
-}
-
-/***
-* Set of runtimes, one per CPU id, running the same script. A callback dispatched
-* through it reaches the instance of the CPU it fired on.
-* @type percpu
-*/
-static void lunatik_releasepercpu(void *private)
-{
-	lunatik_object_t * __percpu *runtimes = lunatik_percpuruntimes(private);
-	int cpu;
-
-	for_each_possible_cpu(cpu) {
-		lunatik_object_t *runtime = *per_cpu_ptr(runtimes, cpu);
-		if (runtime != NULL) /* last reference: a stop would lock, and this can run in softirq */
-			lunatik_putobject(runtime);
-	}
-	free_percpu(runtimes);
-}
-
-static const lunatik_class_t lunatik_percpu_class;
-
-static inline lunatik_object_t * __percpu *lunatik_checkruntimes(lua_State *L, int ix)
-{
-	lunatik_object_t *object = lunatik_checkobject(L, ix);
-	lunatik_argcheckclass(L, ix, object, &lunatik_percpu_class);
-	return lunatik_percpuruntimes(object->private);
-}
-
-/***
-* Closes every instance, releasing their Lua states.
-* @function stop
-*/
-static int lunatik_stoppercpu(lua_State *L)
-{
-	lunatik_object_t * __percpu *runtimes = lunatik_checkruntimes(L, 1);
-	int cpu;
-
-	for_each_possible_cpu(cpu) {
-		lunatik_object_t *runtime = *per_cpu_ptr(runtimes, cpu);
-		if (runtime != NULL)
-			lunatik_closeprivate(runtime);
-	}
-	return 0;
-}
-
-static const luaL_Reg lunatik_percpu_mt[] = {
-	{"__gc", lunatik_deleteobject},
-	{"__close", lunatik_stoppercpu},
-	{"stop", lunatik_stoppercpu},
-	{NULL, NULL}
-};
-
-static const lunatik_class_t lunatik_percpu_class = {
-	.name = "percpu",
-	.methods = lunatik_percpu_mt,
-	.release = lunatik_releasepercpu,
-	.opener = luaopen_lunatik,
-	.opt = LUNATIK_OPT_PERCPU | LUNATIK_OPT_EXTERNAL,
-};
-
-/***
-* Creates one runtime per CPU id, each loading the given script in the calling context.
-* The instances are dispatched by CPU: see `lunatik.cpu` and `runner.run`.
-* @function percpu
-* @tparam string script script name (e.g., `"mymod"` loads `/lib/modules/lua/mymod.lua`)
-* @tparam[opt="process"] string context execution context, as in `lunatik.runtime`
-* @treturn percpu
-* @raise if allocation fails or the script errors on load, after releasing the instances
-*   already created
-* @within lunatik
-*/
-static int lunatik_percpu(lua_State *L)
-{
-	const char *script = luaL_checkstring(L, 1);
-	lunatik_opt_t opt = lunatik_checkcontext(L, 2);
-	int cpu;
-
-	lunatik_object_t *object = lunatik_newobject(L, &lunatik_percpu_class, 0, opt);
-	lunatik_object_t * __percpu *runtimes = alloc_percpu(lunatik_object_t *);
-
-	if (runtimes == NULL)
-		lunatik_enomem(L);
-	object->private = runtimes;
-
-	for_each_possible_cpu(cpu) {
-		if (lunatik_newruntime(per_cpu_ptr(runtimes, cpu), L, script, opt, cpu) != 0) {
-			object->private = NULL;
-			lunatik_releasepercpu(runtimes); /* release the instances now, not on collection */
-			lua_error(L);
-		}
-	}
 	return 1;
 }
 

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -235,7 +235,8 @@ static int lunatik_runscript(lua_State *L)
 	return 1; /* callback */
 }
 
-int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt, int cpu)
+int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt,
+	lunatik_object_t *percpu, int cpu)
 {
 	lunatik_object_t *runtime;
 	lua_State *L;
@@ -255,6 +256,7 @@ int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char
 	lunatik_toruntime(L) = runtime;
 	lunatik_extra(L)->ready = false;
 	lunatik_extra(L)->cpu = cpu;
+	lunatik_extra(L)->percpu = percpu;
 
 	runtime->gfp = GFP_KERNEL; /* might use kvmalloc while running in process */
 	lua_setallocf(L, lunatik_alloc, runtime);
@@ -282,7 +284,7 @@ int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char
 
 int lunatik_runtime(lunatik_object_t **pruntime, const char *script, lunatik_opt_t opt)
 {
-	return lunatik_newruntime(pruntime, NULL, script, opt, LUNATIK_CPU_NONE);
+	return lunatik_newruntime(pruntime, NULL, script, opt, NULL, LUNATIK_CPU_NONE);
 }
 EXPORT_SYMBOL(lunatik_runtime);
 
@@ -305,7 +307,7 @@ static int lunatik_lruntime(lua_State *L)
 	lunatik_opt_t opt = lunatik_checkcontext(L, 2);
 
 	lunatik_object_t **pruntime = lunatik_newpobject(L, 1);
-	if (lunatik_newruntime(pruntime, L, script, opt, LUNATIK_CPU_NONE) != 0)
+	if (lunatik_newruntime(pruntime, L, script, opt, NULL, LUNATIK_CPU_NONE) != 0)
 		lua_error(L);
 	lunatik_setclass(L, &lunatik_class, true);
 	return 1;

--- a/lunatik_obj.c
+++ b/lunatik_obj.c
@@ -69,7 +69,7 @@ EXPORT_SYMBOL(lunatik_cloneobject);
 
 static inline void lunatik_releaseprivate(const lunatik_class_t *class, void *private)
 {
-	void (*release)(void *) = class->release;
+	lunatik_release_t release = class->release;
 
 	if (release)
 		release(private);

--- a/lunatik_percpu.c
+++ b/lunatik_percpu.c
@@ -1,0 +1,107 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+/***
+* Set of runtimes, one per CPU id, running the same script.
+* @module lunatik
+*/
+
+#include <linux/percpu.h>
+
+#include <lunatik.h>
+
+LUNATIK_OPENER(lunatik);
+
+/***
+* Set of runtimes, one per CPU id, running the same script. A callback dispatched
+* through it reaches the instance of the CPU it fired on.
+* @type percpu
+*/
+static void lunatik_releasepercpu(void *private)
+{
+	lunatik_object_t * __percpu *runtimes = lunatik_percpuruntimes(private);
+	int cpu;
+
+	for_each_possible_cpu(cpu) {
+		lunatik_object_t *runtime = *per_cpu_ptr(runtimes, cpu);
+		if (runtime != NULL) /* last reference: a stop would lock, and this can run in softirq */
+			lunatik_putobject(runtime);
+	}
+	free_percpu(runtimes);
+}
+
+static inline lunatik_object_t * __percpu *lunatik_checkruntimes(lua_State *L, int ix)
+{
+	lunatik_object_t *object = lunatik_checkobject(L, ix);
+	lunatik_argcheckclass(L, ix, object, &lunatik_percpu_class);
+	return lunatik_percpuruntimes(object->private);
+}
+
+/***
+* Closes every instance, releasing their Lua states.
+* @function stop
+*/
+static int lunatik_stoppercpu(lua_State *L)
+{
+	lunatik_object_t * __percpu *runtimes = lunatik_checkruntimes(L, 1);
+	int cpu;
+
+	for_each_possible_cpu(cpu) {
+		lunatik_object_t *runtime = *per_cpu_ptr(runtimes, cpu);
+		if (runtime != NULL)
+			lunatik_closeprivate(runtime);
+	}
+	return 0;
+}
+
+static const luaL_Reg lunatik_percpu_mt[] = {
+	{"__gc", lunatik_deleteobject},
+	{"__close", lunatik_stoppercpu},
+	{"stop", lunatik_stoppercpu},
+	{NULL, NULL}
+};
+
+const lunatik_class_t lunatik_percpu_class = {
+	.name = "percpu",
+	.methods = lunatik_percpu_mt,
+	.release = lunatik_releasepercpu,
+	.opener = luaopen_lunatik,
+	.opt = LUNATIK_OPT_PERCPU | LUNATIK_OPT_EXTERNAL,
+};
+
+/***
+* Creates one runtime per CPU id, each loading the given script in the calling context.
+* The instances are dispatched by CPU: see `lunatik.cpu` and `runner.run`.
+* @function percpu
+* @tparam string script script name (e.g., `"mymod"` loads `/lib/modules/lua/mymod.lua`)
+* @tparam[opt="process"] string context execution context, as in `lunatik.runtime`
+* @treturn percpu
+* @raise if allocation fails or the script errors on load, after releasing the instances
+*   already created
+* @within lunatik
+*/
+int lunatik_percpu(lua_State *L)
+{
+	const char *script = luaL_checkstring(L, 1);
+	lunatik_opt_t opt = lunatik_checkcontext(L, 2);
+	int cpu;
+
+	lunatik_object_t *object = lunatik_newobject(L, &lunatik_percpu_class, 0, opt);
+	lunatik_object_t * __percpu *runtimes = alloc_percpu(lunatik_object_t *);
+
+	if (runtimes == NULL)
+		lunatik_enomem(L);
+	object->private = runtimes;
+
+	for_each_possible_cpu(cpu) {
+		if (lunatik_newruntime(per_cpu_ptr(runtimes, cpu), L, script, opt, cpu) != 0) {
+			object->private = NULL;
+			lunatik_releasepercpu(runtimes); /* release the instances now, not on collection */
+			lua_error(L);
+		}
+	}
+	return 1;
+}
+

--- a/lunatik_percpu.c
+++ b/lunatik_percpu.c
@@ -19,40 +19,104 @@ LUNATIK_OPENER(lunatik);
 * through it reaches the instance of the CPU it fired on.
 * @type percpu
 */
-static void lunatik_releasepercpu(void *private)
+static lunatik_object_t *lunatik_finddata(lunatik_percpu_t *percpu, const lunatik_class_t *class)
 {
-	lunatik_object_t * __percpu *runtimes = lunatik_percpuruntimes(private);
-	int cpu;
+	unsigned int i;
 
-	for_each_possible_cpu(cpu) {
-		lunatik_object_t *runtime = *per_cpu_ptr(runtimes, cpu);
-		if (runtime != NULL) /* last reference: a stop would lock, and this can run in softirq */
-			lunatik_putobject(runtime);
+	for (i = 0; i < percpu->ndata; i++) {
+		if (percpu->data[i]->class == class)
+			return percpu->data[i];
 	}
-	free_percpu(runtimes);
+	return NULL;
 }
 
-static inline lunatik_object_t * __percpu *lunatik_checkruntimes(lua_State *L, int ix)
+static lunatik_object_t *lunatik_newdata(lua_State *L, lunatik_object_t *object, const lunatik_class_t *class, size_t size)
+{
+	lunatik_percpu_t *percpu = lunatik_topercpu(object);
+	lunatik_object_t *data;
+
+	percpu->data = lunatik_checknull(L, lunatik_realloc(L, percpu->data, (percpu->ndata + 1) * sizeof(lunatik_object_t *)));
+	if ((data = lunatik_createobject(class, size, LUNATIK_OPT_NONE)) == NULL)
+		lunatik_enomem(L);
+	lunatik_getobject(object); /* stop releases it; collection never sees data outstanding */
+	percpu->data[percpu->ndata++] = data;
+	return data;
+}
+
+lunatik_object_t *lunatik_percpudata(lua_State *L, const lunatik_class_t *class, size_t size)
+{
+	lunatik_object_t *object = lunatik_getpercpu(L);
+
+	if (object == NULL)
+		return NULL;
+
+	if (lunatik_isready(lunatik_toruntime(L)))
+		luaL_error(L, "not allowed after module load");
+
+	lunatik_object_t *data = lunatik_finddata(lunatik_topercpu(object), class);
+	return data != NULL ? data : lunatik_newdata(L, object, class, size);
+}
+EXPORT_SYMBOL(lunatik_percpudata);
+
+static void lunatik_stopdata(lunatik_object_t *object)
+{
+	lunatik_percpu_t *percpu = lunatik_topercpu(object);
+	unsigned int i;
+
+	for (i = 0; i < percpu->ndata; i++) {
+		lunatik_closeprivate(percpu->data[i]); /* the class's release runs here, before the instances close */
+		lunatik_putobject(percpu->data[i]);
+		lunatik_putobject(object);
+	}
+	percpu->ndata = 0;
+	lunatik_free(percpu->data);
+	percpu->data = NULL;
+}
+
+#define lunatik_foreachinstance(percpu, cpu, runtime)	\
+	for_each_possible_cpu(cpu)			\
+		if ((runtime = *per_cpu_ptr((percpu)->runtimes, cpu)) != NULL)
+
+static void lunatik_closeinstances(lunatik_percpu_t *percpu)
+{
+	lunatik_object_t *runtime;
+	int cpu;
+
+	lunatik_foreachinstance(percpu, cpu, runtime)
+		lunatik_closeprivate(runtime);
+}
+
+static void lunatik_releasepercpu(void *private)
+{
+	lunatik_percpu_t *percpu = (lunatik_percpu_t *)private;
+	lunatik_object_t *runtime;
+	int cpu;
+
+	if (percpu->runtimes == NULL)
+		return;
+
+	lunatik_foreachinstance(percpu, cpu, runtime)
+		lunatik_putobject(runtime); /* may run in softirq: a put, never a stop */
+	free_percpu(percpu->runtimes);
+}
+
+static inline lunatik_object_t *lunatik_checkpercpuobject(lua_State *L, int ix)
 {
 	lunatik_object_t *object = lunatik_checkobject(L, ix);
 	lunatik_argcheckclass(L, ix, object, &lunatik_percpu_class);
-	return lunatik_percpuruntimes(object->private);
+	return object;
 }
 
 /***
-* Closes every instance, releasing their Lua states.
+* Closes the objects the instances share, then every instance, releasing their Lua states.
 * @function stop
 */
 static int lunatik_stoppercpu(lua_State *L)
 {
-	lunatik_object_t * __percpu *runtimes = lunatik_checkruntimes(L, 1);
-	int cpu;
+	lunatik_object_t *object = lunatik_checkpercpuobject(L, 1);
 
-	for_each_possible_cpu(cpu) {
-		lunatik_object_t *runtime = *per_cpu_ptr(runtimes, cpu);
-		if (runtime != NULL)
-			lunatik_closeprivate(runtime);
-	}
+	lunatik_stopdata(object);
+	lunatik_closeinstances(lunatik_topercpu(object));
 	return 0;
 }
 
@@ -68,7 +132,7 @@ const lunatik_class_t lunatik_percpu_class = {
 	.methods = lunatik_percpu_mt,
 	.release = lunatik_releasepercpu,
 	.opener = luaopen_lunatik,
-	.opt = LUNATIK_OPT_PERCPU | LUNATIK_OPT_EXTERNAL,
+	.opt = LUNATIK_OPT_PERCPU,
 };
 
 /***
@@ -88,17 +152,16 @@ int lunatik_percpu(lua_State *L)
 	lunatik_opt_t opt = lunatik_checkcontext(L, 2);
 	int cpu;
 
-	lunatik_object_t *object = lunatik_newobject(L, &lunatik_percpu_class, 0, opt);
-	lunatik_object_t * __percpu *runtimes = alloc_percpu(lunatik_object_t *);
+	lunatik_object_t *object = lunatik_newobject(L, &lunatik_percpu_class, sizeof(lunatik_percpu_t), opt);
+	lunatik_percpu_t *percpu = lunatik_topercpu(object);
 
-	if (runtimes == NULL)
+	if ((percpu->runtimes = alloc_percpu(lunatik_object_t *)) == NULL)
 		lunatik_enomem(L);
-	object->private = runtimes;
 
 	for_each_possible_cpu(cpu) {
-		if (lunatik_newruntime(per_cpu_ptr(runtimes, cpu), L, script, opt, cpu) != 0) {
-			object->private = NULL;
-			lunatik_releasepercpu(runtimes); /* release the instances now, not on collection */
+		if (lunatik_newruntime(per_cpu_ptr(percpu->runtimes, cpu), L, script, opt, object, cpu) != 0) {
+			lunatik_stopdata(object);
+			lunatik_closeprivate(object); /* release the instances now, not on collection */
 			lua_error(L);
 		}
 	}

--- a/lunatik_percpu.c
+++ b/lunatik_percpu.c
@@ -100,20 +100,13 @@ static void lunatik_releasepercpu(void *private)
 	free_percpu(percpu->runtimes);
 }
 
-static inline lunatik_object_t *lunatik_checkpercpuobject(lua_State *L, int ix)
-{
-	lunatik_object_t *object = lunatik_checkobject(L, ix);
-	lunatik_argcheckclass(L, ix, object, &lunatik_percpu_class);
-	return object;
-}
-
 /***
 * Closes the objects the instances share, then every instance, releasing their Lua states.
 * @function stop
 */
 static int lunatik_stoppercpu(lua_State *L)
 {
-	lunatik_object_t *object = lunatik_checkpercpuobject(L, 1);
+	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &lunatik_percpu_class);
 
 	lunatik_stopdata(object);
 	lunatik_closeinstances(lunatik_topercpu(object));

--- a/lunatik_percpu.h
+++ b/lunatik_percpu.h
@@ -1,0 +1,54 @@
+/*
+* SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+* SPDX-License-Identifier: MIT OR GPL-2.0-only
+*/
+
+#ifndef lunatik_percpu_h
+#define lunatik_percpu_h
+
+#include <linux/percpu.h>
+#include <linux/preempt.h>
+
+#define LUNATIK_CPU_NONE	(-1)
+#define lunatik_getcpu(L)	(lunatik_extra(L)->cpu)
+#define lunatik_hascpu(L)	(lunatik_getcpu(L) != LUNATIK_CPU_NONE)
+
+#define lunatik_percpuruntimes(p)	((lunatik_object_t * __percpu __force *)(p))
+
+static inline lunatik_object_t *lunatik_pin(lunatik_object_t *object)
+{
+	if (likely(!lunatik_ispercpu(object->opt)))
+		return object;
+
+	if (lunatik_isirq(object->opt))
+		preempt_disable();
+	else /* a process instance may sleep */
+		migrate_disable();
+	return *this_cpu_ptr(lunatik_percpuruntimes(object->private));
+}
+
+static inline void lunatik_unpin(lunatik_object_t *object)
+{
+	if (likely(!lunatik_ispercpu(object->opt)))
+		return;
+
+	if (lunatik_isirq(object->opt))
+		preempt_enable();
+	else
+		migrate_enable();
+}
+
+extern const lunatik_class_t lunatik_percpu_class;
+
+int lunatik_percpu(lua_State *L);
+
+#define LUNATIK_ERR_PERCPU	"not allowed in a percpu runtime"
+
+static inline void lunatik_checkpercpu(lua_State *L)
+{
+	if (lunatik_hascpu(L))
+		luaL_error(L, LUNATIK_ERR_PERCPU);
+}
+
+#endif
+

--- a/lunatik_percpu.h
+++ b/lunatik_percpu.h
@@ -12,8 +12,15 @@
 #define LUNATIK_CPU_NONE	(-1)
 #define lunatik_getcpu(L)	(lunatik_extra(L)->cpu)
 #define lunatik_hascpu(L)	(lunatik_getcpu(L) != LUNATIK_CPU_NONE)
+#define lunatik_getpercpu(L)	(lunatik_extra(L)->percpu)
 
-#define lunatik_percpuruntimes(p)	((lunatik_object_t * __percpu __force *)(p))
+typedef struct lunatik_percpu_s {
+	lunatik_object_t * __percpu *runtimes;
+	lunatik_object_t **data;
+	unsigned int ndata;
+} lunatik_percpu_t;
+
+#define lunatik_topercpu(object)	((lunatik_percpu_t *)(object)->private)
 
 static inline lunatik_object_t *lunatik_pin(lunatik_object_t *object)
 {
@@ -24,7 +31,7 @@ static inline lunatik_object_t *lunatik_pin(lunatik_object_t *object)
 		preempt_disable();
 	else /* a process instance may sleep */
 		migrate_disable();
-	return *this_cpu_ptr(lunatik_percpuruntimes(object->private));
+	return *this_cpu_ptr(lunatik_topercpu(object)->runtimes);
 }
 
 static inline void lunatik_unpin(lunatik_object_t *object)
@@ -41,6 +48,7 @@ static inline void lunatik_unpin(lunatik_object_t *object)
 extern const lunatik_class_t lunatik_percpu_class;
 
 int lunatik_percpu(lua_State *L);
+lunatik_object_t *lunatik_percpudata(lua_State *L, const lunatik_class_t *class, size_t size);
 
 #define LUNATIK_ERR_PERCPU	"not allowed in a percpu runtime"
 


### PR DESCRIPTION
A registration a percpu script makes once for all its instances, a netfilter hook or a kprobe, has nowhere to live: each instance has its own state, and the object's private is the bare array of them. On x86 with GCC 14 that array no longer compiles either, since `__percpu` is a real address space there and `private` is a `void *`.

`lunatik_percpudata(L, &class, size)` gives an instance an object of a class the binding declares, held by the percpu object and seen by every instance; `percpu:stop()` closes it, which runs the class's `release`, before closing the instances. The private becomes `lunatik_percpu_t`, with the array typed `__percpu`; the release callback gets the type `lunatik_release_t`. The percpu object moves first to `lunatik_percpu.c` and `lunatik_percpu.h`, in a commit that changes nothing; two more fold what sparse and the checkers of #776 asked for: the object pointer compared to `NULL` in an argcheck, and `lunatik_checkobjectclass` for a method that needs the object.

First client: netfilter, in #785.
