### PR TITLE
harness: what the percpu review round and a wedged device taught

### DIFF
--- a/.agents/skills/lunatik-cycle/SKILL.md
+++ b/.agents/skills/lunatik-cycle/SKILL.md
@@ -41,3 +41,29 @@ idle system is the driver runtime's require-pins (a kernel `require()` pins the 
 until that state's `lua_close`). `/sys/module/X/holders` lists only symbol dependencies, not
 require-pins; `refcnt` is the complete in-degree.
 
+# A wedged device: before and after the reboot
+
+A `lunatik` process in D state does not come back, and the reboot that clears it is the
+maintainer's call (AGENTS.md, "Build, install, test"). Before asking for it:
+
+    ps -eo pid,stat,etime,cmd | awk '$2 ~ /D/'          # confirm, and note the PID
+    tools/oops.sh > scratch/oops-$(date +%F).txt         # dmesg block, faulting instructions, D-state processes
+
+Then write down (memory or scratch) which tree `make install` last ran from and its HEAD, the
+suites not yet run, and the branches whose tests were interrupted. Run no further `lunatik`
+command; the D-state child cannot be killed and every new one queues behind it.
+
+After the reboot, in this order:
+
+    uname -r                                             # a kernel upgrade may have come with it
+    journalctl -k -b -1 -o cat > scratch/oops-$(date +%F).txt   # if the capture was missed
+    sudo apt install linux-headers-$(uname -r) linux-tools-$(uname -r)
+    git worktree prune                                   # scratch worktrees under /tmp are gone
+    git worktree add <scratch>/w<name> <ref> && git -C <scratch>/w<name> submodule update --init
+    make clean && sudo make btf_install && make && sudo make install && sudo lunatik reload
+    sudo lunatik test <the suite that oopsed>            # twice
+
+A second oops is the bug, traced from `scratch/oops-*.txt`; a clean pair means the trigger
+was state the reboot cleared, reported as untraced. Then the pending list, in the order the
+branches stack.
+

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -8,8 +8,10 @@ comments, after a round. Follow it whole; this card is only the GitHub mechanics
 
 # Reading and driving the branch
 
-- `git fetch origin pull/<N>/head:review/<N>` brings the author's head; build and run it with
-  the lunatik-cycle skill.
+- `git fetch origin pull/<N>/head:review/<N>` brings the author's head; check it out in a worktree
+  of its own (`git worktree add <scratch>/w<N> review/<N>`, then `git submodule update --init`),
+  since a worktree named for a task may be another session's; build and run it with the
+  lunatik-cycle skill.
 - Read the pull request through the REST API, which needs no `read:org` scope:
   `gh api repos/luainkernel/lunatik/pulls/<N>` for the PR,
   `gh api repos/.../issues/<N>/comments` and `gh api repos/.../pulls/<N>/comments` for the

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ doc/*
 /lib/linux/
 
 CLAUDE.local.md
+/scratch/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,15 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
 * A secondary check that must always follow a `LUNATIK_PRIVATECHECKER` (a field that must be set,
   the class identity of the object) goes in the macro's vararg body, in the mold of `luaskb_check`;
   `L` and `ix` are in scope there. A hand written checker only when the macro's shape does not fit.
+* A method that reads `private` as its own type checks the class first. `lunatik_checkobject`
+  accepts any Lunatik object, so a foreign object's private read through this class's pointer is a
+  kernel crash reachable from Lua: `getmetatable(a).method(b)` is one line of script. The check is
+  `lunatik_argcheckclass` in the checker's body, or in a hand written checker when the cast needs
+  `__force`.
+* A per-CPU access names the guarantee it has: `this_cpu_ptr` where preemption is off, `per_cpu_ptr`
+  with an explicit id, and `raw_cpu_ptr` never to silence the check a preemptible caller would trip.
+  A cast into an annotated address space or type, `__percpu` or `__bitwise`, carries `__force`, as
+  the `opt` constants do.
 * `/*** @section name */` separates logical sections in a merged C file and groups them in the docs.
 * Two short mutually exclusive calls read better as a ternary than a four line if/else; void arms are
   fine. This does not transpose to Lua (see Lua style).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,17 @@ Use `sudo make install`, not the partial `*_install` targets. Use `sudo lunatik 
 
 After a kernel upgrade the installed modules were built for the previous kernel and fail to load with
 `Exec format error` (a vermagic mismatch). Reinstall the headers, `make clean && make`, and reinstall
-before the next `reload`.
+before the next `reload`. The eBPF modules also need the running kernel's BTF at build time,
+`sudo make btf_install` before `make`, or they log `missing module BTF, cannot register kfuncs` and
+do not load; and the `bpftool` wrapper needs `linux-tools-$(uname -r)`, or every BPF program fails
+to load.
+
+A wedged device — a `lunatik` process in D state, usually below an oops in `dmesg` — is cleared only
+by a reboot, and the reboot is the maintainer's to trigger: other sessions share the host. Before
+asking, capture what the reboot erases with `tools/oops.sh`, write down which suites were pending
+and which build was installed, and run nothing else against the device. After it, the suite that
+oopsed runs twice: a second oops is a bug to trace, a clean pair is a symptom without its cause,
+said as such. The lunatik-cycle skill orders both halves.
 
 Never run two `lunatik` operations at once. Concurrent operations wedge `/dev/lunatik` and leave
 processes in D state. Check with `ps` before starting one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -492,6 +492,14 @@ A review produces two things: the comments, and a branch showing what the commen
 is posted before the maintainer has seen both, and the checklist below is the reviewer's own — a
 review that fails it is not ready, whatever the code looks like.
 
+The checklist runs whole on every pull request, whoever wrote it: the maintainer's own, another
+session's, or this session's earlier work. Authorship shortens nothing. A change that arrives with
+a rationale attached — a comment beside the line, a body that explains the choice, a prior session
+that "already reviewed it" — is reviewed against the code, not against the rationale: a comment
+beside `raw_cpu_ptr` about a preemptible caller that does not exist is a finding to run to ground
+against the kernel's own idiom, not a reason to pass the line. Reading the rationale as the review
+is how a mutex in softirq and a crash reachable from Lua were passed.
+
 ### Before the verdict
 
 1. Check out the author's branch, build it, and run the suite. Reading the diff misses what the
@@ -564,6 +572,9 @@ review that fails it is not ready, whatever the code looks like.
   `tc`'s BPF programs were right to declare `Dual MIT/GPL`; the `xdp` ones still on `GPL` are what a
   separate cleanup fixes.
 * Missing tests are a finding of their own, written as such, not a remark appended to another comment.
+* A contract the author documented is not redesigned by the review. An ergonomics preference, `nil`
+  against an object whose methods raise, is stated with its trade-off and left to the maintainer;
+  shipped as a fixup, it asks the author to un-decide.
 
 ### Fixups
 
@@ -576,8 +587,10 @@ review that fails it is not ready, whatever the code looks like.
   per target commit: a comment pointing at a commit that does three unrelated things cannot be accepted
   in parts, and the author is the one who autosquashes what they accept. A fixup touches only what the
   pull request introduced; check the symbol's provenance first, since one already on `master` is a
-  separate change on its own branch. A consistency fix on the branch's own code is done now, not
-  deferred.
+  separate change on its own branch, and a design note under `doc/design/` that mentions the old
+  shape is a snapshot of a plan, not the API's documentation, and stays out. A fixup is the
+  reviewer's code with no reviewer, so it gets the pass the author's code got. A consistency fix on
+  the branch's own code is done now, not deferred.
 * A script or command handed to the author is one you ran, not one you syntax-checked or copied from a
   doc. `bash -n` passing is not the script working, and "it is the README's own command" is not "it
   runs here". If the environment cannot verify it — a stale module, a skewed signature in the way —
@@ -619,6 +632,9 @@ review that fails it is not ready, whatever the code looks like.
   closed and there is more to say, comment. And feedback lives in one artifact: when you fall back to a
   comment, or correct or move a comment, edit or supersede the one that carries it — never leave two
   copies to drift.
+* A stacked pull request is merged after its base, never before: GitHub merges it into the base
+  branch, the base pull request grows a commit nobody reviewed there, and the stacked one closes
+  as merged with nothing on `master`. A verdict on a stacked pull request says "after #N".
 * Approving is the reviewer's to state; merging is the maintainer's to trigger. Even a clean, approved
   PR is not merged on the reviewer's initiative — pushing or merging to `master` is irreversible and
   public, and the click is the maintainer's alone. A question about state — "can we merge?", "is it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,11 @@ Never `require("foo").method()`.
 * A comment is one line carrying the reason the code is not obvious, nothing the code below already
   says. State the why; the what and the how are the code's job.
 * A comment about a specific call goes on that call's line, not above the function signature.
+* When the surprise is the call itself, a `put` where the tree would `stop`, the comment on the
+  call's line gives the one reason it is not the expected call, `/* last reference: a stop would
+  lock, and this can run in softirq */`; when the alternative is the other arm of the same `if`,
+  the reason alone, `else /* this arm may sleep */`. The comment states the choice, not the world
+  behind it; the invariant the choice rests on is the commit body's.
 * Reaching for a comment is a signal to reconsider the code's clarity first: a name that states the
   intent, a helper that names the step, an enum instead of a bare constant. Comment what the code
   cannot be made to say, not what a clearer shape would.
@@ -347,7 +352,9 @@ Tests are shell scripts emitting KTAP plus a kernel side Lua script.
   first, since restoring is a `git checkout --` that takes any uncommitted work with it;
 * a test for an exactly once property runs on the path where that property is structural, and the
   header says which path and why. The same assertion on a path that can migrate CPUs mid way passes
-  for the wrong reason.
+  for the wrong reason;
+* a test that guards a kernel crash is not proved by removing the guard. Say that its discrimination
+  rests on the message it asserts, and prove the rest of the suite the usual way.
 
 A test is not done until `tests/README.md` describes it, the suite's `run.sh` runs it, and, for a new
 suite, the top level `README.md` lists it. Same commit, or a fixup of it.
@@ -388,6 +395,10 @@ old factory — kept building and broke at the first packet.
   move on. A question is for a genuine fork — where the answer changes the outcome and no rule,
   precedent, or test resolves it. Asking whether to add a comment the tree's macros never carry spends
   the maintainer on a call this document already made.
+* "The tree does it" is a fact about the tree, not a reason. A choice is defended by what it buys and
+  what it costs; prevalence says whether it is common, never whether it is right, and a tree can be
+  wrong in a hundred places. When the only support for a line is a precedent, say so and judge it
+  again.
 
 ## Patches and commits
 
@@ -410,6 +421,10 @@ old factory — kept building and broke at the first packet.
   not say: a new API, a behaviour change, a non obvious rationale. No bullet list of every detail.
 * A pull request title and body follow the same rule: what and why, nothing the commits already say.
   No "Test plan" section, and no em dashes.
+* A pull request is one mechanism, read in one screen of diff and one paragraph of body. A body that
+  needs a section per mechanism describes several pull requests: stack them, each on the one below.
+* No session links or assistant footers in a commit or a pull request beyond the `Co-Authored-By`
+  trailer. The project settings turn the link off; one that slipped in is removed with a reword.
 * A root cause named in a commit body or a pull request rests on a captured stack or a source-traced
   chain, not a correlated log line or a plausible mechanism. Until it is traced it is a hypothesis,
   labelled as one; a fix may land on the observed behaviour without naming a cause it has not proven.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,15 @@ before the next `reload`.
 Never run two `lunatik` operations at once. Concurrent operations wedge `/dev/lunatik` and leave
 processes in D state. Check with `ps` before starting one.
 
+A worktree named for a task may belong to another session on the same machine. Check
+`git worktree list` and the branch a worktree holds before a checkout or a reset there, and never
+reset a branch checked out elsewhere. A review, or a build of a branch not your own, runs in a
+worktree created for it (`git worktree add`, then `git submodule update --init`) and removed at the
+end.
+
+A tree with a conflict pending (`git status` showing `UU`) is not a test subject: a suite run over a
+half-applied rebase or cherry-pick measures neither side. Resolve and commit, then build.
+
 `lunatik reload` unloads only the modules the installed CLI lists. A module loaded from another
 branch's install escapes it and pins the core: `rmmod` reports `Module lunatik is in use by ...`
 while `lunatik list` is empty. Diff `lsmod` against the installed `lunatik/config.lua` to find the

--- a/tests/tc/Makefile
+++ b/tests/tc/Makefile
@@ -3,7 +3,7 @@
 
 all: tc_pass.bpf.o tc_drop.bpf.o tc_detach.bpf.o tc_zerokey.bpf.o tc_reattach.bpf.o
 
-vmlinux.h:
+vmlinux.h: /sys/kernel/btf/vmlinux
 	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $@
 
 tc_pass.bpf.o: tc_pass.bpf.c vmlinux.h

--- a/tests/xdp/Makefile
+++ b/tests/xdp/Makefile
@@ -3,7 +3,7 @@
 
 all: xdp_pass.bpf.o xdp_drop.bpf.o xdp_detach.bpf.o xdp_zerokey.bpf.o xdp_process.bpf.o xdp_percpu.bpf.o
 
-vmlinux.h:
+vmlinux.h: /sys/kernel/btf/vmlinux
 	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $@
 
 xdp_pass.bpf.o: xdp_pass.bpf.c vmlinux.h

--- a/tools/Readme.md
+++ b/tools/Readme.md
@@ -15,3 +15,15 @@ To check it works:
 ```sh
 sudo dpkg-reconfigure linux-image-`uname -r`
 ```
+
+## oops.sh
+
+Captures the last kernel oops before a reboot takes it away: the `dmesg` block, the instructions
+around the faulting one in the installed module, and the processes left in D state.
+
+```sh
+tools/oops.sh > scratch/oops-$(date +%F).txt
+```
+
+A saved dump, `journalctl -k -b -1 -o cat` after the reboot where the journal is persistent,
+is read the same way: `tools/oops.sh <dump>`.

--- a/tools/checks/module-conventions.sh
+++ b/tools/checks/module-conventions.sh
@@ -39,6 +39,21 @@ check() {
 		add "has } else on the same line; else goes on its own line"
 	[ "$(tail -c2 "$file" | tr '\n' 'N')" = "NN" ] || \
 		add "does not end with a trailing blank line"
+	grep -nE '\braw_cpu_ptr\(' "$file" >/dev/null 2>&1 && \
+		add "uses raw_cpu_ptr; a per-CPU access names its guarantee: this_cpu_ptr where preemption is off, per_cpu_ptr with an explicit id"
+	grep -nE '__percpu[[:space:]]+\*[[:space:]]*\)' "$file" 2>/dev/null | grep -v '__force' | grep -q . && \
+		add "casts into __percpu without __force; a cast into an annotated address space carries __force, as the opt constants do"
+	grep -nE 'lunatik_toobject\(L, *(-?[0-9]+|ix)\)->private' "$file" 2>/dev/null | grep -vE 'lunatik_getregistry|_key\)' | grep -q . && \
+		add "reads ->private through lunatik_toobject on an argument; lunatik_toobject returns NULL for a non-userdata, so a checker (lunatik_checkobject) goes first"
+	# a method that reads private as its own type right after lunatik_checkobject, which
+	# accepts any Lunatik object, skips the class check; a checker tests the class in between.
+	awk '
+		/lunatik_checkobject\(L, *(-?[0-9]+|ix)\)/ { hold=NR }
+		hold && /argcheckclass|argexpected/ { hold=0 }
+		hold && NR<=hold+3 && /->private/ { print NR; found=1; hold=0 }
+		END { exit !found }
+	' "$file" >/dev/null 2>&1 && \
+		add "reads ->private right after lunatik_checkobject, which accepts any Lunatik object; check the class first (lunatik_argcheckclass, or luaL_argexpected over the classes the method accepts)"
 
 	# over-comment nudges. Heuristic, so advisory.
 	# (a) a comment right after a preprocessor branch usually restates the condition.

--- a/tools/oops.sh
+++ b/tools/oops.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Captures the last kernel oops before a reboot takes it away: the dmesg block from the fault
+# to "end trace", the instructions around the faulting one in the installed module, and the
+# processes left in D state. Prints to stdout; keep it under scratch/, not /tmp, which the
+# reboot clears too.
+# Usage: tools/oops.sh [dmesg-dump] > scratch/oops-$(date +%F).txt
+# The dump may be `journalctl -k -b -1 -o cat`, taken after the reboot from a persistent journal.
+
+src="$1"
+
+dump() {
+	if [ -n "$src" ]; then cat "$src"; else dmesg; fi
+}
+
+block=$(dump | awk '/Unable to handle|BUG: |Internal error/ { f=1 } f { print } /end trace/ { f=0 }')
+[ -n "$block" ] || { echo "no oops in dmesg" >&2; exit 1; }
+echo "$block"
+
+pc=$(echo "$block" | sed -n 's/.*pc : \([A-Za-z0-9_]*\)+0x\([0-9a-f]*\)\/0x[0-9a-f]* \[\([A-Za-z0-9_]*\)\].*/\1 \2 \3/p' | head -1)
+if [ -n "$pc" ]; then
+	read -r sym off mod <<< "$pc"
+	ko=$(modinfo -n "$mod" 2>/dev/null)
+	if [ -n "$ko" ] && command -v objdump > /dev/null 2>&1; then
+		echo
+		echo "== $mod: $sym+0x$off in $ko (the installed build; it must be the one that crashed)"
+		listing=$(objdump -d --no-show-raw-insn "$ko" | awk -v s="<$sym>:" '$0 ~ s { f=1 } f && /^$/ { exit } f')
+		base=$(echo "$listing" | head -1 | cut -d' ' -f1)
+		target=$(printf '%x' $((16#$base + 16#$off)))
+		echo "$listing" | grep -n -E "^ *$target:" | cut -d: -f1 | head -1 | while read -r n; do
+			echo "$listing" | sed -n "$((n > 8 ? n - 8 : 1)),$((n + 4))p" | sed "s/^ *$target:/=> &/"
+		done
+	fi
+fi
+
+echo
+echo "== processes in D state"
+ps -eo pid,stat,etime,cmd | awk '$2 ~ /D/'
+


### PR DESCRIPTION
Supersedes #775 and #778, restructured into six commits, one per subject, each carrying the check or skill step it entails, with the review fixups folded in.

Eleven rules from the review of the percpu stack, in four commits. A build or review runs in a worktree of its own and never over a tree with a conflict pending, and the review skill card gains that step. A method checks the class before reading private as its own type, and a per-CPU access names its guarantee with an annotated cast carrying `__force`: `module-conventions.sh`, which the edit hook runs on every C file written, flags `raw_cpu_ptr`, a `__percpu` cast without `__force`, a `->private` read through `lunatik_toobject` on an argument and one right after `lunatik_checkobject` with no class test in between. On master those name `device:stop`, `notifier:stop`, `probe:stop`, `probe:enable` and both checker macros in `lunatik.h`, fixed in #776; the class bullet and the check's message describe the macro on master today, and whichever of the two lands second updates them. A comment on a surprising call names the expected call and why not; a test guarding a kernel crash is not proved by removing the guard; a pull request is one mechanism and carries no session link; the review runs whole on every pull request, whoever wrote it, and reads the code rather than the rationale beside it; a documented contract is not redesigned by the review; a precedent is a fact, not a reason; a fixup gets the pass the author's code got; a stacked pull request is merged after its base.

The last two commits are the reboot protocol. A kernel oops left the device with a process in D state, and the protocol around it was improvised: the dmesg block read by hand, the faulting instruction found by disassembling the module afterwards, and the reboot brought a kernel upgrade whose headers, BTF and bpftool surfaced as three separate failures (`Exec format error`, `missing module BTF, cannot register kfuncs`, every BPF program refusing to load until `linux-tools-$(uname -r)` was installed). `tools/oops.sh` captures the dmesg block, the instructions around the fault in the installed module and the D-state processes in one go, before the reboot erases `/tmp` and, without a persistent journal, `dmesg`; a dump saved from `journalctl -k -b -1` is read the same way. `AGENTS.md` carries the rule, the reboot being the maintainer's call, the lunatik-cycle skill orders both halves, and the repository ignores `scratch/`, where the capture goes. The test `vmlinux.h` now depends on `/sys/kernel/btf/vmlinux`, whose mtime is set on its first access after boot, so a reboot into another kernel regenerates it.

Checked here: the check on master and on #776's tree names what the body says and nothing else; the script on the journal of the boot that oopsed finds `luarcu_map+0x40` and prints the `ldr x0, [x0]` after `lua_touserdata` returned NULL; the header rebuilds when older than the BTF and stays put otherwise.
