### PR TITLE
harness: confirm the installed tree, tear a case down before its verdict, ask before dropping a crash guard

### DIFF
--- a/.agents/skills/lunatik-cycle/SKILL.md
+++ b/.agents/skills/lunatik-cycle/SKILL.md
@@ -21,6 +21,10 @@ A worktree installs only after `make`: `scripts_install` needs the autogen outpu
 install's output visible, and confirm what landed under `/lib/modules/lua/` (timestamp, or a
 grep for a symbol only the branch has) before trusting a run against it.
 
+A tree that drops a crash guard (a checker, an `argcheck`) is not installed or run on the shared
+host: the test covering the guard reproduces the crash. `crash-guard.sh` blocks it; an experiment
+needs the maintainer's authorization first, and `CRASH_AB_OK=1` on the command records that.
+
 `lunatik test` unloads the modules when it finishes: `sudo lunatik reload` before a direct
 `bash tests/<suite>/<test>.sh` afterwards, or it skips with `not loaded`.
 

--- a/.agents/skills/lunatik-cycle/SKILL.md
+++ b/.agents/skills/lunatik-cycle/SKILL.md
@@ -17,6 +17,13 @@ without module changes, `bash tests/<suite>/run.sh` skips the reload and is gent
 device. `make scripts_install` does not install tests: after touching lib or tests, run the full
 install, or the installed suite drifts from the tree.
 
+A worktree installs only after `make`: `scripts_install` needs the autogen output. Keep the
+install's output visible, and confirm what landed under `/lib/modules/lua/` (timestamp, or a
+grep for a symbol only the branch has) before trusting a run against it.
+
+`lunatik test` unloads the modules when it finishes: `sudo lunatik reload` before a direct
+`bash tests/<suite>/<test>.sh` afterwards, or it skips with `not loaded`.
+
 # One operation at a time
 
 Never run two lunatik operations concurrently (`test`, `run`, `reload`, a suite's run.sh): the

--- a/.claude/hooks/on-edit.sh
+++ b/.claude/hooks/on-edit.sh
@@ -14,10 +14,10 @@ dir=$(git -C "$(dirname "$file")" rev-parse --show-toplevel 2>/dev/null)
 
 findings=$(for check in module-conventions test-harness cppcheck-tests; do
 	bash "$dir/tools/checks/$check.sh" "$file" 2>&1
-done)
+done; bash "$dir/tools/checks/guard-removed.sh" "$file" 2>&1)
 [ -z "$findings" ] && exit 0
 
-escaped=$(printf '%s' "$findings" | tr '"' "'" | sed ':a;N;$!ba;s/\n/\\n/g')
+escaped=$(printf '%s' "$findings" | tr '"\t' "' " | sed ':a;N;$!ba;s/\n/\\n/g')
 printf '{"decision":"block","reason":"%s"}\n' "$escaped"
 exit 0
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,8 @@
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/review-post-guard.sh\"" }
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/review-post-guard.sh\"" },
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/crash-guard.sh\"" }
         ]
       }
     ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,13 @@ run, the heuristic checks annotate it. Install the commit gate with:
 
     ln -s ../../tools/checks/pre-commit .git/hooks/pre-commit
 
+`guard-removed.sh` names the crash guards a C file drops against `HEAD` (a checker, an
+`argcheck`, a context check): removing one and running the test that covers it reproduces the
+crash the guard prevents, and on the shared host that is a forced reboot. `crash-guard.sh`, wired
+before a shell call like the review guard below, blocks an install, reload or run while any
+worktree drops such a line, unless the command carries `CRASH_AB_OK=1`, set once the maintainer
+authorized the experiment and named the machine it may take down.
+
 `review-post-guard.sh` reads the tool command on stdin instead of a file, for an assistant wired
 to run it before a shell call (`PreToolUse`): it blocks a `gh` write to reviews or comments unless
 the command carries the `REVIEW_POST_OK` marker, set once the exact text has been shown to the
@@ -363,6 +370,11 @@ Tests are shell scripts emitting KTAP plus a kernel side Lua script.
   that fails before its own teardown leaves its runtime registered, and the next run finds it already
   there. A new case extends the cleanup in the commit that adds it, so the up-front run clears the
   leak and a green formal test stays authoritative;
+* a test that guards a kernel crash is not proved by removing the guard: that reproduces the crash,
+  and on the shared host it is a forced reboot. Its discrimination rests on the message it asserts.
+  An experiment that does remove a guard is authorized by the maintainer beforehand, names the
+  machine it may take down, and runs after the commit it is meant to prove; `crash-guard.sh` blocks
+  the install or run until `CRASH_AB_OK=1` says that happened;
 * a case tears down before it reads its verdict: every program it attached, pin it made and script it
   started is undone before the first check, so a failing check leaves nothing for the next case to
   trip on. A case that returns from a check with its program still attached turns one failure into

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,10 @@ Tests are shell scripts emitting KTAP plus a kernel side Lua script.
   that fails before its own teardown leaves its runtime registered, and the next run finds it already
   there. A new case extends the cleanup in the commit that adds it, so the up-front run clears the
   leak and a green formal test stays authoritative;
+* a case tears down before it reads its verdict: every program it attached, pin it made and script it
+  started is undone before the first check, so a failing check leaves nothing for the next case to
+  trip on. A case that returns from a check with its program still attached turns one failure into
+  one per case after it;
 * a test does not depend on what else runs on the host: when a host process — a network manager, say
   — can race it by acting on a resource the test created, make the test robust to any such process,
   not wired to silence one by name, which does not carry to another distro or to CI;
@@ -564,7 +568,10 @@ is how a mutex in softirq and a crash reachable from Lua were passed.
   the same inputs, is environment state, not a code path — the variable is the leftover, so control it
   (a fresh reload, a pinned CPU, the program cut down to the one call under test) rather than theorise
   a bug. The minimal isolating reproduction settles in one run what reading the noisy end-to-end path
-  never does.
+  never does. When the variable is a stimulus the host may or may not supply — a stray packet in a
+  window — supply it yourself and reproduce the signature on demand, and log what the hook actually
+  saw before naming the packet. A mechanism proved by injection is reported as that, not as the
+  trigger of the run that failed, which was not captured.
 * A finding is resolved, not parked. When something looks wrong, run it to ground — reproduce it, find
   the cause, then fix it or dismiss it. "I'll flag it to the author", "let's look into it separately",
   or asking whether to investigate is dropping it, not handling it. Deferral is for work that belongs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,16 @@ state and does not follow a branch switch. The symptom is a runtime `attempt to 
 on a `linux.*` constant, not a build error. Regenerate cleanly with
 `rm -f autogen/.stamp autogen/linux/*.lua && make`; autogen recreates the files, not the directory.
 
+A worktree that has not run `make` cannot install: `scripts_install` needs the autogen output and
+fails, and an install whose output was silenced fails unseen while the previous install stays in
+place, so every run after it tests the wrong tree. Keep the install's output visible, and before
+reading a result confirm that what sits under `/lib/modules/lua/` is the tree under test: its
+timestamp, or a grep for a symbol only the branch has.
+
+`lunatik test` reloads the modules before the suite and unloads them after it. A test script run
+directly afterwards (`bash tests/<suite>/<test>.sh`) skips with `not loaded` until the next
+`lunatik reload`; that unload is the CLI's, not a leak.
+
 `make install` never removes a stray file from `/lib/modules/lua/`. A scratch script left there
 shadows the module of the same name: `require` returns `true` and the failure surfaces later as
 `attempt to index a boolean value`, far from its cause. Remove a scratch script right after

--- a/tools/checks/crash-guard.sh
+++ b/tools/checks/crash-guard.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# PreToolUse (Bash) hook: an install, reload or run over a tree that drops a crash
+# guard reproduces the crash the guard prevents, and on the shared host that is a
+# forced reboot. This blocks (exit 2) make install, lunatik reload/run/spawn/test and
+# a direct test run while any worktree of the project, against its HEAD, removes a
+# line carrying a guard, unless the command carries the CRASH_AB_OK=1 marker, set by
+# hand once the maintainer authorized the experiment and named the machine it may
+# take down. Silent (exit 0) on everything else. The marker forces the ask; it cannot
+# check that the answer was yes, only that it was set on purpose.
+# Matches the raw hook input, which embeds the command verbatim.
+
+input=$(cat)
+
+case "$input" in
+	*"make install"*|*"lunatik reload"*|*"lunatik run"*|*"lunatik spawn"*|*"lunatik test"*|*"bash tests/"*|*"/run.sh"*) ;;
+	*) exit 0 ;;
+esac
+
+case "$input" in
+	*CRASH_AB_OK=1*) exit 0 ;;
+esac
+
+guards='lunatik_argcheckclass|lunatik_argchecknull|lunatik_checkobject|lunatik_checkpobject|LUNATIK_PRIVATECHECKER'
+guards="$guards|luaL_argcheck|luaL_argexpected|luaL_checktype|luaL_checkudata|lunatik_checkruntime"
+guards="$guards|lunatik_checkpercpu|lunatik_checkcontext|lunatik_checkclass|lunatik_cannotsleep"
+
+project=${CLAUDE_PROJECT_DIR:-$(printf '%s' "$input" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)}
+[ -d "$project" ] || exit 0
+
+removed=$(git -C "$project" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}' | while read -r tree; do
+	[ -d "$tree" ] || continue
+	git -C "$tree" diff HEAD -U0 -- '*.c' '*.h' 2>/dev/null | grep -E '^-[^-]' | grep -E "$guards" | sed "s|^|$tree: |"
+done)
+[ -z "$removed" ] && exit 0
+
+echo "crash-guard: a worktree drops a crash guard; installing or running it reproduces the crash the guard prevents, which on the shared host is a forced reboot:" >&2
+echo "$removed" >&2
+echo "crash-guard: commit the change if it is not an experiment; for an experiment, get the maintainer's authorization and the machine it may take down, then re-run with CRASH_AB_OK=1 as a command prefix." >&2
+exit 2
+

--- a/tools/checks/guard-removed.sh
+++ b/tools/checks/guard-removed.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Names the crash guards a C file drops against HEAD, for an editor or assistant to
+# see at edit time: removing one and running the test that covers it reproduces the
+# crash the guard prevents. Takes file paths; silent on files that drop none.
+# crash-guard.sh blocks the install or run that would follow.
+
+guards='lunatik_argcheckclass|lunatik_argchecknull|lunatik_checkobject|lunatik_checkpobject|LUNATIK_PRIVATECHECKER'
+guards="$guards|luaL_argcheck|luaL_argexpected|luaL_checktype|luaL_checkudata|lunatik_checkruntime"
+guards="$guards|lunatik_checkpercpu|lunatik_checkcontext|lunatik_checkclass|lunatik_cannotsleep"
+
+for file in "$@"; do
+	case "$file" in *.c|*.h) ;; *) continue ;; esac
+	removed=$(git -C "$(dirname "$file")" diff HEAD -U0 -- "$(basename "$file")" 2>/dev/null | grep -E '^-[^-]' | grep -E "$guards")
+	[ -z "$removed" ] && continue
+	echo "$file drops a crash guard against HEAD:"
+	echo "$removed"
+	echo "Running the test that covers it reproduces the crash the guard prevents; on the shared host that is a forced reboot. An experiment needs the maintainer's authorization and a machine that may go down (CRASH_AB_OK=1); otherwise commit, or restore the guard."
+done
+


### PR DESCRIPTION
Three lessons from verifying #782, #779 and #776 on this host.

A branch was checked for an afternoon against the previous install, because its worktree had never run `make`, `scripts_install` failed at the autogen files and the redirect hid it; and `lunatik test` unloading the modules on exit read as modules vanishing. One stray packet in the xdp detach case's window became four failures, since the case returned with its program still attached, and the packet itself was never captured: injecting one reproduced the signature on demand. And an A/B that removed a class check and ran the test covering it reproduced the kernel oops the check prevents, on the shared host, twice.

`AGENTS.md` gains the install and reload rules under "Build, install, test", the case-teardown and crash-guard bullets under "Tests", and the injection method next to the non-determinism rule. `tools/checks/guard-removed.sh` names a dropped guard at edit time, and `tools/checks/crash-guard.sh`, a `PreToolUse` hook beside the review guard, blocks an install, reload or run while any worktree drops one unless the command carries `CRASH_AB_OK=1`, set after the maintainer's authorization. The `lunatik-cycle` skill orders the steps accordingly. The test-side fixes themselves are in #779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
