### PR TITLE
harness: what the hand-back carries, and a pull request body that opens with the failure

### DIFF
--- a/.agents/skills/pr-prep/SKILL.md
+++ b/.agents/skills/pr-prep/SKILL.md
@@ -13,5 +13,12 @@ no "Test plan" section, no em dashes. On top of it:
   covers the trailing blank line on staged files.
 - Fixup commits stay unsquashed unless squashing was explicitly requested; the maintainer
   reviews them before they are folded.
+- Every function the diff touches is re-read whole before the hand-back: is a new branch this
+  function's job or its caller's; is a condition with stack juggling a predicate helper; did the
+  new shape leave a guard redundant.
+- The hand-back lists the findings of your own review the change does not apply, each with its
+  reason; none is dropped in silence.
+- The hand-back carries the test matrix: for each guard or mechanism the change adds, operations
+  by types by outcomes, each cell with its test or the reason it is not covered.
 - After any force-push, re-read the title and body against the branch as it now stands.
 

--- a/.agents/skills/pr-prep/SKILL.md
+++ b/.agents/skills/pr-prep/SKILL.md
@@ -20,5 +20,8 @@ no "Test plan" section, no em dashes. On top of it:
   reason; none is dropped in silence.
 - The hand-back carries the test matrix: for each guard or mechanism the change adds, operations
   by types by outcomes, each cell with its test or the reason it is not covered.
+- The body opens with the failure or the need in one plain sentence, then what the change does,
+  then what it depends on: three short paragraphs at most; `bash tools/checks/pr-body.sh <file>`
+  before posting it.
 - After any force-push, re-read the title and body against the branch as it now stands.
 

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -17,6 +17,12 @@ comments, after a round. Follow it whole; this card is only the GitHub mechanics
   `gh api repos/.../issues/<N>/comments` and `gh api repos/.../pulls/<N>/comments` for the
   conversation, `gh api -X PATCH repos/.../pulls/<N> -f title=... -F body=@file` to edit.
 
+# Before the verdict
+
+- Write the matrix the change is held to: for each guard or mechanism it adds, the operations by
+  types by outcomes, and read the tests against it, cell by cell. A test set taken as given because
+  it came with the branch, or with the branch a rewrite replaces, is the review not done.
+
 # Posting the review (only when asked; placement is decided BEFORE posting)
 
 Each finding goes inline on its line; the review body is only the verdict, opening with the

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,8 @@
         "matcher": "Bash",
         "hooks": [
           { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/review-post-guard.sh\"" },
-          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/crash-guard.sh\"" }
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/crash-guard.sh\"" },
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/pr-body-guard.sh\"" }
         ]
       }
     ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,11 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
 * Do not duplicate a struct defined by another module; use its exported API.
 * Prefer a named `static inline` helper over an open coded repetition, and do not inline an existing
   named helper into its callers while refactoring; they exist for readability and symmetry.
+* A function does one thing; whether to do it is its caller's decision. An early return added at the
+  top of a function that creates something, guarded by a lookup with its own stack juggling, moves
+  that decision into the wrong place: the lookup becomes a `has`/`is` predicate beside the ones the
+  header already has, and the caller that loops over the work tests it. `lunatik_newclass` grew such
+  a guard and gave it back to `lunatik_newclasses` through `lunatik_hasclass`.
 * When a two line pattern repeats in every method, collapse it into one helper or macro.
 * A helper meant to be shared is held to a higher design bar than a one-off, because everything
   built on it inherits its shape: a pair mirrors, so whatever one half acquires or registers its
@@ -473,6 +478,11 @@ old factory — kept building and broke at the first packet.
   the path taken.
 * Naming an existing literal is done by visiting every call site of what carries it: sweep for the
   function's callers or the field's users, not for the literal, which misses positional arguments.
+* Changing the value of a field visits every reader of it, in the code and in the field's doc, and
+  asks what each does with the value: `class->name` is the type name a type error quotes and the
+  key `lunatik_require` registers the library under, and renaming `rcu` to `rcu.table` for the
+  first opened `luarcu` twice in every runtime through the second. A reader that merely compiles
+  against the new value is not accounted for.
 * A force-push that restructures a branch is not done until the pull request title and body are
   re-read against it. They describe the branch; a rewrite that drops or replaces a mechanism turns
   them into fiction the reviewer reads first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,10 @@ before a shell call like the review guard below, blocks an install, reload or ru
 worktree drops such a line, unless the command carries `CRASH_AB_OK=1`, set once the maintainer
 authorized the experiment and named the machine it may take down.
 
+`pr-body.sh` takes a pull request body file and fails it on more than three paragraphs, an em dash
+or a "Test plan" section; `pr-body-guard.sh`, wired before a shell call like `crash-guard.sh`,
+blocks a `gh` write to pulls that carries a body file the check fails on.
+
 `review-post-guard.sh` reads the tool command on stdin instead of a file, for an assistant wired
 to run it before a shell call (`PreToolUse`): it blocks a `gh` write to reviews or comments unless
 the command carries the `REVIEW_POST_OK` marker, set once the exact text has been shown to the
@@ -462,6 +466,11 @@ old factory — kept building and broke at the first packet.
   not say: a new API, a behaviour change, a non obvious rationale. No bullet list of every detail.
 * A pull request title and body follow the same rule: what and why, nothing the commits already say.
   No "Test plan" section, and no em dashes.
+* The body opens with the failure or the need in one plain sentence — what a script can do today,
+  what breaks, what has nowhere to live — then says what the change does, in a few lines, and what
+  it depends on. Three short paragraphs at most. How the problem was found, what was measured and
+  what was tried belong in the commits; a body a reviewer has to study is not a summary.
+  `tools/checks/pr-body.sh` holds a body file to this.
 * A pull request is one mechanism, read in one screen of diff and one paragraph of body. A body that
   needs a section per mechanism describes several pull requests: stack them, each on the one below.
 * No session links or assistant footers in a commit or a pull request beyond the `Co-Authored-By`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,12 +498,25 @@ dropped or a rationale its call sites contradict, is caught there, as *Patches a
 Saying the prose matches is not the check; showing the claim-to-code mapping is. A change shown
 without that pass is not done.
 
+Before the hand-back, every function the diff touches is re-read whole, not by its changed lines:
+a new branch is asked whether it is this function's job or its caller's, a condition with stack
+juggling is asked whether it is a predicate helper, and a guard the new shape made redundant is
+removed. The maintainer reading a function and finding it dirtier than before is the pass not run.
+
+The hand-back lists each finding of your own review that the change does not apply, with the
+reason. A finding dropped in silence is found again by the maintainer, who then doubts the whole
+review; and "few sites" is not a reason against a rule that collapses a repeated pattern — three
+class tests written by hand where the checker takes the classes were that.
+
 ## Before opening a pull request
 
 1. `make` is clean, with no new warnings;
 2. `sudo make install && sudo lunatik reload && sudo lunatik test` passes;
 3. new API is documented and listed in `config.ld` and the README;
-4. new tests are wired into their suite and described;
+4. new tests are wired into their suite and described, and the hand-back carries the matrix the
+   change is held to: for each guard or mechanism it adds, the operations by types by outcomes,
+   each cell naming its test or saying why it is not covered. Wiring is what a check confirms; the
+   matrix is what a rewrite inherits from the branch it replaces unless it is written down;
 5. error paths audited: for each raise, everything already acquired is released;
 6. commits are small, ordered, and none of them undoes another;
 7. every helper the change introduces has a caller. A helper extracted to remove duplication but
@@ -611,6 +624,8 @@ is how a mutex in softirq and a crash reachable from Lua were passed.
   `tc`'s BPF programs were right to declare `Dual MIT/GPL`; the `xdp` ones still on `GPL` are what a
   separate cleanup fixes.
 * Missing tests are a finding of their own, written as such, not a remark appended to another comment.
+  The review writes the matrix the change is held to and reads the tests against it; a test set
+  taken as given because it came with the branch is the review not done.
 * A contract the author documented is not redesigned by the review. An ergonomics preference, `nil`
   against an object whose methods raise, is stated with its trade-off and left to the maintainer;
   shipped as a fixup, it asks the author to un-decide.

--- a/tools/checks/module-conventions.sh
+++ b/tools/checks/module-conventions.sh
@@ -45,6 +45,8 @@ check() {
 		add "casts into __percpu without __force; a cast into an annotated address space carries __force, as the opt constants do"
 	grep -nE 'lunatik_toobject\(L, *(-?[0-9]+|ix)\)->private' "$file" 2>/dev/null | grep -vE 'lunatik_getregistry|_key\)' | grep -q . && \
 		add "reads ->private through lunatik_toobject on an argument; lunatik_toobject returns NULL for a non-userdata, so a checker (lunatik_checkobject) goes first"
+	grep -nE '(object|[a-z]+)->class *== *&lua[a-z_]+_class' "$file" 2>/dev/null | grep -q . && \
+		add "tests the class by hand; LUNATIK_PRIVATECHECKER and lunatik_argcheckclass take the class, LUNATIK_PRIVATECHECKERS a list of them"
 	# a method that reads private as its own type right after lunatik_checkobject, which
 	# accepts any Lunatik object, skips the class check; a checker tests the class in between.
 	awk '

--- a/tools/checks/pr-body-guard.sh
+++ b/tools/checks/pr-body-guard.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PreToolUse (Bash) hook: a pull request body is posted only when pr-body.sh passes on
+# it. This blocks (exit 2) a gh write to pulls that carries a body file (-F body=@file)
+# the check fails on, printing the findings; silent (exit 0) on everything else.
+# Matches the raw hook input, which embeds the command verbatim.
+
+input=$(cat)
+
+case "$input" in
+	*"gh api"*pulls*"body=@"*|*"gh pr create"*"--body-file"*|*"gh pr edit"*"--body-file"*) ;;
+	*) exit 0 ;;
+esac
+
+file=$(printf '%s' "$input" | sed -n 's/.*body=@\([^ "\\]*\).*/\1/p; s/.*--body-file[ =]\([^ "\\]*\).*/\1/p' | head -1)
+[ -n "$file" ] && [ -f "$file" ] || exit 0
+
+findings=$(bash "$(dirname "$0")/pr-body.sh" "$file")
+[ -z "$findings" ] && exit 0
+
+echo "pr-body-guard: $findings" >&2
+exit 2
+

--- a/tools/checks/pr-body.sh
+++ b/tools/checks/pr-body.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Checks a pull request body against AGENTS.md, "Patches and commits": at most three
+# paragraphs, the first one the failure or the need, no em dash and no "Test plan"
+# section. Takes the body file; prints what fails and exits 1, silent otherwise. The
+# footer an assistant appends (a line opening with an emoji) does not count.
+
+status=0
+for file in "$@"; do
+	body=$(grep -v '^🤖' "$file")
+	paragraphs=$(printf '%s\n' "$body" | awk 'BEGIN{n=0; blank=1} /^[[:space:]]*$/{blank=1; next} {if (blank) n++; blank=0} END{print n}')
+	if [ "$paragraphs" -gt 3 ]; then
+		echo "$file: $paragraphs paragraphs; a body is the failure, the change and what it depends on, three at most"
+		status=1
+	fi
+	if printf '%s' "$body" | grep -q '—'; then
+		echo "$file: carries an em dash"
+		status=1
+	fi
+	if printf '%s' "$body" | grep -qi 'test plan'; then
+		echo "$file: carries a Test plan section"
+		status=1
+	fi
+done
+exit $status
+


### PR DESCRIPTION
The rewrite of #776 was handed over with a review finding dropped in silence, tests inherited from the branch it replaced, a function carrying a decision that was its caller's, a field renamed without visiting its second reader, and pull request bodies that said everything but the failure.

`AGENTS.md` names each in the hand-back pass (findings not applied, the test matrix, every touched function re-read whole), in "C style" and "Patches and commits" (a decision is its caller's, a field's readers are visited, a body opens with the failure); `module-conventions.sh` flags a class test written by hand, and `pr-body.sh` with its `PreToolUse` guard holds a body to three paragraphs. The `pr-prep` and `review-pr` skills carry the steps.
