### PR TITLE
harness: sparse for an address space, the doc build by its exit status, and a long function asks for a helper

### DIFF
--- a/.agents/skills/lunatik-cycle/SKILL.md
+++ b/.agents/skills/lunatik-cycle/SKILL.md
@@ -8,6 +8,7 @@ AGENTS.md, "Build, install, test", is the authority; this skill orders the workf
 # The cycle
 
     make
+    make C=1                 # sparse, for a change touching __percpu or another address space
     sudo make install        # never a partial *_install
     sudo lunatik reload      # never rmmod by hand
     sudo lunatik test [suite]

--- a/.agents/skills/pr-prep/SKILL.md
+++ b/.agents/skills/pr-prep/SKILL.md
@@ -7,8 +7,10 @@ Run AGENTS.md, "Before opening a pull request" (every item) and the pull request
 under "Patches and commits": title and body say what and why, nothing the commits already say,
 no "Test plan" section, no em dashes. On top of it:
 
-- When `@type`/`@treturn` changed, generate the docs (`ldoc .`) and check the links land on
-  types, not functions.
+- When a doc block, `@type`, `@treturn` or `config.ld` changed, run `make doc-site LUA=lua5.4`, the
+  CI target, and read its exit status: LDoc quits on a module it cannot place with a line that
+  says neither "warning" nor "error", so a grep for those passes a failed run. Then check the links
+  land on types, not functions.
 - Compare `git diff` against `git diff -w` for stray whitespace; `bash tools/checks/pre-commit`
   covers the trailing blank line on staged files.
 - Fixup commits stay unsquashed unless squashing was explicitly requested; the maintainer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,7 +529,11 @@ class tests written by hand where the checker takes the classes were that.
 
 ## Before opening a pull request
 
-1. `make` is clean, with no new warnings;
+1. `make` is clean, with no new warnings, and a change that touches a `__percpu` pointer, or any
+   other address-space annotated one, is clean under `make C=1` too: sparse models the annotation as
+   an address space, as GCC 14 on x86 does for `__percpu` (`__seg_gs`), so a `void *` holding one, or
+   a cast between the two, is a warning here and a build error there. The `lunatik_percpuruntimes`
+   cast and `object->private = runtimes` were both;
 2. `sudo make install && sudo lunatik reload && sudo lunatik test` passes;
 3. new API is documented and listed in `config.ld` and the README;
 4. new tests are wired into their suite and described, and the hand-back carries the matrix the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -535,7 +535,10 @@ class tests written by hand where the checker takes the classes were that.
    a cast between the two, is a warning here and a build error there. The `lunatik_percpuruntimes`
    cast and `object->private = runtimes` were both;
 2. `sudo make install && sudo lunatik reload && sudo lunatik test` passes;
-3. new API is documented and listed in `config.ld` and the README;
+3. new API is documented and listed in `config.ld` and the README, and `make doc-site LUA=lua5.4`,
+   the CI target, exits zero: a C file that contributes to a module another file declares carries
+   `@module` with the same name, which `merge = true` in `config.ld` folds, since `@submodule`
+   deduces its section name from a path under `lib/`;
 4. new tests are wired into their suite and described, and the hand-back carries the matrix the
    change is held to: for each guard or mechanism it adds, the operations by types by outcomes,
    each cell naming its test or saying why it is not covered. Wiring is what a check confirms; the


### PR DESCRIPTION
The percpu object on master does not build on x86 with GCC 14, where `__percpu` is the `__seg_gs` address space: a `void *` held the pointer and a cast brought it back. On this aarch64 host both lines are silent to GCC and flagged by sparse. A core file added with `@submodule` quit LDoc in CI after a local run filtered for "warning" and "error" had passed it. And a register of thirty-nine lines went to review whole, where the rule that a step wants a name was prose only.

`AGENTS.md` asks `make C=1` of a change touching an address-space annotated pointer and `make doc-site` read by its exit status of a change touching the docs; `module-conventions.sh` flags a function past thirty lines of body; the `lunatik-cycle` and `pr-prep` skills carry the steps.
