### PR TITLE
lunatik: test the object pointer against NULL in lunatik_checkpobject

### DIFF
--- a/lunatik.h
+++ b/lunatik.h
@@ -347,7 +347,7 @@ static inline lunatik_object_t **lunatik_testobject(lua_State *L, int ix)
 static inline lunatik_object_t **lunatik_checkpobject(lua_State *L, int ix)
 {
 	lunatik_object_t **pobject = lunatik_testobject(L, ix);
-	luaL_argcheck(L, pobject, ix, "invalid object");
+	luaL_argcheck(L, pobject != NULL, ix, "invalid object");
 	return pobject;
 }
 


### PR DESCRIPTION
`lunatik_checkpobject` passes the object pointer to `luaL_argcheck` as the condition; sparse notes a pointer used as a plain integer. Compare it to `NULL`.
