### PR TITLE
lunatik: fetch a registered object through one checked call

### DIFF
--- a/doc/capi.md
+++ b/doc/capi.md
@@ -362,6 +362,15 @@ int lunatik_getregistry(lua_State *L, void *key);
 Pushes the value stored in `LUA_REGISTRYINDEX` at `key` onto the Lua stack and returns
 its type. Defined as a macro wrapping `lua_rawgetp`.
 
+### lunatik\_getregistryobject
+```C
+lunatik_object_t *lunatik_getregistryobject(lua_State *L, void *key);
+```
+Pushes the value stored in `LUA_REGISTRYINDEX` at `key` and returns it as a Lunatik object, or
+`NULL` when there is none or it is no Lunatik object: a hook that reaches for the object it
+registered (an `skb`, a handle) reads it through this rather than through `lunatik_toobject`,
+which does not check.
+
 ### lunatik\_attach
 ```C
 void lunatik_attach(lua_State *L, obj, field, new_fn, ...);

--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -167,10 +167,9 @@ static luahid_t *luahid_gethid(struct hid_device *hdev)
 
 static inline lunatik_object_t *luahid_pushdata(lua_State *L, luahid_ctx_t *ctx)
 {
-	lunatik_object_t *obj;
+	lunatik_object_t *obj = lunatik_getregistryobject(L, ctx->hid->data);
 
-	if (lunatik_getregistry(L, ctx->hid->data) != LUA_TUSERDATA ||
-	    unlikely((obj = lunatik_toobject(L, -1)) == NULL)) {
+	if (unlikely(obj == NULL)) {
 		ctx->ret = -ENXIO;
 		luaL_error(L, "couldn't find data");
 	}

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -52,14 +52,10 @@ static inline bool luanetfilter_pushcb(lua_State *L, luanetfilter_t *luanf)
 
 static inline lunatik_object_t *luanetfilter_pushskb(lua_State *L, luanetfilter_t *luanf, struct sk_buff *skb)
 {
-	if (lunatik_getregistry(L, luanf->skb) != LUA_TUSERDATA) {
-		pr_err("couldn't find skb\n");
-		return NULL;
-	}
+	lunatik_object_t *object = lunatik_getregistryobject(L, luanf->skb);
 
-	lunatik_object_t *object = lunatik_toobject(L, -1);
 	if (unlikely(object == NULL)) {
-		pr_err("couldn't get skb object\n");
+		pr_err("couldn't find skb\n");
 		return NULL;
 	}
 
@@ -72,12 +68,13 @@ static int luanetfilter_hook_cb(lua_State *L, luanetfilter_hook_t *hook, struct 
 	lunatik_object_t *object = NULL;
 	int ret = -1;
 
-	if (lunatik_getregistry(L, hook) != LUA_TUSERDATA) {
+	lunatik_object_t *handle = lunatik_getregistryobject(L, hook);
+	if (handle == NULL) {
 		pr_err("couldn't find hook\n");
 		goto out;
 	}
 
-	luanetfilter_t *luanf = (luanetfilter_t *)lunatik_toobject(L, -1)->private;
+	luanetfilter_t *luanf = (luanetfilter_t *)handle->private;
 	if (!luanetfilter_pushcb(L, luanf) || (object = luanetfilter_pushskb(L, luanf, skb)) == NULL)
 		goto out;
 

--- a/lunatik.h
+++ b/lunatik.h
@@ -398,6 +398,12 @@ LUNATIK_CHECKER(checker, T, luaL_argexpected(L, lunatik_isoneof(object->class, c
 
 #define lunatik_getregistry(L, key)	lua_rawgetp((L), LUA_REGISTRYINDEX, (key))
 
+static inline lunatik_object_t *lunatik_getregistryobject(lua_State *L, void *key)
+{
+	lunatik_object_t **pobject = lunatik_getregistry(L, key) == LUA_TUSERDATA ? lunatik_testobject(L, -1) : NULL;
+	return pobject != NULL ? *pobject : NULL;
+}
+
 #define lunatik_setstring(L, idx, hook, field, maxlen)		\
 do {								\
 	size_t len;						\


### PR DESCRIPTION
Three hooks fetched the object they had registered by reading the registry and taking the userdata pointer unchecked, each with two error paths of its own.

`lunatik_getregistryobject(L, key)` pushes the value and returns the object or `NULL`, through `lunatik_testobject`; the netfilter skb and hook handle and the hid data read it. Stacked on #785.
