### PR TITLE
lunatik: percpu:resume delivers to every runtime

### DIFF
--- a/lunatik.h
+++ b/lunatik.h
@@ -122,6 +122,7 @@ static inline int lunatik_trylock(lunatik_object_t *object)
 int lunatik_runtime(lunatik_object_t **pruntime, const char *script, lunatik_opt_t opt);
 int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt,
 	lunatik_object_t *percpu, int cpu);
+int lunatik_resume(lua_State *Lto, lua_State *Lfrom, int ixfrom, int nargs);
 int lunatik_stop(lunatik_object_t *runtime);
 int lunatik_copyobjects(lua_State *Lto, lua_State *Lfrom, int ixfrom, int nobjects);
 

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -119,11 +119,13 @@ int lunatik_copyobjects(lua_State *Lto, lua_State *Lfrom, int ixfrom, int nobjec
 }
 EXPORT_SYMBOL(lunatik_copyobjects);
 
-static inline int lunatik_resume(lua_State *Lto, lua_State *Lfrom, int nargs)
+int lunatik_resume(lua_State *Lto, lua_State *Lfrom, int ixfrom, int nargs)
 {
 	int nresults;
-	int status = lua_resume(Lto, Lfrom, nargs, &nresults);
-	return status == LUA_OK || status == LUA_YIELD ? nresults : -1;
+
+	if (lunatik_copyobjects(Lto, Lfrom, ixfrom, nargs) != LUA_OK)
+		return -ECANCELED;
+	return lua_resume(Lto, Lfrom, nargs, &nresults) > LUA_YIELD ? -ECANCELED : nresults;
 }
 
 /***
@@ -140,9 +142,9 @@ static int lunatik_lresume(lua_State *L)
 {
 	lua_State *Lto = lunatik_check(L, 1);
 	int nargs = lua_gettop(L) - 1;
-	int nresults = 0;
+	int nresults = lunatik_resume(Lto, L, 2, nargs);
 
-	if (lunatik_copyobjects(Lto, L, 2, nargs) != LUA_OK || (nresults = lunatik_resume(Lto, L, nargs)) < 0) {
+	if (nresults < 0) {
 		lua_pushfstring(L, "%s\n", lua_tostring(Lto, -1));
 		lua_pop(Lto, 1); /* error message */
 		lua_error(L);

--- a/lunatik_percpu.c
+++ b/lunatik_percpu.c
@@ -100,6 +100,54 @@ static void lunatik_releasepercpu(void *private)
 	free_percpu(percpu->runtimes);
 }
 
+static int lunatik_resumeruntime(lua_State *L, lunatik_object_t *runtime, int nargs, char *error)
+{
+	int nresults = -ENXIO;
+
+	lunatik_lock(runtime); /* a runtime dispatches as soon as its script registers a hook */
+	if (likely(lunatik_isready(runtime))) {
+		lua_State *Lto = lunatik_getstate(runtime);
+
+		nresults = lunatik_resume(Lto, L, 2, nargs);
+		if (nresults < 0) /* the caller raises: a longjmp here would skip the unlock */
+			strscpy(error, lua_tostring(Lto, -1) ?: "error object is not a string", LUAL_BUFFERSIZE);
+		lua_pop(Lto, nresults < 0 ? 1 : nresults); /* the message, or the yield a broadcast drops */
+	}
+	lunatik_unlock(runtime);
+	return nresults;
+}
+
+/***
+* Resumes every runtime, as `runtime:resume` does, delivering the same objects to each. Nothing
+* comes back: a broadcast has no single set of values to return, so what a runtime yields is
+* dropped.
+* @function resume
+* @param ... objects delivered to each runtime as the return values of its `coroutine.yield()`
+* @raise "null pointer dereference" if the object has been stopped; otherwise the error of the
+*   first runtime that refuses a value it cannot carry or raises on resumption, naming its CPU,
+*   with the runtimes after it not resumed. A runtime that refuses a value stays where it yielded;
+*   one that raises is dead, so every later resume delivers to the CPUs before it again and fails
+*   on it again
+*/
+static int lunatik_resumepercpu(lua_State *L)
+{
+	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &lunatik_percpu_class);
+	lunatik_percpu_t *percpu = lunatik_topercpu(object);
+	int nargs = lua_gettop(L) - 1;
+	char error[LUAL_BUFFERSIZE];
+	lunatik_object_t *runtime;
+	int cpu;
+
+	lunatik_foreachruntime(percpu, cpu, runtime) {
+		int status = lunatik_resumeruntime(L, runtime, nargs, error);
+
+		luaL_argcheck(L, status != -ENXIO, 1, LUNATIK_ERR_NULLPTR);
+		if (status < 0)
+			luaL_error(L, "cpu %d: %s", cpu, error);
+	}
+	return 0;
+}
+
 /***
 * Closes the objects the runtimes share, then every runtime, releasing their Lua states.
 * @function stop
@@ -117,6 +165,7 @@ static const luaL_Reg lunatik_percpu_mt[] = {
 	{"__gc", lunatik_deleteobject},
 	{"__close", lunatik_stoppercpu},
 	{"stop", lunatik_stoppercpu},
+	{"resume", lunatik_resumepercpu},
 	{NULL, NULL}
 };
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -236,6 +236,18 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   of another library; `rcu.map` refuses `nil`; and a method on a closed
   runtime or fifo is refused instead of dereferencing its NULL private.
 
+- **resume_percpu**: `percpu:resume()` delivers the objects it is given to
+  every runtime of a process set and of a softirq one, each marking its own
+  CPU id in the shared `rcu.table`s it receives, and two of them are marked in
+  the order they were passed; what a runtime yields is dropped, and the next
+  `resume()` carries the runtimes past their yield; a hardirq set, whose
+  runtimes resume under `spin_lock_irqsave`, receives what it is given and
+  raises when it is given nothing; the error a runtime raises comes back naming
+  it and leaves that runtime dead, so the next `resume()` fails on it again,
+  while a value that cannot cross is refused without consuming the yield; and
+  it refuses a stopped object, whose runtimes have no state left, and an object
+  of another class.
+
 - **resume_mailbox**: `completion` objects pass through `runtime:resume()`
   to enable the mailbox pattern. Sub-runtime sends via `fifo` +
   `completion`; main runtime receives.

--- a/tests/runtime/resume_percpu.lua
+++ b/tests/runtime/resume_percpu.lua
@@ -1,0 +1,93 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Driver script for the percpu resume test (see resume_percpu.sh).
+
+local lunatik = require("lunatik")
+local linux   = require("linux")
+local rcu     = require("rcu")
+local test    = require("util").test
+
+local SCRIPT <const> = "tests/runtime/resume_percpu_recv"
+local FAILING <const> = "tests/runtime/resume_percpu_fail"
+local IRQ <const> = "tests/runtime/resume_percpu_irq"
+local ANSWER <const> = 42
+
+test("resume delivers the same object to every runtime", function()
+	local seen = rcu.table()
+	local runtimes <close> = lunatik.percpu(SCRIPT)
+	runtimes:resume(seen)
+	for cpu = 0, linux.numcpus() - 1 do
+		assert(seen[tostring(cpu)], "runtime " .. cpu .. " did not receive the object")
+	end
+	assert(select("#", runtimes:resume()) == 0, "resume returned what a runtime yielded")
+	for cpu = 0, linux.numcpus() - 1 do
+		assert(seen[tostring(cpu)] == nil, "runtime " .. cpu .. " was not resumed past its yield")
+	end
+end)
+
+test("resume delivers to the runtimes of a softirq set", function()
+	local seen = rcu.table()
+	local runtimes <close> = lunatik.percpu(SCRIPT, "softirq")
+	runtimes:resume(seen)
+	for cpu = 0, linux.numcpus() - 1 do
+		assert(seen[tostring(cpu)], "softirq runtime " .. cpu .. " did not receive the object")
+	end
+end)
+
+test("resume delivers every object it is given, in order", function()
+	local first, second = rcu.table(), rcu.table()
+	local runtimes <close> = lunatik.percpu(SCRIPT)
+	runtimes:resume(first, second)
+	for cpu = 0, linux.numcpus() - 1 do
+		local id = tostring(cpu)
+		assert(first[id] == 1 and second[id] == 2, "runtime " .. cpu .. " did not receive both objects in order")
+	end
+end)
+
+test("resume delivers to the runtimes of a hardirq set", function()
+	local runtimes <close> = lunatik.percpu(IRQ, "hardirq")
+	runtimes:resume(rcu.table())
+	local ok, err = pcall(runtimes.resume, runtimes)
+	assert(not ok, "a hardirq runtime accepted a resume that delivered nothing")
+	assert(err:match("nothing was delivered"), "resume raised something else: " .. tostring(err))
+	assert(err:match("cpu %d+"), "the error does not name the CPU: " .. tostring(err))
+end)
+
+test("resume raises what a runtime raises", function()
+	local runtimes <close> = lunatik.percpu(FAILING)
+	local ok, err = pcall(runtimes.resume, runtimes, rcu.table())
+	assert(not ok, "resume accepted a script that errors")
+	assert(err:match("intentional error on resumption"), "resume raised something else: " .. tostring(err))
+	assert(err:match("cpu %d+"), "the error does not name the CPU: " .. tostring(err))
+	local again = select(2, pcall(runtimes.resume, runtimes, rcu.table()))
+	assert(again:match("cannot resume dead coroutine"), "the raising runtime was left resumable: " .. tostring(again))
+end)
+
+test("resume refuses a value that is not an object", function()
+	local runtimes <close> = lunatik.percpu(SCRIPT)
+	local ok, err = pcall(runtimes.resume, runtimes, ANSWER)
+	assert(not ok, "resume accepted a value that is not an object")
+	assert(err:match("invalid object"), "resume raised something else: " .. tostring(err))
+	assert(err:match("cpu %d+"), "the error does not name the CPU: " .. tostring(err))
+	local seen = rcu.table()
+	runtimes:resume(seen)
+	assert(seen["0"], "runtime 0 was not resumable after the refusal")
+end)
+
+test("resume refuses a stopped object", function()
+	local runtimes = lunatik.percpu(SCRIPT)
+	runtimes:stop()
+	local ok, err = pcall(runtimes.resume, runtimes, rcu.table())
+	assert(not ok, "resume accepted a stopped object")
+	assert(err:match("null pointer"), "resume raised something else: " .. tostring(err))
+end)
+
+test("resume refuses a percpu object of another class", function()
+	local runtimes <close> = lunatik.percpu(SCRIPT)
+	local ok, err = pcall(getmetatable(runtimes).resume, rcu.table(), rcu.table())
+	assert(not ok, "resume accepted an object of another class")
+	assert(err:match("percpu expected"), "resume raised something else: " .. tostring(err))
+end)
+

--- a/tests/runtime/resume_percpu.sh
+++ b/tests/runtime/resume_percpu.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for percpu:resume: the objects it delivers reach every
+# runtime, each of which marks its own CPU id in the shared rcu.tables the
+# driver then reads, for a process set and for a softirq one, which is what a
+# packet hook is, and two objects are marked in the order they were passed;
+# what a runtime yields is dropped, and the runtimes are resumable past their
+# yield; a hardirq set, whose runtimes resume under spin_lock_irqsave, takes
+# what it is given and raises when it is given nothing; the error a runtime
+# raises comes back naming it and leaves that runtime dead, so the next resume
+# fails on it again, while a value that cannot cross is refused before the
+# resume, leaving the runtimes where they yielded; and resume is refused on a
+# stopped object, whose runtimes have no state left, and on an object of
+# another class reached through the percpu metatable.
+#
+# Usage: sudo bash tests/runtime/resume_percpu.sh
+
+SCRIPT="tests/runtime/resume_percpu"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+mark_dmesg
+run_script "$SCRIPT"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+ktap_pass "percpu:resume delivers to every runtime of a process, softirq and hardirq set, raises what one raises, and refuses a stopped object and another class"
+
+ktap_totals
+

--- a/tests/runtime/resume_percpu_fail.lua
+++ b/tests/runtime/resume_percpu_fail.lua
@@ -1,0 +1,12 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Receiver sub-script for the percpu resume test (see resume_percpu.sh).
+
+local function recv()
+	error("intentional error on resumption")
+end
+
+return recv
+

--- a/tests/runtime/resume_percpu_irq.lua
+++ b/tests/runtime/resume_percpu_irq.lua
@@ -1,0 +1,17 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Receiver sub-script for the percpu resume test (see resume_percpu.sh).
+
+local function recv(delivered)
+	while true do
+		if delivered == nil then
+			error("nothing was delivered")
+		end
+		delivered = coroutine.yield()
+	end
+end
+
+return recv
+

--- a/tests/runtime/resume_percpu_recv.lua
+++ b/tests/runtime/resume_percpu_recv.lua
@@ -1,0 +1,21 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Receiver sub-script for the percpu resume test (see resume_percpu.sh).
+
+local lunatik = require("lunatik")
+
+local function recv(first, second)
+	local cpu = tostring(lunatik.cpu())
+
+	first[cpu] = 1
+	if second ~= nil then
+		second[cpu] = 2
+	end
+	coroutine.yield(first)
+	first[cpu] = nil
+end
+
+return recv
+

--- a/tests/runtime/run.sh
+++ b/tests/runtime/run.sh
@@ -15,6 +15,7 @@ TESTS=(
 	resume_shared.sh
 	resume_results.sh
 	resume_foreign.sh
+	resume_percpu.sh
 	foreign_method.sh
 	foreign_checker.sh
 	resume_mailbox.sh


### PR DESCRIPTION
A percpu script has no way to be handed an object by the runtime that started it, the quarantine set of the `ifquarantine` example: `resume` belongs to the plain runtime alone, so a script that takes its state that way cannot be one runtime per CPU.

`percpu:resume` copies the objects into each runtime and resumes it under the runtime's lock, where it also reads the state, since a runtime dispatches as soon as its script registers a hook and a stopped one has no state left. What a runtime yields is dropped, a broadcast having no single set of values to return, and the error of the first runtime that refuses a value or raises comes back naming it. Delivering the objects and resuming become one entry point, `lunatik_resume`, so that sequence is written once for both callers. Test: `resume_percpu`.

Based on #803, which fixes what `resume` does with what the script leaves behind.

