### PR TITLE
tests: the percpu rollback releases the hooks of the instances before it

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -197,7 +197,9 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   successful `netfilter.register()` call. The fix, under the runtime
   spinlock, nulls `runtime->private`, calls `lua_close(L)` to fire the
   hook finalizer (`nf_unregister_net_hook` + `symbol_put_addr`), and
-  then releases the runtime.
+  then releases the runtime. The percpu case errors on the last instance, so
+  the rollback has the hooks of the earlier ones, which the shared registration
+  holds, to release; it needs more than one CPU and skips otherwise.
 
 - **resume_shared**: `runtime:resume()` passes shared (monitored) objects
   across runtime boundaries. Push into a shared `fifo`, resume a

--- a/tests/runtime/refcnt_leak.sh
+++ b/tests/runtime/refcnt_leak.sh
@@ -16,12 +16,22 @@
 # Usage: sudo bash tests/runtime/refcnt_leak.sh
 
 SCRIPT="tests/runtime/refcnt_leak"
+PERCPU="tests/runtime/refcnt_leak_percpu"
 MODULE="luanetfilter"
 
 source "$(dirname "$(readlink -f "$0")")/../lib.sh"
 
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+	lunatik stop "$PERCPU" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+cleanup
+
 ktap_header
-ktap_plan 1
+ktap_plan 2
 
 before=$(cat /sys/module/$MODULE/refcnt 2>/dev/null) || {
 	echo "# SKIP: $MODULE not loaded"
@@ -43,6 +53,22 @@ after=$(cat /sys/module/$MODULE/refcnt 2>/dev/null)
 [ "$before" = "$after" ] || fail "$MODULE refcnt leaked: $before -> $after (fix lunatik_newruntime error path)"
 
 ktap_pass "$MODULE refcnt restored after failed script"
+
+[ "$(sed 's/.*-//' /sys/devices/system/cpu/possible)" -gt 0 ] || {
+	echo "# SKIP: the percpu rollback needs an instance before the one that fails"
+	ktap_skip "$MODULE refcnt restored after a percpu script failed on its last instance"
+	ktap_totals
+	exit 0
+}
+
+mark_dmesg
+output=$(lunatik run "$PERCPU" softirq percpu 2>&1)
+echo "$output" | grep -q "intentional error on the last instance" || \
+	fail "percpu script did not reach the intentional error: $output"
+check_dmesg || { ktap_totals; exit 1; }
+after=$(cat /sys/module/$MODULE/refcnt 2>/dev/null)
+[ "$before" = "$after" ] || fail "$MODULE refcnt leaked: $before -> $after (the rollback left a hook of an earlier instance)"
+ktap_pass "$MODULE refcnt restored after a percpu script failed on its last instance"
 
 ktap_totals
 

--- a/tests/runtime/refcnt_leak_percpu.lua
+++ b/tests/runtime/refcnt_leak_percpu.lua
@@ -1,0 +1,29 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu refcnt leak test (see refcnt_leak.sh):
+-- every instance registers a hook and the last one errors, so the rollback
+-- has hooks of earlier instances to release.
+
+local lunatik   = require("lunatik")
+local linux     = require("linux")
+local netfilter = require("netfilter")
+local nf        = require("linux.nf")
+
+local function hook(skb)
+	return nf.action.ACCEPT
+end
+
+netfilter.register{
+	hook     = hook,
+	pf       = nf.proto.INET,
+	hooknum  = nf.inet.FORWARD,
+	priority = nf.ip.pri.FILTER,
+	mark     = 0,
+}
+
+if lunatik.cpu() == linux.numcpus() - 1 then
+	error("intentional error on the last instance")
+end
+


### PR DESCRIPTION
A percpu script that errors on its last instance leaves the hooks the earlier instances registered, held by the shared registration, for the rollback to release; `refcnt_leak` covered only a plain runtime.

It now runs the same check as a percpu script that errors on its last instance, reading the module use-count, which is 6 with a hook per instance on this host and 0 once the rollback is done.
