### PR TITLE
examples: ifquarantine filters with one runtime per CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,10 +323,10 @@ released from quarantine by writing `allow=<name>` to `/dev/ifquarantine`;
 re-denied with `deny=<name>`; inspected with `cat /dev/ifquarantine`.
 
 The control runtime (process context) owns `notifier.netdevice` and the
-device; it spawns a child softirq runtime with the netfilter hook, sharing
-the quarantine set via `rcu.table` through `runtime:resume()`. Illustrates
-cross-subsystem composition between two notifier chains of different
-execution contexts.
+device; it runs the netfilter hook as a softirq percpu script, one runtime
+per CPU sharing the hook, and hands each the quarantine set via `rcu.table`
+through `percpu:resume()`. Illustrates cross-subsystem composition between
+two notifier chains of different execution contexts.
 
 #### Usage
 
@@ -336,7 +336,7 @@ sudo lunatik run examples/ifquarantine/control     # starts control+filter
 sudo cat /dev/ifquarantine                         # lists known interfaces and verdict
 sudo sh -c "echo 'allow=eth0' > /dev/ifquarantine" # lift quarantine on eth0
 sudo sh -c "echo 'deny=eth0'  > /dev/ifquarantine" # re-apply quarantine
-sudo lunatik stop examples/ifquarantine/control    # stops both runtimes
+sudo lunatik stop examples/ifquarantine/control    # stops both scripts
 ```
 
 Pre-existing interfaces are covered as well: `register_netdevice_notifier`

--- a/examples/ifquarantine/control.lua
+++ b/examples/ifquarantine/control.lua
@@ -13,6 +13,7 @@ local notify   = require("linux.notify")
 local stat     = require("linux.stat")
 
 local filter      <const> = "examples/ifquarantine/filter"
+local percpu      <const> = true
 local quarantined         = rcu.table()   -- tostring(ifindex) -> true
 local known               = {}            -- name -> ifindex
 
@@ -79,8 +80,8 @@ end
 
 device.new(driver)
 
-local rt = runner.run(filter, "softirq")
-rt:resume(quarantined)
+local runtimes = runner.run(filter, "softirq", percpu)
+runtimes:resume(quarantined)
 
 driver.sentinel = setmetatable({}, {__gc = function()
 	runner.stop(filter)


### PR DESCRIPTION
The `ifquarantine` filter is a packet hook that keeps no state of its own, the case one runtime per CPU serves, and it could not be one: it takes the quarantine set through `resume`, which the percpu object did not have.

The control runtime runs the filter as one runtime per CPU, sharing the netfilter hook, and hands each runtime the set through `percpu:resume`.

Based on #792, which gives the percpu object that `resume`.

