### PR TITLE
harness: fix what you find, read the kernel source, check the running core, read the commit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,9 @@ point it here.
 Lunatik runs Lua inside the Linux kernel. A mistake here does not raise an exception, it panics a
 machine. Two rules follow from that and outrank everything else in this document:
 
-1. **Verify, do not assume.** Before using a kernel API, read its declaration in
+1. **Verify, do not assume.** How the kernel behaves is read in its source, not inferred from a
+   measurement: which CPU a hook runs on is answered by `NF_HOOK`'s callers, and a run on one host
+   confirms that reading, it does not replace it. Before using a kernel API, read its declaration in
    `/usr/src/linux-headers-$(uname -r)/include` and confirm it is exported in `Module.symvers`. A
    kernel interface read at runtime rather than linked — a `/sys` or `/proc` path and the format it
    returns, the `/dev/lunatik` protocol — is held to the same rule: confirm it against the source
@@ -633,6 +635,10 @@ is how a mutex in softirq and a crash reachable from Lua were passed.
   window — supply it yourself and reproduce the signature on demand, and log what the hook actually
   saw before naming the packet. A mechanism proved by injection is reported as that, not as the
   trigger of the run that failed, which was not captured.
+* A defect found on the way is fixed, not reported and left: a pre-existing one, in code the change
+  does not touch, becomes a commit of its own, or a pull request of its own when it stands apart, and
+  the hand-back says which. Asking whether to fix it is asking the maintainer to decide what the
+  rules already decide.
 * A finding is resolved, not parked. When something looks wrong, run it to ground — reproduce it, find
   the cause, then fix it or dismiss it. "I'll flag it to the author", "let's look into it separately",
   or asking whether to investigate is dropping it, not handling it. Deferral is for work that belongs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,11 @@ Use `sudo make install`, not the partial `*_install` targets. Use `sudo lunatik 
 `rmmod`: the CLI knows the dependency order and unloads cleanly.
 
 `lunatik reload` cannot always replace the core module while something still holds it. If you changed
-`lunatik.ko` itself and the behaviour did not change, verify rather than assume the new core is live.
+`lunatik.ko` itself and the behaviour did not change, verify rather than assume the new core is live:
+`cat /sys/module/lunatik/srcversion` against `modinfo -F srcversion` of the installed `.ko` says
+whether the running core is the one just built. A kernel thread outliving its runtime is one way to
+pin it, and nothing short of a reboot gets it back, so a test that spawns one gives its body work
+that ends rather than a loop waiting to be stopped.
 
 After a kernel upgrade the installed modules were built for the previous kernel and fail to load with
 `Exec format error` (a vermagic mismatch). Reinstall the headers, `make clean && make`, and reinstall
@@ -461,6 +465,9 @@ old factory — kept building and broke at the first packet.
 * A change to a function is read against the whole function, not the lines it touches: re-read it
   and take the simplification the change enables. A guard left standing that the new shape made
   redundant — `!cond || check(cond)` where the call now sits inside `if (cond)` — is a partial fix.
+* Read the commit before pushing it, not only the working tree: `git show` the diff that is about to
+  be published. Instrumentation added while debugging — a `pr_err`, a hardcoded branch — is invisible
+  in a passing test and lands in the pull request.
 * Change only what the task requires. Do not reformat untouched lines, do not move code, do not
   rename variables in passing. Compare `git diff` against `git diff -w` before committing to catch
   stray whitespace.


### PR DESCRIPTION
Four lessons from the percpu round. Two pre-existing defects of an example were reported and left for the maintainer to decide on; a question about which CPU a hook runs on was answered by measuring rather than by reading the kernel source; a kernel thread left behind by a test pinned the core, so a reload kept the old one and an A/B answered for code that was never loaded; and debug instrumentation committed by accident reached a pull request.

`AGENTS.md` says a defect found on the way is fixed, that kernel behaviour is read in the source, how to tell whether the running core is the one just built, and that the commit itself is read before pushing.
