### PR TITLE
lunatik: say what runtime:resume does with what the script leaves behind

### DIFF
--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -126,28 +126,23 @@ static inline int lunatik_resume(lua_State *Lto, lua_State *Lfrom, int nargs)
 
 /***
 * Resumes a yielded runtime, analogous to `coroutine.resume`.
+* What the script leaves on its stack stays there for the next resumption, which is how a
+* script hands the function it returns to `thread.run`; nothing comes back to the caller.
 * @function resume
 * @param ... values delivered to the script as return values of `coroutine.yield()`
-* @treturn vararg values passed to the next `coroutine.yield()`, or returned by the script
 * @raise if the runtime errors on resumption
 */
 static int lunatik_lresume(lua_State *L)
 {
 	lua_State *Lto = lunatik_check(L, 1);
 	int nargs = lua_gettop(L) - 1;
-	int nresults = 0;
 
-	if (lunatik_copyobjects(Lto, L, 2, nargs) != LUA_OK || (nresults = lunatik_resume(Lto, L, nargs) < 0)) {
+	if (lunatik_copyobjects(Lto, L, 2, nargs) != LUA_OK || lunatik_resume(Lto, L, nargs) < 0) {
 		lua_pushfstring(L, "%s\n", lua_tostring(Lto, -1));
 		lua_pop(Lto, 1); /* error message */
 		lua_error(L);
 	}
-
-	int status = lunatik_copyobjects(L, Lto, nargs, nresults);
-	lua_pop(Lto, nresults);
-	if (status != LUA_OK)
-		lua_error(L);
-	return nresults;
+	return 0;
 }
 
 /***

--- a/tests/README.md
+++ b/tests/README.md
@@ -219,6 +219,10 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   of another library; `rcu.map` refuses `nil`; and a method on a closed
   runtime or fifo is refused instead of dereferencing its NULL private.
 
+- **resume_thread**: what a resumed script returns stays on its stack for the
+  next resumption, which is how `thread.run` gets a thread body, as `echod`
+  does; `resume` itself returns nothing to its caller.
+
 - **resume_mailbox**: `completion` objects pass through `runtime:resume()`
   to enable the mailbox pattern. Sub-runtime sends via `fifo` +
   `completion`; main runtime receives.

--- a/tests/runtime/resume_thread.lua
+++ b/tests/runtime/resume_thread.lua
@@ -1,0 +1,44 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Driver script for the resume/thread chaining test (see resume_thread.sh). Spawned,
+-- because thread.run is refused during module load, which is also why echod does this
+-- from its daemon thread.
+
+local lunatik = require("lunatik")
+local fifo    = require("fifo")
+local thread  = require("thread")
+local linux   = require("linux")
+
+local SCRIPT  <const> = "tests/runtime/resume_thread_body"
+local MESSAGE <const> = "resumed and spawned"
+
+local function driver()
+	local runtime = lunatik.runtime(SCRIPT)
+	local queue = fifo.new(64)
+	local returned = runtime:resume(queue)
+	thread.run(runtime, "resume_thread") -- the body pushes and returns, ending the thread
+
+	local got = ""
+	for _ = 1, 40 do
+		got = queue:pop(#MESSAGE) or ""
+		if got ~= "" then break end
+		linux.schedule(50)
+	end
+
+	if returned ~= nil then
+		print("resume_thread: FAIL resume returned a value to its caller")
+	elseif got ~= MESSAGE then
+		print("resume_thread: FAIL the thread body did not run: '" .. got .. "'")
+	else
+		print("resume_thread: PASS the thread body ran with what resume left behind")
+	end
+
+	while not thread.shouldstop() do
+		linux.schedule(100)
+	end
+end
+
+return driver
+

--- a/tests/runtime/resume_thread.sh
+++ b/tests/runtime/resume_thread.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for what runtime:resume leaves behind: a resumed script hands
+# the function it returns to the next resumption, which is how thread.run gets a
+# thread body, as the echod example does. A resume that consumed that value
+# would return it to the caller and leave the thread with nothing to run.
+#
+# Usage: sudo bash tests/runtime/resume_thread.sh
+
+SCRIPT="tests/runtime/resume_thread"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+mark_dmesg
+output=$(lunatik spawn "$SCRIPT" 2>&1)
+[ -n "$output" ] && fail "Lua error while spawning: $output"
+sleep 2
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -qF "resume_thread: PASS" || \
+	fail "$(dmesg_since | grep -o 'resume_thread: FAIL.*' | head -1)"
+ktap_pass "a resumed script hands its thread body to thread.run"
+
+ktap_totals
+

--- a/tests/runtime/resume_thread_body.lua
+++ b/tests/runtime/resume_thread_body.lua
@@ -1,0 +1,17 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Receiver sub-script for the resume/thread chaining test: the attacher returns the
+-- thread body, as the echod worker does, and resume must leave it on the stack.
+
+local MESSAGE <const> = "resumed and spawned"
+
+local function attacher(queue)
+	return function ()
+		queue:push(MESSAGE)
+	end
+end
+
+return attacher
+

--- a/tests/runtime/run.sh
+++ b/tests/runtime/run.sh
@@ -13,6 +13,7 @@ FAILED=0
 TESTS=(
 	refcnt_leak.sh
 	resume_shared.sh
+	resume_thread.sh
 	resume_foreign.sh
 	foreign_method.sh
 	foreign_checker.sh


### PR DESCRIPTION
Superseded by #803, which makes `runtime:resume` return what the resumed script left, the contract its doc block already stated, and by #802, which gives `thread.run` the arguments `echod` used to get through the stack resume left untouched.

This pull request wrote the defect down as the contract instead.
