### PR TITLE
lunatik: name the percpu field after the instances it holds

### DIFF
--- a/lunatik.h
+++ b/lunatik.h
@@ -72,12 +72,13 @@ do {							\
 do {										\
 	lunatik_object_t *_object = (object);					\
 	lunatik_object_t *_runtime = lunatik_pin(_object);			\
-	lunatik_lock(_runtime);							\
-	if (unlikely(!lunatik_isready(_runtime)))				\
-		ret = -ENXIO;							\
-	else									\
-		lunatik_handle(_runtime, handler, ret, ## __VA_ARGS__);		\
-	lunatik_unlock(_runtime);						\
+	ret = -ENXIO;								\
+	if (likely(_runtime != NULL)) {						\
+		lunatik_lock(_runtime);						\
+		if (likely(lunatik_isready(_runtime)))				\
+			lunatik_handle(_runtime, handler, ret, ## __VA_ARGS__);	\
+		lunatik_unlock(_runtime);					\
+	}									\
 	lunatik_unpin(_object);							\
 } while(0)
 

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -278,7 +278,7 @@ int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char
 
 	lunatik_setready(runtime); /* lunatik_run returns -ENXIO until here */
 
-	*pruntime = runtime;
+	smp_store_release(pruntime, runtime);
 	return 0;
 }
 

--- a/lunatik_percpu.c
+++ b/lunatik_percpu.c
@@ -73,31 +73,31 @@ static void lunatik_stopdata(lunatik_object_t *object)
 	percpu->data = NULL;
 }
 
-#define lunatik_foreachinstance(percpu, cpu, runtime)	\
+#define lunatik_foreachinstance(percpu, cpu, instance)	\
 	for_each_possible_cpu(cpu)			\
-		if ((runtime = *per_cpu_ptr((percpu)->runtimes, cpu)) != NULL)
+		if ((instance = *per_cpu_ptr((percpu)->instances, cpu)) != NULL)
 
 static void lunatik_closeinstances(lunatik_percpu_t *percpu)
 {
-	lunatik_object_t *runtime;
+	lunatik_object_t *instance;
 	int cpu;
 
-	lunatik_foreachinstance(percpu, cpu, runtime)
-		lunatik_closeprivate(runtime);
+	lunatik_foreachinstance(percpu, cpu, instance)
+		lunatik_closeprivate(instance);
 }
 
 static void lunatik_releasepercpu(void *private)
 {
 	lunatik_percpu_t *percpu = (lunatik_percpu_t *)private;
-	lunatik_object_t *runtime;
+	lunatik_object_t *instance;
 	int cpu;
 
-	if (percpu->runtimes == NULL)
+	if (percpu->instances == NULL)
 		return;
 
-	lunatik_foreachinstance(percpu, cpu, runtime)
-		lunatik_putobject(runtime); /* may run in softirq: a put, never a stop */
-	free_percpu(percpu->runtimes);
+	lunatik_foreachinstance(percpu, cpu, instance)
+		lunatik_putobject(instance); /* may run in softirq: a put, never a stop */
+	free_percpu(percpu->instances);
 }
 
 /***
@@ -148,11 +148,11 @@ int lunatik_percpu(lua_State *L)
 	lunatik_object_t *object = lunatik_newobject(L, &lunatik_percpu_class, sizeof(lunatik_percpu_t), opt);
 	lunatik_percpu_t *percpu = lunatik_topercpu(object);
 
-	if ((percpu->runtimes = alloc_percpu(lunatik_object_t *)) == NULL)
+	if ((percpu->instances = alloc_percpu(lunatik_object_t *)) == NULL)
 		lunatik_enomem(L);
 
 	for_each_possible_cpu(cpu) {
-		if (lunatik_newruntime(per_cpu_ptr(percpu->runtimes, cpu), L, script, opt, object, cpu) != 0) {
+		if (lunatik_newruntime(per_cpu_ptr(percpu->instances, cpu), L, script, opt, object, cpu) != 0) {
 			lunatik_stopdata(object);
 			lunatik_closeprivate(object); /* release the instances now, not on collection */
 			lua_error(L);

--- a/lunatik_percpu.h
+++ b/lunatik_percpu.h
@@ -31,7 +31,8 @@ static inline lunatik_object_t *lunatik_pin(lunatik_object_t *object)
 		preempt_disable();
 	else /* a process instance may sleep */
 		migrate_disable();
-	return *this_cpu_ptr(lunatik_topercpu(object)->runtimes);
+	/* an instance is published after its script ran; until then this is NULL */
+	return smp_load_acquire(this_cpu_ptr(lunatik_topercpu(object)->runtimes));
 }
 
 static inline void lunatik_unpin(lunatik_object_t *object)

--- a/lunatik_percpu.h
+++ b/lunatik_percpu.h
@@ -15,7 +15,7 @@
 #define lunatik_getpercpu(L)	(lunatik_extra(L)->percpu)
 
 typedef struct lunatik_percpu_s {
-	lunatik_object_t * __percpu *runtimes;
+	lunatik_object_t * __percpu *instances;
 	lunatik_object_t **data;
 	unsigned int ndata;
 } lunatik_percpu_t;
@@ -32,7 +32,7 @@ static inline lunatik_object_t *lunatik_pin(lunatik_object_t *object)
 	else /* a process instance may sleep */
 		migrate_disable();
 	/* an instance is published after its script ran; until then this is NULL */
-	return smp_load_acquire(this_cpu_ptr(lunatik_topercpu(object)->runtimes));
+	return smp_load_acquire(this_cpu_ptr(lunatik_topercpu(object)->instances));
 }
 
 static inline void lunatik_unpin(lunatik_object_t *object)

--- a/tests/README.md
+++ b/tests/README.md
@@ -261,10 +261,11 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
 
 - **percpu_netfilter**: the instances of a percpu script share one
   `LOCAL_IN` hook: with the ping pinned to the last online CPU, each marked
-  request is counted exactly once, by the instance of that CPU; a second
-  registration of the same hook in one instance is refused; a registration
-  from a callback, after load, is refused; and the same script registers as
-  a plain softirq runtime.
+  request is counted exactly once, by the instance of that CPU; a burst that
+  reaches the hook while the instances are still being created is accepted
+  without being counted; a second registration of the same hook in one
+  instance is refused; a registration from a callback, after load, is
+  refused; and the same script registers as a plain softirq runtime.
 
 ### set
 

--- a/tests/runtime/percpu_netfilter.sh
+++ b/tests/runtime/percpu_netfilter.sh
@@ -6,11 +6,15 @@
 # Regression test for a netfilter hook in a percpu script: the instances share one
 # LOCAL_IN hook, so each marked ping request is handled exactly once, and by the
 # instance of the CPU that received it, which is where the loopback delivers the
-# pinned ping; a second registration of the same hook in one instance is refused;
-# a registration from a callback, after the script loaded, is refused before it
+# pinned ping; a marked packet reaching that hook while the instances are still
+# being created finds none published on its CPU, and is accepted without being
+# counted; a second registration of the same hook in one instance is refused; a
+# registration from a callback, after the script loaded, is refused before it
 # could sleep in softirq; and the same script registers as a plain softirq
 # runtime. The exactly-once assertion runs on the shared hook, where it is
-# structural.
+# structural. The burst starts when the script reports the hook armed, and runs
+# inside the spin every instance does before returning, so it arrives while no
+# instance is published.
 #
 # Usage: sudo bash tests/runtime/percpu_netfilter.sh
 
@@ -18,9 +22,13 @@ SCRIPT="tests/runtime/percpu_netfilter"
 CHECK="tests/runtime/percpu_netfilter_check"
 TWICE="tests/runtime/percpu_netfilter_twice"
 LATE="tests/runtime/percpu_netfilter_late"
+EARLY="tests/runtime/percpu_netfilter_early"
+ARMED="percpu netfilter early: armed"
 MODULE="luanetfilter"
 MARK=208
 COUNT=5
+BURST=10
+TRIES=100
 
 source "$(dirname "$(readlink -f "$0")")/../lib.sh"
 
@@ -30,6 +38,17 @@ cleanup()
 	lunatik stop "$CHECK" > /dev/null 2>&1
 	lunatik stop "$TWICE" > /dev/null 2>&1
 	lunatik stop "$LATE" > /dev/null 2>&1
+	lunatik stop "$EARLY" > /dev/null 2>&1
+}
+
+burst_when_armed()
+{
+	local try
+	for ((try = 0; try < TRIES; try++)); do
+		dmesg_since | grep -qF "$ARMED" && break
+		sleep 0.02
+	done
+	ping -f -c $BURST -m $MARK 127.0.0.1 > /dev/null 2>&1
 }
 
 count_pinned()
@@ -47,11 +66,12 @@ trap cleanup EXIT
 cleanup
 
 ktap_header
-ktap_plan 4
+ktap_plan 5
 
 cat /sys/module/$MODULE/refcnt > /dev/null 2>&1 || {
 	echo "# SKIP: $MODULE not loaded"
 	ktap_skip "the instances share one hook: each marked request is counted once, by the receiving CPU"
+	ktap_skip "a packet reaching the shared hook before the instances are published is accepted, uncounted"
 	ktap_skip "a second registration of the same hook in one instance is refused"
 	ktap_skip "a registration from a callback, after load, is refused"
 	ktap_skip "the same script registers as a plain softirq runtime"
@@ -66,6 +86,17 @@ dmesg_since | grep -qF "percpu netfilter: nf_percpu:$cpu $COUNT" || \
 	fail "the packets were not counted by the instance of CPU $cpu: $(dmesg_since | grep 'percpu netfilter')"
 lunatik stop "$SCRIPT" > /dev/null 2>&1
 ktap_pass "the instances share one hook: each marked request is counted once, by the receiving CPU"
+
+mark_dmesg
+burst_when_armed &
+burst=$!
+run_script "$EARLY" softirq percpu
+wait $burst || fail "a marked ping was lost while the instances were being created"
+count_pinned "$cpu"
+dmesg_since | grep -qF "percpu netfilter: nf_percpu:$cpu $COUNT" || \
+	fail "the burst was counted, or it missed the instance of CPU $cpu: $(dmesg_since | grep 'percpu netfilter')"
+lunatik stop "$EARLY" > /dev/null 2>&1
+ktap_pass "a packet reaching the shared hook before the instances are published is accepted, uncounted"
 
 output=$(lunatik run "$TWICE" softirq percpu 2>&1)
 echo "$output" | grep -q "hook already registered" || fail "the second registration was not refused: $output"

--- a/tests/runtime/percpu_netfilter_early.lua
+++ b/tests/runtime/percpu_netfilter_early.lua
@@ -1,0 +1,33 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu netfilter test, a packet during creation (see percpu_netfilter.sh).
+
+local lunatik   = require("lunatik")
+local netfilter = require("netfilter")
+local nf        = require("linux.nf")
+
+local MARK <const> = 208
+local SPIN <const> = 100000000
+
+local env = lunatik._ENV
+local key = "nf_percpu:" .. lunatik.cpu()
+
+local function count(skb)
+	env[key] = (env[key] or 0) + 1
+	return nf.action.ACCEPT
+end
+
+netfilter.register{
+	hook     = count,
+	pf       = nf.proto.INET,
+	hooknum  = nf.inet.LOCAL_IN,
+	priority = nf.ip.pri.FILTER,
+	mark     = MARK,
+}
+
+print("percpu netfilter early: armed")
+
+for _ = 1, SPIN do end -- widen the gap between arming the hook and publishing this instance
+


### PR DESCRIPTION
The percpu object holds its per-CPU runtimes in a field called `runtimes`, while the comments, the error messages and the tests around it call each element an instance, and `runtimes` already names something else in the tree: the table of active runtimes the eBPF bindings look up in `_ENV`.

The field and the locals that read it are `instances`, which is what the documentation already says. No behaviour changes.

Based on #801, which touches the same line of `lunatik_pin`.
