### PR TITLE
lunatik: drop a callback that reaches a percpu runtime before it is published

### DIFF
--- a/lunatik.h
+++ b/lunatik.h
@@ -72,12 +72,13 @@ do {							\
 do {										\
 	lunatik_object_t *_object = (object);					\
 	lunatik_object_t *_runtime = lunatik_pin(_object);			\
-	lunatik_lock(_runtime);							\
-	if (unlikely(!lunatik_isready(_runtime)))				\
-		ret = -ENXIO;							\
-	else									\
-		lunatik_handle(_runtime, handler, ret, ## __VA_ARGS__);		\
-	lunatik_unlock(_runtime);						\
+	ret = -ENXIO;								\
+	if (likely(_runtime != NULL)) {						\
+		lunatik_lock(_runtime);						\
+		if (likely(lunatik_isready(_runtime)))				\
+			lunatik_handle(_runtime, handler, ret, ## __VA_ARGS__);	\
+		lunatik_unlock(_runtime);					\
+	}									\
 	lunatik_unpin(_object);							\
 } while(0)
 

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -278,7 +278,8 @@ int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char
 
 	lunatik_setready(runtime); /* lunatik_run returns -ENXIO until here */
 
-	*pruntime = runtime;
+	/* pairs with smp_load_acquire() in lunatik_pin() */
+	smp_store_release(pruntime, runtime);
 	return 0;
 }
 

--- a/lunatik_percpu.h
+++ b/lunatik_percpu.h
@@ -29,9 +29,10 @@ static inline lunatik_object_t *lunatik_pin(lunatik_object_t *object)
 
 	if (lunatik_isirq(object->opt))
 		preempt_disable();
-	else /* a process instance may sleep */
+	else /* a process runtime may sleep */
 		migrate_disable();
-	return *this_cpu_ptr(lunatik_topercpu(object)->runtimes);
+	/* pairs with smp_store_release() in lunatik_newruntime(); NULL until this CPU's runtime is published */
+	return smp_load_acquire(this_cpu_ptr(lunatik_topercpu(object)->runtimes));
 }
 
 static inline void lunatik_unpin(lunatik_object_t *object)

--- a/tests/README.md
+++ b/tests/README.md
@@ -250,7 +250,7 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   back the ones already created before the run returns.
 
 - **percpu_object**: `lunatik.percpu()` runs the script once per possible
-  CPU id, each instance stamping its own id; `stop` closes every instance
+  CPU id, each runtime stamping its own id; `stop` closes every runtime
   and the object can be created again; `stop` refuses an object of another
   class; a script that fails on one instance raises with its error instead of
   returning an object.
@@ -259,12 +259,13 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   at load, naming percpu, with a clean rollback, and the same script
   runs as a plain runtime: `device.new`, whose registration is global.
 
-- **percpu_netfilter**: the instances of a percpu script share one
+- **percpu_netfilter**: the runtimes of a percpu script share one
   `LOCAL_IN` hook: with the ping pinned to the last online CPU, each marked
-  request is counted exactly once, by the instance of that CPU; a second
-  registration of the same hook in one instance is refused; a registration
-  from a callback, after load, is refused; and the same script registers as
-  a plain softirq runtime.
+  request is counted exactly once, by the runtime of that CPU; a burst that
+  reaches the hook while the runtimes are still being created is accepted
+  without being counted; a second registration of the same hook in one
+  runtime is refused; a registration from a callback, after load, is
+  refused; and the same script registers as a plain softirq runtime.
 
 ### set
 

--- a/tests/runtime/percpu_netfilter.sh
+++ b/tests/runtime/percpu_netfilter.sh
@@ -3,14 +3,18 @@
 # SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
 # SPDX-License-Identifier: MIT OR GPL-2.0-only
 #
-# Regression test for a netfilter hook in a percpu script: the instances share one
+# Regression test for a netfilter hook in a percpu script: the runtimes share one
 # LOCAL_IN hook, so each marked ping request is handled exactly once, and by the
-# instance of the CPU that received it, which is where the loopback delivers the
-# pinned ping; a second registration of the same hook in one instance is refused;
-# a registration from a callback, after the script loaded, is refused before it
+# runtime of the CPU that received it, which is where the loopback delivers the
+# pinned ping; a marked packet reaching that hook while the runtimes are still
+# being created finds none published on its CPU, and is accepted without being
+# counted; a second registration of the same hook in one runtime is refused; a
+# registration from a callback, after the script loaded, is refused before it
 # could sleep in softirq; and the same script registers as a plain softirq
 # runtime. The exactly-once assertion runs on the shared hook, where it is
-# structural.
+# structural. The burst starts when the script reports the hook armed, and runs
+# inside the spin every runtime does before returning, so it arrives while no
+# runtime is published.
 #
 # Usage: sudo bash tests/runtime/percpu_netfilter.sh
 
@@ -18,9 +22,13 @@ SCRIPT="tests/runtime/percpu_netfilter"
 CHECK="tests/runtime/percpu_netfilter_check"
 TWICE="tests/runtime/percpu_netfilter_twice"
 LATE="tests/runtime/percpu_netfilter_late"
+EARLY="tests/runtime/percpu_netfilter_early"
+ARMED="percpu netfilter early: armed"
 MODULE="luanetfilter"
 MARK=208
 COUNT=5
+BURST=10
+TRIES=100
 
 source "$(dirname "$(readlink -f "$0")")/../lib.sh"
 
@@ -30,6 +38,17 @@ cleanup()
 	lunatik stop "$CHECK" > /dev/null 2>&1
 	lunatik stop "$TWICE" > /dev/null 2>&1
 	lunatik stop "$LATE" > /dev/null 2>&1
+	lunatik stop "$EARLY" > /dev/null 2>&1
+}
+
+burst_when_armed()
+{
+	local try
+	for ((try = 0; try < TRIES; try++)); do
+		dmesg_since | grep -qF "$ARMED" && break
+		sleep 0.02
+	done
+	ping -f -c $BURST -m $MARK 127.0.0.1 > /dev/null 2>&1
 }
 
 count_pinned()
@@ -37,7 +56,7 @@ count_pinned()
 	local cpu="$1"
 	mark_dmesg
 	taskset -c "$cpu" ping -c $COUNT -i 0.2 -m $MARK 127.0.0.1 > /dev/null 2>&1
-	dmesg_since | grep -qF "couldn't find hook" && fail "a hook fired for an instance that did not register it"
+	dmesg_since | grep -qF "couldn't find hook" && fail "a hook fired for a runtime that did not register it"
 	run_script "$CHECK"
 	check_dmesg || { ktap_totals; exit 1; }
 	lunatik stop "$CHECK" > /dev/null 2>&1
@@ -47,12 +66,13 @@ trap cleanup EXIT
 cleanup
 
 ktap_header
-ktap_plan 4
+ktap_plan 5
 
 cat /sys/module/$MODULE/refcnt > /dev/null 2>&1 || {
 	echo "# SKIP: $MODULE not loaded"
-	ktap_skip "the instances share one hook: each marked request is counted once, by the receiving CPU"
-	ktap_skip "a second registration of the same hook in one instance is refused"
+	ktap_skip "the runtimes share one hook: each marked request is counted once, by the receiving CPU"
+	ktap_skip "a packet reaching the shared hook before the runtimes are published is accepted, uncounted"
+	ktap_skip "a second registration of the same hook in one runtime is refused"
 	ktap_skip "a registration from a callback, after load, is refused"
 	ktap_skip "the same script registers as a plain softirq runtime"
 	ktap_totals
@@ -63,9 +83,20 @@ cpu=$(sed 's/.*[-,]//' /sys/devices/system/cpu/online)
 run_script "$SCRIPT" softirq percpu
 count_pinned "$cpu"
 dmesg_since | grep -qF "percpu netfilter: nf_percpu:$cpu $COUNT" || \
-	fail "the packets were not counted by the instance of CPU $cpu: $(dmesg_since | grep 'percpu netfilter')"
+	fail "the packets were not counted by the runtime of CPU $cpu: $(dmesg_since | grep 'percpu netfilter')"
 lunatik stop "$SCRIPT" > /dev/null 2>&1
-ktap_pass "the instances share one hook: each marked request is counted once, by the receiving CPU"
+ktap_pass "the runtimes share one hook: each marked request is counted once, by the receiving CPU"
+
+mark_dmesg
+burst_when_armed &
+burst=$!
+run_script "$EARLY" softirq percpu
+wait $burst || fail "a marked ping was lost while the runtimes were being created"
+count_pinned "$cpu"
+dmesg_since | grep -qF "percpu netfilter: nf_percpu:$cpu $COUNT" || \
+	fail "the burst was counted, or it missed the runtime of CPU $cpu: $(dmesg_since | grep 'percpu netfilter')"
+lunatik stop "$EARLY" > /dev/null 2>&1
+ktap_pass "a packet reaching the shared hook before the runtimes are published is accepted, uncounted"
 
 output=$(lunatik run "$TWICE" softirq percpu 2>&1)
 echo "$output" | grep -q "hook already registered" || fail "the second registration was not refused: $output"
@@ -73,7 +104,7 @@ listed=$(lunatik list)
 case "$listed" in
 	*"$TWICE"*) fail "the refused run left the script registered: $listed" ;;
 esac
-ktap_pass "a second registration of the same hook in one instance is refused"
+ktap_pass "a second registration of the same hook in one runtime is refused"
 
 mark_dmesg
 run_script "$LATE" softirq percpu

--- a/tests/runtime/percpu_netfilter_early.lua
+++ b/tests/runtime/percpu_netfilter_early.lua
@@ -1,0 +1,33 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu netfilter test, a packet during creation (see percpu_netfilter.sh).
+
+local lunatik   = require("lunatik")
+local netfilter = require("netfilter")
+local nf        = require("linux.nf")
+
+local MARK <const> = 208
+local SPIN <const> = 100000000
+
+local env = lunatik._ENV
+local key = "nf_percpu:" .. lunatik.cpu()
+
+local function count(skb)
+	env[key] = (env[key] or 0) + 1
+	return nf.action.ACCEPT
+end
+
+netfilter.register{
+	hook     = count,
+	pf       = nf.proto.INET,
+	hooknum  = nf.inet.LOCAL_IN,
+	priority = nf.ip.pri.FILTER,
+	mark     = MARK,
+}
+
+print("percpu netfilter early: armed")
+
+for _ = 1, SPIN do end -- widen the gap between arming the hook and publishing this runtime
+


### PR DESCRIPTION
A percpu object creates one runtime at a time and fills each per-CPU slot only after that runtime's script body ran, so a hook or a kprobe the body registers is armed while the other slots are still NULL. A callback arriving then reached `lunatik_run` with a NULL runtime and `lunatik_lock` read `opt` off it: that is the oops that took this host down, once a shared kprobe put the window under every syscall on every CPU.

`lunatik_run` now drops such a callback with the `-ENXIO` it already answers while a script is loading, and `smp_store_release` publishes the slot against the `smp_load_acquire` in `lunatik_pin`, so a callback that finds a runtime sees it fully built. The test forces the window instead of waiting for it. It is needed on its own: `luanetfilter_sharehook` has the same shape on master today.
