### PR TITLE
thread: run the body with the objects given to thread.run

### DIFF
--- a/doc/capi.md
+++ b/doc/capi.md
@@ -109,6 +109,17 @@ and the memory allocated for the `runtime` environment are released.
 If the `runtime` environment has been released, it returns `1`;
 otherwise, it returns `0`.
 
+### lunatik\_copyobjects
+```C
+int lunatik_copyobjects(lua_State *Lto, lua_State *Lfrom, int ixfrom, int nobjects);
+```
+Clones onto `Lto`, in order, the `nobjects` Lunatik objects `Lfrom` holds from `ixfrom`, which may
+be negative to count from `Lfrom`'s top. It carries objects and nothing else: a value that is not a
+Lunatik object fails it with `invalid object`, an object marked `SINGLE` with
+`cannot share SINGLE object`. On failure it returns the status of the
+[protected call](https://www.lua.org/manual/5.5/manual.html#lua_pcall) and leaves the message on
+`Lto`, which the caller pops; on success it returns `LUA_OK`.
+
 ### lunatik\_run
 ```C
 void lunatik_run(lunatik_object_t *runtime, <inttype> (*handler)(...), <inttype> &ret, ...);

--- a/examples/echod/daemon.lua
+++ b/examples/echod/daemon.lua
@@ -31,8 +31,7 @@ local function daemon()
 		if ok then
 			control:setbyte(0, n) -- #workers
 			local runtime = lunatik.runtime("examples/" .. worker)
-			runtime:resume(control, session)
-			thread.run(runtime, worker .. n)
+			thread.run(runtime, worker .. n, control, session)
 			n = n + 1
 		elseif session == "EAGAIN" then
 			linux.schedule(100)

--- a/examples/echod/worker.lua
+++ b/examples/echod/worker.lua
@@ -23,18 +23,16 @@ local function echo(session)
 end
 
 local function worker(control, session)
-	return function ()
-		local id = control:getbyte(0)
+	local id = control:getbyte(0)
 
-		info(id, "started")
-		repeat
-			local ok, err = pcall(echo, session)
-				if not ok then
-				return info(id, "aborted")
-			end
-		until (not alive(control) or err or shouldstop())
-		info(id, "stopped")
-	end
+	info(id, "started")
+	repeat
+		local ok, err = pcall(echo, session)
+		if not ok then
+			return info(id, "aborted")
+		end
+	until (not alive(control) or err or shouldstop())
+	info(id, "stopped")
 end
 
 return worker

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -182,8 +182,11 @@ static int luathread_run(lua_State *L)
 	thread->runtime = runtime;
 
 	thread->task = kthread_run(luathread_func, object, name);
-	if (IS_ERR(thread->task))
+	if (IS_ERR(thread->task)) {
+		lunatik_putobject(runtime);
+		lunatik_putobject(object);
 		luaL_error(L, "failed to create a new thread");
+	}
 
 	return 1; /* object */
 }

--- a/lib/luathread.c
+++ b/lib/luathread.c
@@ -23,15 +23,17 @@
 typedef struct luathread_s {
 	struct task_struct *task;
 	lunatik_object_t *runtime;
+	int nargs;
 } luathread_t;
 
 static int luathread_run(lua_State *L);
 static int luathread_current(lua_State *L);
+static void luathread_popargs(lunatik_object_t *runtime, int nargs);
 
 static int luathread_resume(lua_State *L, luathread_t *thread)
 {
 	int nresults;
-	int status = lua_resume(L, NULL, 0, &nresults);
+	int status = lua_resume(L, NULL, thread->nargs, &nresults);
 	if (status != LUA_OK && status != LUA_YIELD) {
 		pr_err("[%p] %s\n", thread, lua_tostring(L, -1));
 		lua_pop(L, 1);
@@ -102,6 +104,7 @@ static int luathread_stop(lua_State *L)
 
 		if (result == -EINTR) {
 			thread->task = NULL;
+			luathread_popargs(runtime, thread->nargs);
 			lunatik_putobject(thread->runtime);
 			lunatik_putobject(object);
 			pr_warn("[%p] thread has never run\n", thread);
@@ -156,16 +159,52 @@ static const lunatik_class_t luathread_class = {
 };
 
 #define luathread_new(L)	(lunatik_newobject((L), &luathread_class, sizeof(luathread_t), LUNATIK_OPT_NONE))
+#define LUATHREAD_ARGIX		3
+
+static void luathread_checkargs(lua_State *L, int nargs)
+{
+	int i;
+
+	for (i = 0; i < nargs; i++)
+		lunatik_checkshareable(L, LUATHREAD_ARGIX + i);
+}
+
+static void luathread_pushargs(lua_State *L, lunatik_object_t *runtime, int nargs)
+{
+	lua_State *Lto;
+	int status = LUA_OK;
+
+	lunatik_lock(runtime);
+	Lto = lunatik_isready(runtime) ? lunatik_getstate(runtime) : NULL;
+	if (Lto != NULL && nargs > 0 && (status = lunatik_copyobjects(Lto, L, LUATHREAD_ARGIX, nargs)) != LUA_OK)
+		lua_pop(Lto, 1); /* error message */
+	lunatik_unlock(runtime);
+
+	luaL_argcheck(L, Lto != NULL, 1, "stopped runtime"); /* raising under the lock would skip the unlock */
+	if (status != LUA_OK)
+		luaL_error(L, "couldn't pass the thread arguments");
+}
+
+static void luathread_popargs(lunatik_object_t *runtime, int nargs)
+{
+	lunatik_lock(runtime);
+	if (lunatik_isready(runtime))
+		lua_pop(lunatik_getstate(runtime), nargs);
+	lunatik_unlock(runtime);
+}
 
 /***
 * Creates and starts a new kernel thread to run a Lua task.
 * The runtime must be sleepable; the script it loaded must return a function,
-* which becomes the thread body.
+* which becomes the thread body, called with the objects given here.
 * @function run
 * @tparam runtime runtime A sleepable Lunatik runtime whose script returns a function.
 * @tparam string name A descriptive name for the kernel thread.
+* @param ... Lunatik objects passed to the thread body.
 * @treturn thread A new thread object.
-* @raise Error if the runtime is not sleepable or if thread creation fails.
+* @raise Error if called during module load, if the runtime is not sleepable or has been stopped,
+*   if a value passed to the body is not a Lunatik object or is a `SINGLE` one, if the arguments
+*   couldn't be passed, or if thread creation fails.
 * @see lunatik.runtime
 */
 static int luathread_run(lua_State *L)
@@ -174,8 +213,15 @@ static int luathread_run(lua_State *L)
 	lunatik_object_t *runtime = lunatik_checkobjectclass(L, 1, &lunatik_class);
 	luaL_argcheck(L, !lunatik_isirq(runtime->opt), 1, "IRQ runtime cannot spawn threads");
 	const char *name = luaL_checkstring(L, 2);
+	int nargs = lua_gettop(L) - LUATHREAD_ARGIX + 1;
+
+	luathread_checkargs(L, nargs);
+
 	lunatik_object_t *object = luathread_new(L);
 	luathread_t *thread = object->private;
+
+	luathread_pushargs(L, runtime, nargs);
+	thread->nargs = nargs;
 
 	lunatik_getobject(object);
 	lunatik_getobject(runtime);
@@ -183,6 +229,7 @@ static int luathread_run(lua_State *L)
 
 	thread->task = kthread_run(luathread_func, object, name);
 	if (IS_ERR(thread->task)) {
+		luathread_popargs(runtime, nargs);
 		lunatik_putobject(runtime);
 		lunatik_putobject(object);
 		luaL_error(L, "failed to create a new thread");

--- a/lunatik.h
+++ b/lunatik.h
@@ -123,6 +123,7 @@ int lunatik_runtime(lunatik_object_t **pruntime, const char *script, lunatik_opt
 int lunatik_newruntime(lunatik_object_t **pruntime, lua_State *Lfrom, const char *script, lunatik_opt_t opt,
 	lunatik_object_t *percpu, int cpu);
 int lunatik_stop(lunatik_object_t *runtime);
+int lunatik_copyobjects(lua_State *Lto, lua_State *Lfrom, int ixfrom, int nobjects);
 
 static inline int lunatik_nop(lua_State *L)
 {
@@ -326,6 +327,15 @@ static inline lunatik_object_t **lunatik_checkpobject(lua_State *L, int ix)
 	lunatik_object_t **pobject = lunatik_testobject(L, ix);
 	luaL_argcheck(L, pobject != NULL, ix, "invalid object");
 	return pobject;
+}
+
+static inline lunatik_object_t *lunatik_checkshareable(lua_State *L, int ix)
+{
+	lunatik_object_t *object = lunatik_checkobject(L, ix);
+
+	if (lunatik_issingle(object->opt))
+		luaL_argerror(L, ix, LUNATIK_ERR_SINGLE);
+	return object;
 }
 
 static inline lunatik_object_t *lunatik_checkobjectclass(lua_State *L, int ix, const lunatik_class_t *cls)

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -98,6 +98,7 @@ static int lunatik_lcopyobjects(lua_State *L)
 	int nobjects = lua_tointeger(L, 3);
 	int i;
 
+	luaL_checkstack(L, nobjects, "too many objects");
 	for (i = 0; i < nobjects; i++) {
 		lunatik_object_t **pobject = lunatik_testobject(Lfrom, ixfrom + i);
 

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -108,7 +108,7 @@ static int lunatik_lcopyobjects(lua_State *L)
 	return nobjects;
 }
 
-static inline int lunatik_copyobjects(lua_State *Lto, lua_State *Lfrom, int ixfrom, int nobjects)
+int lunatik_copyobjects(lua_State *Lto, lua_State *Lfrom, int ixfrom, int nobjects)
 {
 	lua_pushcfunction(Lto, lunatik_lcopyobjects);
 	lua_pushlightuserdata(Lto, Lfrom);
@@ -117,6 +117,7 @@ static inline int lunatik_copyobjects(lua_State *Lto, lua_State *Lfrom, int ixfr
 
 	return lua_pcall(Lto, 3, nobjects, 0);
 }
+EXPORT_SYMBOL(lunatik_copyobjects);
 
 static inline int lunatik_resume(lua_State *Lto, lua_State *Lfrom, int nargs)
 {

--- a/lunatik_val.c
+++ b/lunatik_val.c
@@ -18,9 +18,7 @@ void lunatik_checkvalue(lua_State *L, int ix, lunatik_value_t *value)
 		value->integer = lua_tointeger(L, ix);
 		break;
 	case LUA_TUSERDATA:
-		value->object = lunatik_checkobject(L, ix);
-		if (lunatik_issingle(value->object->opt))
-			luaL_argerror(L, ix, LUNATIK_ERR_SINGLE);
+		value->object = lunatik_checkshareable(L, ix);
 		break;
 	default:
 		luaL_argerror(L, ix, "unsupported type");

--- a/tests/README.md
+++ b/tests/README.md
@@ -370,6 +370,16 @@ Regression tests for `luathread`.
 - **foreign_object**: `thread.run()` refuses an object of another class
   instead of using its private data as a Lua state.
 
+- **run_args**: `thread.run()` passes its extra arguments, which must be
+  Lunatik objects, to the function the script returned, in the order they
+  were given: the body receives a `fifo` and a control block, and pushes a
+  marker through the fifo once it reads the driver's token in the control
+  block. A number in their place is refused with "invalid object" and a
+  `SINGLE` object with "cannot share SINGLE object", neither reaching the
+  runtime, which the run that follows proves still usable; a runtime already
+  stopped is refused with "stopped runtime"; and a second run carries more
+  objects than `LUA_MINSTACK`, which the body sees in order.
+
 - **run_during_load**: `runner.spawn()` called from a script's top-level
   code must error instead of hanging the kernel.
 

--- a/tests/thread/run.sh
+++ b/tests/thread/run.sh
@@ -11,7 +11,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
 SEP=""
-for t in "$DIR"/shouldstop.sh "$DIR"/run_during_load.sh "$DIR"/foreign_object.sh "$DIR"/task.sh; do
+for t in "$DIR"/shouldstop.sh "$DIR"/run_during_load.sh "$DIR"/foreign_object.sh "$DIR"/run_args.sh "$DIR"/task.sh; do
 	echo "${SEP}# --- $(basename "$t") ---"
 	SEP=$'\n'
 	bash "$t" || FAILED=$((FAILED+1))

--- a/tests/thread/run_args.lua
+++ b/tests/thread/run_args.lua
@@ -1,0 +1,74 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Driver for the thread.run() arguments test (see run_args.sh).
+
+local lunatik = require("lunatik")
+local thread  = require("thread")
+local fifo    = require("fifo")
+local data    = require("data")
+local linux   = require("linux")
+
+local BODY <const> = "tests/thread/run_args_body"
+local MARKER <const> = "run_args"
+local NOTOBJECT <const> = 42
+local TOKEN <const> = 7
+local SIZE <const> = 8
+local MANY <const> = 32
+local TRIES <const> = 100
+local PAUSE <const> = 10
+
+local function assert_error(fn, pattern)
+	local ok, err = pcall(fn)
+	assert(not ok, "expected error but got none")
+	assert(err:find(pattern), "unexpected error: " .. tostring(err))
+end
+
+local function newcontrol(extra)
+	local control = data.new(SIZE)
+	control:setbyte(0, TOKEN)
+	control:setbyte(1, extra)
+	return control
+end
+
+local function await(queue)
+	for _ = 1, TRIES do
+		if queue:pop(SIZE) == MARKER then
+			return true
+		end
+		if thread.shouldstop() then
+			return false
+		end
+		linux.schedule(PAUSE)
+	end
+	return false
+end
+
+local function driver()
+	local queue = fifo.new(SIZE)
+	local single = data.new(SIZE, "single")
+	local runtime = lunatik.runtime(BODY)
+	local stopped = lunatik.runtime(BODY)
+
+	stopped:stop()
+
+	assert_error(function() thread.run(runtime, MARKER, NOTOBJECT) end, "invalid object")
+	assert_error(function() thread.run(runtime, MARKER, single) end, "cannot share SINGLE object")
+	assert_error(function() thread.run(stopped, MARKER, queue) end, "stopped runtime")
+
+	thread.run(runtime, MARKER, queue, newcontrol(0))
+	assert(await(queue), "the thread body never pushed the marker for the objects it was given")
+
+	local args = {lunatik.runtime(BODY), MARKER, queue, newcontrol(MANY)}
+	for i = 1, MANY do
+		table.insert(args, data.new(i))
+	end
+	thread.run(table.unpack(args))
+	assert(await(queue), "the thread body did not get the objects past the ones a C function is entered with")
+
+	print("run_args: PASS")
+end
+
+return driver
+

--- a/tests/thread/run_args.sh
+++ b/tests/thread/run_args.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Tests the objects thread.run() passes to the thread body.
+#
+# The driver is spawned, since thread.run() is refused while a script loads.
+# It runs a body script with a fifo and a control block, and waits for the
+# marker the body pushes through the fifo once it reads the token the driver
+# left in the control block, pinning the order in which the two objects
+# arrive. Before that it takes the three refusals:
+# a number where an object is expected ("invalid object") and a SINGLE object
+# ("cannot share SINGLE object"), neither of which reaches the runtime, as the
+# run that follows proves; and a runtime already stopped ("stopped runtime").
+#
+# A second run carries more objects than the LUA_MINSTACK slots a C function is
+# entered with, sized 1 to 32 so the body sees them in order, which is a copy
+# longer than the stack the copy is given.
+#
+# Usage: sudo bash tests/thread/run_args.sh
+
+SCRIPT="tests/thread/run_args"
+SLEEP=2
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() { lunatik stop "$SCRIPT" 2>/dev/null; }
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+mark_dmesg
+output=$(lunatik spawn "$SCRIPT" 2>&1)
+[ -n "$output" ] && fail "$output"
+sleep $SLEEP
+lunatik stop "$SCRIPT"
+
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -q "run_args: PASS" || fail "the thread body did not get the objects given to thread.run()"
+ktap_pass "thread.run() passes its objects to the thread body and refuses what cannot cross"
+
+ktap_totals
+

--- a/tests/thread/run_args_body.lua
+++ b/tests/thread/run_args_body.lua
@@ -1,0 +1,24 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Thread body for the thread.run() arguments test (see run_args.sh).
+
+local MARKER <const> = "run_args"
+local TOKEN <const> = 7
+
+local function body(queue, control, ...)
+	local extra = table.pack(...)
+
+	for i = 1, extra.n do
+		if #extra[i] ~= i then
+			return
+		end
+	end
+	if control:getbyte(0) == TOKEN and control:getbyte(1) == extra.n then
+		queue:push(MARKER)
+	end
+end
+
+return body
+


### PR DESCRIPTION
`thread.run` had no way to give the body anything. The body is the function the script returns, so what it needed had to reach it inside a closure, which cannot cross between Lua states, or through values some earlier `resume` had left on the runtime's stack: a channel invisible at the call site, resting on an order of operations no contract states.

`thread.run(runtime, name, ...)` copies the Lunatik objects it is given onto the runtime under the runtime's lock, and the kthread resumes with them, so the body takes what it needs as arguments, over the transport `runtime:resume` already uses instead of a second, tacit one. Two defects on that path go with it: `lunatik_lcopyobjects` pushed one value per object into the `LUA_MINSTACK` slots a C function is entered with and nothing more, and a `thread.run` whose kthread failed to start dropped neither reference it had taken. Test: `run_args`.

This lands before #803, which stops `resume` leaving anything on that stack.
