### PR TITLE
lunatik: resume returns the objects the resumed script left

### DIFF
--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -128,10 +128,13 @@ static inline int lunatik_resume(lua_State *Lto, lua_State *Lfrom, int nargs)
 
 /***
 * Resumes a yielded runtime, analogous to `coroutine.resume`.
+* Only Lunatik objects cross between the runtimes, in either direction.
 * @function resume
-* @param ... values delivered to the script as return values of `coroutine.yield()`
-* @treturn vararg values passed to the next `coroutine.yield()`, or returned by the script
-* @raise if the runtime errors on resumption
+* @param ... objects delivered to the script as return values of `coroutine.yield()`
+* @treturn vararg objects passed to the next `coroutine.yield()`, or returned by the script
+* @raise "invalid object" or "cannot share SINGLE object" if a value cannot cross, numbering the
+*   arguments on the way in and the yielded values on the way back, or the error raised on
+*   resumption
 */
 static int lunatik_lresume(lua_State *L)
 {
@@ -139,13 +142,13 @@ static int lunatik_lresume(lua_State *L)
 	int nargs = lua_gettop(L) - 1;
 	int nresults = 0;
 
-	if (lunatik_copyobjects(Lto, L, 2, nargs) != LUA_OK || (nresults = lunatik_resume(Lto, L, nargs) < 0)) {
+	if (lunatik_copyobjects(Lto, L, 2, nargs) != LUA_OK || (nresults = lunatik_resume(Lto, L, nargs)) < 0) {
 		lua_pushfstring(L, "%s\n", lua_tostring(Lto, -1));
 		lua_pop(Lto, 1); /* error message */
 		lua_error(L);
 	}
 
-	int status = lunatik_copyobjects(L, Lto, nargs, nresults);
+	int status = lunatik_copyobjects(L, Lto, -nresults, nresults);
 	lua_pop(Lto, nresults);
 	if (status != LUA_OK)
 		lua_error(L);

--- a/tests/README.md
+++ b/tests/README.md
@@ -211,6 +211,17 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   across runtime boundaries. Push into a shared `fifo`, resume a
   sub-runtime with it, assert the value pops on the other side.
 
+- **resume_results**: `runtime:resume()` returns what the resumed script
+  yields, and what it returns: one object, then two in the order they were
+  yielded, then the returned one. A yielded value that is not a Lunatik
+  object, and a yielded `SINGLE` one, are refused by name and leave the
+  runtime suspended and resumable; a number given to `resume()` is refused
+  the same way; and a runtime whose body has returned is dead to the next
+  `resume()`. The first `resume()` carries two objects the script checks it
+  got in order, so the values come back off the resumed stack rather than
+  from a slot indexed by the caller's argument count, and one round carries
+  more objects than `LUA_MINSTACK`, in both directions.
+
 - **resume_foreign**: `runtime:resume()` refuses an object of another class
   instead of reading its private data as a Lua state.
 

--- a/tests/runtime/resume_results.lua
+++ b/tests/runtime/resume_results.lua
@@ -1,0 +1,57 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Driver script for the resume_results test (see resume_results.sh).
+
+local lunatik = require("lunatik")
+local data    = require("data")
+
+local ANSWER <const> = 42
+local FIRST <const> = 1
+local SECOND <const> = 2
+local MANY <const> = 32
+
+local function assert_error(fn, pattern)
+	local ok, err = pcall(fn)
+	assert(not ok, "expected error but got none")
+	assert(err:find(pattern), "unexpected error: " .. tostring(err))
+end
+
+local rt = lunatik.runtime("tests/runtime/resume_results_recv")
+
+-- a value that is not an object never crosses, and leaves the runtime untouched
+assert_error(function() rt:resume(ANSWER) end, "invalid object")
+
+-- one object yielded, on a resume carrying two arguments: the value comes off the resumed stack
+local one = rt:resume(data.new(FIRST), data.new(SECOND))
+assert(one:getbyte(0) == ANSWER, "resume did not return the object the script yielded")
+
+-- two objects yielded, in the order the script yielded them
+local first, second = rt:resume()
+assert(first:getbyte(0) == FIRST and second:getbyte(0) == SECOND, "resume reordered the yielded objects")
+
+-- more objects than the LUA_MINSTACK slots a C function is entered with, in and back out
+local sent = {}
+for i = 1, MANY do
+	table.insert(sent, data.new(i))
+end
+local back = table.pack(rt:resume(table.unpack(sent)))
+assert(back.n == MANY, "resume returned " .. back.n .. " of the " .. MANY .. " objects the script yielded")
+for i = 1, MANY do
+	assert(#back[i] == i, "resume reordered the yielded objects at " .. i)
+end
+
+-- a yielded value that is not an object, with the runtime still suspended after it
+assert_error(function() rt:resume() end, "invalid object")
+
+-- a yielded SINGLE object, with the runtime still suspended after it
+assert_error(function() rt:resume() end, "cannot share SINGLE object")
+
+-- the object the script returns
+local last = rt:resume()
+assert(last:getbyte(0) == ANSWER, "resume did not return the object the script returned")
+
+-- the runtime is dead once its body has returned
+assert_error(function() rt:resume() end, "cannot resume dead coroutine")
+

--- a/tests/runtime/resume_results.sh
+++ b/tests/runtime/resume_results.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Tests what runtime:resume() returns to its caller.
+#
+# The sub-runtime yields one object, then two, then a value that is not an
+# object, then a SINGLE one, and finally returns an object. The driver asserts
+# it gets the objects back and in order; that the two refusals name their
+# reason and leave the runtime suspended and resumable; and that a runtime
+# whose body has returned is dead to the next resume. It also passes a number
+# to resume(), which the inbound leg refuses the same way.
+#
+# The first resume carries two objects, which the sub-runtime checks it got in
+# order: the values come back off the resumed stack, so an index taken from
+# the caller's argument count lands on the wrong slot. One round carries more
+# objects than the LUA_MINSTACK slots a C function is entered with, in both
+# directions, which is a copy longer than the stack the copy is given.
+#
+# Usage: sudo bash tests/runtime/resume_results.sh
+
+SCRIPT="tests/runtime/resume_results"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() { lunatik stop "$SCRIPT" 2>/dev/null; }
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+mark_dmesg
+
+run_script "$SCRIPT"
+
+check_dmesg || { ktap_totals; exit 1; }
+ktap_pass "resume returns the objects the script yields and returns"
+
+ktap_totals
+

--- a/tests/runtime/resume_results_recv.lua
+++ b/tests/runtime/resume_results_recv.lua
@@ -1,0 +1,33 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Receiver sub-script for the resume_results test (see resume_results.sh);
+-- yields, and finally returns, what the driver expects to get back.
+
+local data = require("data")
+
+local ANSWER <const> = 42
+local FIRST <const> = 1
+local SECOND <const> = 2
+local MANY <const> = 32
+
+local function byte(value)
+	local d = data.new(1)
+	d:setbyte(0, value)
+	return d
+end
+
+local function recv(first, second)
+	assert(#first == FIRST and #second == SECOND, "resume did not deliver its arguments in order")
+	coroutine.yield(byte(ANSWER))
+	local many = table.pack(coroutine.yield(byte(FIRST), byte(SECOND)))
+	assert(many.n == MANY, "resume delivered " .. many.n .. " of the " .. MANY .. " objects it was given")
+	coroutine.yield(table.unpack(many, 1, many.n))
+	coroutine.yield(ANSWER)
+	coroutine.yield(data.new(4, "single"))
+	return byte(ANSWER)
+end
+
+return recv
+

--- a/tests/runtime/run.sh
+++ b/tests/runtime/run.sh
@@ -13,6 +13,7 @@ FAILED=0
 TESTS=(
 	refcnt_leak.sh
 	resume_shared.sh
+	resume_results.sh
 	resume_foreign.sh
 	foreign_method.sh
 	foreign_checker.sh


### PR DESCRIPTION
`runtime:resume` promises a vararg of what the resumed script yields, and `<` binds tighter than `=`, so the count it copied back was the result of a comparison and zero on every success: the copy-back read nothing and resume returned nothing. The index it read from was wrong as well, naming the caller's argument count while indexing the resumed state.

The count is now the one `lua_resume` left and the values are the top of that stack, where a return and a yield both leave them, so the contract is what the code does; only Lunatik objects cross, as they already do on the way in. A runtime whose body has returned is dead to the next resume now that nothing of it is left on the stack. Test: `resume_results`.

Based on #802, whose `thread.run` arguments are how `echod` gets its worker body once resume stops leaving it on the stack. Supersedes #799, which wrote the defect down as the contract.
