### PR TITLE
examples: dnsdoctor reads the packet from the network header

### DIFF
--- a/examples/dnsdoctor/nf_dnsdoctor.lua
+++ b/examples/dnsdoctor/nf_dnsdoctor.lua
@@ -17,7 +17,7 @@ local pri       = nf.ip.pri
 local udp = 0x11
 
 local function dnsdoctor_hook(skb)
-	local pkt = skb:data("mac")
+	local pkt = skb:data("net")
 	local ihl = pkt:getuint8(0) & 0x0F
 	local thoff = ihl * 4
 	local proto = pkt:getuint8(9)


### PR DESCRIPTION
`dnsdoctor` never rewrote anything on a path that carries an ethernet header: the hook asked `skb:data` for the "mac" layer and then indexed it as an IP header, so the byte it read as the protocol fell inside the source MAC address, the test against UDP failed, and the DNS answer went through unchanged.

The hook reads the "net" layer, as `dnsblock` and `tcpreject` do.
