### PR TITLE
lunatik: pop the value lua_getiuservalue pushes for a userdata without one

### DIFF
--- a/lunatik.h
+++ b/lunatik.h
@@ -301,12 +301,14 @@ static inline void lunatik_newclass(lua_State *L, const lunatik_class_t *class, 
 
 static inline lunatik_class_t *lunatik_getclass(lua_State *L, int ix)
 {
-	if (lua_type(L, ix) == LUA_TUSERDATA && lua_getiuservalue(L, ix, 1) != LUA_TNONE) {
-		lunatik_class_t *class = (lunatik_class_t *)lua_touserdata(L, -1);
+	lunatik_class_t *class = NULL;
+
+	if (lua_type(L, ix) == LUA_TUSERDATA) {
+		lua_getiuservalue(L, ix, 1); /* pushes nil when the userdata has no such value */
+		class = (lunatik_class_t *)lua_touserdata(L, -1);
 		lua_pop(L, 1); /* class */
-		return class;
 	}
-	return NULL;
+	return class;
 }
 
 static inline bool lunatik_isobject(lua_State *L, int ix, lunatik_object_t *object)


### PR DESCRIPTION
`lua_getiuservalue` pushes nil and returns `LUA_TNONE` when the userdata has no such value (`lua/lapi.c:842-850`), and `lunatik_getclass` returned without popping it.

With the pop unconditional the tag test buys nothing either: `lua_touserdata` returns NULL for nil as for any other tag, which is what `lunatik_testobject` already relies on one function below.

Nothing manifests the slot today, so it goes without a test: every caller either raises right after, which unwinds it, or runs inside a callback, where `lunatik_handle` restores the top it saved.
