### PR TITLE
bindings: rate-limit the errors a callback path logs

### DIFF
--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -86,7 +86,7 @@ static int luadevice_fop(lua_State *L, luadevice_t *luadev, const char *fop, int
 	int ret = -ENXIO;
 
 	if (lunatik_getregistry(L, luadev) != LUA_TTABLE) {
-		pr_err("%s: couldn't find driver\n", fop);
+		pr_err_ratelimited("%s: couldn't find driver\n", fop);
 		goto err;
 	}
 
@@ -96,7 +96,7 @@ static int luadevice_fop(lua_State *L, luadevice_t *luadev, const char *fop, int
 	lua_insert(L, base + 2); /* driver */
 
 	if (lua_pcall(L, nargs + 1, nresults, 0) != LUA_OK) { /* fop(driver, arg1, ...) */
-		pr_err("%s: %s\n", lua_tostring(L, -1), fop);
+		pr_err_ratelimited("%s: %s\n", lua_tostring(L, -1), fop);
 		ret = -ECANCELED;
 		goto err;
 	}

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -39,12 +39,12 @@ static void luanetfilter_release(void *private);
 static inline bool luanetfilter_pushcb(lua_State *L, luanetfilter_t *luanf)
 {
 	if (lunatik_getregistry(L, luanf) != LUA_TTABLE) {
-		pr_err("couldn't find ops table\n");
+		pr_err_ratelimited("couldn't find ops table\n");
 		return false;
 	}
 
 	if (lua_getfield(L, -1, "hook") != LUA_TFUNCTION) {
-		pr_err("operation not defined\n");
+		pr_err_ratelimited("operation not defined\n");
 		return false;
 	}
 	return true;
@@ -55,7 +55,7 @@ static inline lunatik_object_t *luanetfilter_pushskb(lua_State *L, luanetfilter_
 	lunatik_object_t *object = lunatik_getregistryobject(L, luanf->skb);
 
 	if (unlikely(object == NULL)) {
-		pr_err("couldn't find skb\n");
+		pr_err_ratelimited("couldn't find skb\n");
 		return NULL;
 	}
 
@@ -70,7 +70,7 @@ static int luanetfilter_hook_cb(lua_State *L, luanetfilter_hook_t *hook, struct 
 
 	lunatik_object_t *handle = lunatik_getregistryobject(L, hook);
 	if (handle == NULL) {
-		pr_err("couldn't find hook\n");
+		pr_err_ratelimited("couldn't find hook\n");
 		goto out;
 	}
 
@@ -79,7 +79,7 @@ static int luanetfilter_hook_cb(lua_State *L, luanetfilter_hook_t *hook, struct 
 		goto out;
 
 	if (lua_pcall(L, 1, 2, 0) != LUA_OK) {
-		pr_err("%s\n", lua_tostring(L, -1));
+		pr_err_ratelimited("%s\n", lua_tostring(L, -1));
 		lua_pop(L, 1);
 		goto clear;
 	}

--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -56,7 +56,7 @@ static int luanotifier_handler(lua_State *L, luanotifier_t *notifier, unsigned l
 	lua_pushinteger(L, (lua_Integer)event);
 	nargs += notifier->handler(L, data);
 	if (lua_pcall(L, nargs, 1, 0) != LUA_OK) { /* callback(event, ...) */
-		pr_err("%s\n", lua_tostring(L, -1));
+		pr_err_ratelimited("%s\n", lua_tostring(L, -1));
 		return NOTIFY_OK;
 	}
 

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -41,7 +41,7 @@ static int luaprobe_handler(lua_State *L, luaprobe_t *probe, const char *handler
 	const char *symbol = kp->symbol_name;
 
 	if (lunatik_getregistry(L, probe) != LUA_TTABLE) {
-		pr_err("couldn't find probe table\n");
+		pr_err_ratelimited("couldn't find probe table\n");
 		goto out;
 	}
 
@@ -58,7 +58,7 @@ static int luaprobe_handler(lua_State *L, luaprobe_t *probe, const char *handler
 	lua_insert(L, -4); /* stack: dump, handler, symbol | addr, dump */
 
 	if (lua_pcall(L, 2, 0, 0) != LUA_OK) /* handler(symbol | addr, dump) */
-		pr_err("%s\n", lua_tostring(L, -1));
+		pr_err_ratelimited("%s\n", lua_tostring(L, -1));
 
 	lua_pushnil(L);
 	lua_setupvalue(L, -2, 1); /* clean up regs */


### PR DESCRIPTION
A callback logs with a plain `pr_err`, so a script failing in a netfilter hook, a kprobe, a notifier or a device operation writes one line per packet, per syscall or per read, and the storm buries the message that would explain the failure. A percpu kprobe on every syscall did exactly that on this host.

The ten call sites a callback reaches now use `pr_err_ratelimited`, as `lunatik_ebpf.h` already does throughout. The module init path keeps its plain `pr_err`, and so does `luathread_resume`, which logs once per thread rather than once per event.
