### PR TITLE
ci: run the checks on a pull request against any base

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,8 +2,6 @@
 name: Build Modules
 on:
   pull_request:
-    branches:
-    - master
   push:
     branches:
     - master

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,8 +1,6 @@
 name: Checks
 on:
   pull_request:
-    branches:
-    - master
 jobs:
   checks:
     name: Convention checks

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,8 +2,6 @@
 name: Build Docs
 on:
   pull_request:
-    branches:
-    - master
   push:
     branches:
     - master


### PR DESCRIPTION
A stacked pull request targets the branch below it, and every workflow filtered the pull_request event by branches: [master], so those PRs got no check runs at all, absent rather than pending.

The filter is gone from the three workflows. The push trigger still fires only for master.