### PR TITLE
checks: catch the two mistakes a rule would only describe

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,9 +4,22 @@
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/review-post-guard.sh\"" },
-          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/crash-guard.sh\"" },
-          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/pr-body-guard.sh\"" }
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/review-post-guard.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/crash-guard.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/pr-body-guard.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/consumers-guard.sh\""
+          }
         ]
       }
     ],
@@ -14,7 +27,10 @@
       {
         "matcher": "Write|Edit",
         "hooks": [
-          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/on-edit.sh\"" }
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/on-edit.sh\""
+          }
         ]
       }
     ]
@@ -23,4 +39,3 @@
     "sessionUrl": false
   }
 }
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,13 @@ authorized the experiment and named the machine it may take down.
 or a "Test plan" section; `pr-body-guard.sh`, wired before a shell call like `crash-guard.sh`,
 blocks a `gh` write to pulls that carries a body file the check fails on.
 
+`consumers.sh` names the out-of-tree scripts that load a binding the changed files touch, reading the
+clones listed in `LUNATIK_CONSUMERS`; `consumers-guard.sh`, wired before a shell call, blocks opening or
+editing a pull request that changes such a binding until the command carries `CONSUMERS_OK=1`, set once
+those scripts were read. A product built on Lunatik is a consumer this tree cannot grep, and narrowing
+what a binding reports was proposed here as a fix until the script that reads that notifier turned up in
+another repository, using exactly what the change removed.
+
 `review-post-guard.sh` reads the tool command on stdin instead of a file, for an assistant wired
 to run it before a shell call (`PreToolUse`): it blocks a `gh` write to reviews or comments unless
 the command carries the `REVIEW_POST_OK` marker, set once the exact text has been shown to the

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -11,7 +11,9 @@ KTAP_PASS=0
 KTAP_FAIL=0
 KTAP_SKIP=0
 
-ktap_header() { echo "KTAP version 1"; }
+# the core a result was produced against: a suite read without it can be measuring the
+# module a failed build left installed
+ktap_header() { echo "KTAP version 1"; echo "# core: $(cat /sys/module/lunatik/srcversion 2>/dev/null || echo "not loaded")"; }
 ktap_plan()   { echo "1..$1"; }
 ktap_pass()   { KTAP_COUNT=$((KTAP_COUNT+1)); KTAP_PASS=$((KTAP_PASS+1)); echo "ok $KTAP_COUNT $*"; }
 ktap_fail()   { KTAP_COUNT=$((KTAP_COUNT+1)); KTAP_FAIL=$((KTAP_FAIL+1)); echo "not ok $KTAP_COUNT $*"; }

--- a/tools/checks/consumers-guard.sh
+++ b/tools/checks/consumers-guard.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# PreToolUse (Bash) hook: a pull request that changes a binding is not opened
+# before the out-of-tree scripts that load it were read. Reads the tool command
+# on stdin, runs consumers.sh over the branch's own diff, and blocks (exit 2)
+# when a consumer turns up, unless the command carries CONSUMERS_OK=1, set once
+# they were read. Silent when LUNATIK_CONSUMERS is unset or nothing matches.
+
+input=$(cat)
+
+case "$input" in
+	*"gh api"*pulls*) ;;
+	*) exit 0 ;;
+esac
+case "$input" in
+	*"-X POST"*|*"-X PATCH"*) ;;
+	*) exit 0 ;;
+esac
+case "$input" in
+	*CONSUMERS_OK=1*) exit 0 ;;
+esac
+
+dir=$(printf '%s' "$input" | grep -oE 'cd [^ ]+' | head -1 | cut -d' ' -f2)
+[ -d "$dir" ] || dir="$CLAUDE_PROJECT_DIR"
+[ -d "$dir" ] || exit 0
+
+files=$(git -C "$dir" diff --name-only origin/master...HEAD 2>/dev/null)
+[ -n "$files" ] || exit 0
+
+report=$(cd "$dir" && bash "$CLAUDE_PROJECT_DIR/tools/checks/consumers.sh" $files)
+[ -n "$report" ] || exit 0
+
+echo "$report" >&2
+echo "consumers-guard: read them, then re-run with CONSUMERS_OK=1 as a command prefix." >&2
+exit 2
+

--- a/tools/checks/consumers.sh
+++ b/tools/checks/consumers.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Names the out-of-tree scripts that require a binding the given files change.
+# A product built on Lunatik is a consumer this tree cannot grep: point the check
+# at the clones with LUNATIK_CONSUMERS, a colon separated list of directories,
+# and it reports which of their scripts load what is being changed. Silent when
+# the variable is unset, when nothing under lib/ is touched, or when no consumer
+# script requires it.
+#
+# Usage: LUNATIK_CONSUMERS=/path/a:/path/b bash tools/checks/consumers.sh <files...>
+
+[ -n "$LUNATIK_CONSUMERS" ] || exit 0
+
+modules=""
+for f in "$@"; do
+	case "$f" in
+		lib/lua*.c)   modules="$modules $(basename "$f" .c | sed 's/^lua//')" ;;
+		lib/*.lua)    modules="$modules $(basename "$f" .lua)" ;;
+		lib/*/*.lua)  modules="$modules $(echo "$f" | sed 's|^lib/||; s|\.lua$||')" ;;
+	esac
+done
+[ -n "$modules" ] || exit 0
+
+found=""
+for m in $modules; do
+	for dir in $(echo "$LUNATIK_CONSUMERS" | tr ':' ' '); do
+		[ -d "$dir" ] || continue
+		hits=$(grep -rln "require(\"$m\")\|require('$m')" "$dir" --include='*.lua' 2>/dev/null)
+		[ -n "$hits" ] && found="$found\n  $m: $(echo $hits | tr '\n' ' ')"
+	done
+done
+
+[ -n "$found" ] || exit 0
+echo "Out-of-tree consumers load a binding this change touches:"
+printf "$found\n"
+echo "Read them before narrowing what it reports, and say in the pull request what their maintainer must change."
+

--- a/tools/checks/pre-commit
+++ b/tools/checks/pre-commit
@@ -3,6 +3,16 @@
 # missing the trailing blank line the tree requires.
 # Install with: ln -s ../../tools/checks/pre-commit .git/hooks/pre-commit
 
+conflicted=$(git diff --cached --name-only --diff-filter=ACM -G'^(<{7}|={7}|>{7})( |$)')
+if [ -n "$conflicted" ]; then
+	echo "ERROR: Files staged with conflict markers:"
+	for f in $conflicted; do
+		echo "  $f"
+	done
+	echo "Resolve them: git grep -n '^<<<<<<< '"
+	exit 1
+fi
+
 bad=""
 for f in $(git diff --cached --name-only --diff-filter=ACM); do
 	case "$f" in


### PR DESCRIPTION
Three mistakes this session made are mechanical, so a rule against them is not the fix. A rebase resolved file by file left a conflict marker in `tests/run.sh`, and `git add -A` staged it without complaining. An A/B whose build failed while its output was silenced ran against the module the previous install had left, and the pass it printed was read as the test failing to discriminate. And a binding was narrowed without anyone reading the script that loads it, because that script lives in another repository.

The commit gate refuses a staged conflict marker; the KTAP header carries the srcversion of the loaded core, so a result says what produced it; and `consumers.sh` names the out-of-tree scripts that require a binding a change touches, with a guard that blocks the pull request until they were read. Each was tested against the case it comes from: the gate rejects the exact `tests/run.sh` that reached the branch, the header prints the running core, and the guard blocks the pull request that narrowed `notifier.netdevice`, naming `vlan.lua` in the product that uses it.

The consumer list is per machine, so the check is silent unless `LUNATIK_CONSUMERS` points at the clones.
