### PR TITLE
checks: read the state of the work instead of remembering it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,11 @@ machine. Two rules follow from that and outrank everything else in this document
 
 1. **Verify, do not assume.** How the kernel behaves is read in its source, not inferred from a
    measurement: which CPU a hook runs on is answered by `NF_HOOK`'s callers, and a run on one host
-   confirms that reading, it does not replace it. Before using a kernel API, read its declaration in
+   confirms that reading, it does not replace it. The state of the work is read the same way: which pull
+   requests are open, what a branch carries, what is installed on the host. It comes from a command run
+   while the answer is being written, or it is given as unverified. A list of pull requests called ready
+   was assembled from memory here and was wrong on two of three. Before using a kernel API, read its
+   declaration in
    `/usr/src/linux-headers-$(uname -r)/include` and confirm it is exported in `Module.symvers`. A
    kernel interface read at runtime rather than linked — a `/sys` or `/proc` path and the format it
    returns, the `/dev/lunatik` protocol — is held to the same rule: confirm it against the source
@@ -155,6 +159,11 @@ editing a pull request that changes such a binding until the command carries `CO
 those scripts were read. A product built on Lunatik is a consumer this tree cannot grep, and narrowing
 what a binding reports was proposed here as a fix until the script that reads that notifier turned up in
 another repository, using exactly what the change removed.
+
+`pr-status.sh` prints the open pull requests as GitHub has them: base and whether it still merges,
+commits and how many are unsquashed fixups, the CI conclusion, and the labels. What it cannot see is
+whether anyone read one, so a review workflow labels what it finished with `workflow-reviewed`, and a
+pull request without that label has had no second reader.
 
 `review-post-guard.sh` reads the tool command on stdin instead of a file, for an assistant wired
 to run it before a shell call (`PreToolUse`): it blocks a `gh` write to reviews or comments unless

--- a/tools/pr-status.sh
+++ b/tools/pr-status.sh
@@ -1,27 +1,37 @@
 #!/bin/bash
 # Reports the state of the open pull requests, so a claim about them is read
 # rather than remembered: base, mergeability, commit count and how many of those
-# are unsquashed fixups, the CI conclusion, and the labels the review workflows
-# leave behind. A pull request whose branch is not fetched shows its state as
-# GitHub has it and nothing more.
+# are unsquashed fixups, the size, the CI conclusion, and the labels the review
+# workflows leave behind.
 #
-# Usage: GH_TOKEN=... bash tools/pr-status.sh [<number>...]
+# With --ready, lists only what a maintainer can pick up: reviewed by a workflow,
+# green on CI, no unsquashed fixup, and mergeable as GitHub has computed it.
+#
+# Usage: GH_TOKEN=... bash tools/pr-status.sh [--ready] [<number>...]
 
 repo=${LUNATIK_REPO:-luainkernel/lunatik}
+fmt='%-6s %-26s %-24s %-5s %-7s %-11s %-9s %s\n'
+
+ready=0
+[ "$1" = "--ready" ] && { ready=1; shift; }
 numbers="$*"
 [ -n "$numbers" ] || numbers=$(gh api "repos/$repo/pulls" --paginate -q '.[].number' | sort -n)
 
-printf '%-6s %-26s %-24s %-5s %-7s %-11s %-9s %s\n' PR BRANCH BASE COMM FIXUPS SIZE CI LABELS
+printf "$fmt" PR BRANCH BASE COMM FIXUPS SIZE CI LABELS
 for n in $numbers; do
-	read -r branch base commits mergeable size < <(gh api "repos/$repo/pulls/$n" \
-		-q '"\(.head.ref) \(.base.ref) \(.commits) \(.mergeable) +\(.additions)/-\(.deletions)"')
+	pr=$(gh api "repos/$repo/pulls/$n" \
+		-q '[.head.ref, .base.ref, (.commits|tostring), (.mergeable|tostring), "+\(.additions)/-\(.deletions)", .head.sha, ([.labels[].name] | join(",") // "")] | @tsv') || continue
+	IFS=$'\t' read -r branch base commits mergeable size sha labels <<< "$pr"
 	fixups=$(gh api "repos/$repo/pulls/$n/commits" \
 		-q '[.[] | select(.commit.message | startswith("fixup!"))] | length')
-	labels=$(gh api "repos/$repo/pulls/$n" -q '[.labels[].name] | join(",")')
-	sha=$(gh api "repos/$repo/pulls/$n" -q .head.sha)
 	ci=$(gh api "repos/$repo/commits/$sha/check-runs" \
 		-q '[.check_runs[].conclusion] | if length == 0 then "none" else (unique | join(",")) end' 2>/dev/null)
-	[ "$mergeable" = "true" ] || base="$base(!)"
-	printf '%-6s %-26s %-24s %-5s %-7s %-11s %-9s %s\n' "#$n" "$branch" "$base" "$commits" "$fixups" "$size" "$ci" "${labels:--}"
+
+	if [ "$ready" = 1 ]; then
+		[ "$mergeable" = "true" ] && [ "$fixups" = 0 ] && [ "$ci" = "success" ] || continue
+		case "$labels" in *workflow-reviewed*) ;; *) continue ;; esac
+	fi
+	case "$mergeable" in true) ;; null) base="$base(?)" ;; *) base="$base(!)" ;; esac
+	printf "$fmt" "#$n" "$branch" "$base" "$commits" "$fixups" "$size" "$ci" "${labels:--}"
 done
 

--- a/tools/pr-status.sh
+++ b/tools/pr-status.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Reports the state of the open pull requests, so a claim about them is read
+# rather than remembered: base, mergeability, commit count and how many of those
+# are unsquashed fixups, the CI conclusion, and the labels the review workflows
+# leave behind. A pull request whose branch is not fetched shows its state as
+# GitHub has it and nothing more.
+#
+# Usage: GH_TOKEN=... bash tools/pr-status.sh [<number>...]
+
+repo=${LUNATIK_REPO:-luainkernel/lunatik}
+numbers="$*"
+[ -n "$numbers" ] || numbers=$(gh api "repos/$repo/pulls" --paginate -q '.[].number' | sort -n)
+
+printf '%-6s %-26s %-24s %-5s %-7s %-9s %s\n' PR BRANCH BASE COMM FIXUPS CI LABELS
+for n in $numbers; do
+	read -r branch base commits mergeable < <(gh api "repos/$repo/pulls/$n" \
+		-q '"\(.head.ref) \(.base.ref) \(.commits) \(.mergeable)"')
+	fixups=$(gh api "repos/$repo/pulls/$n/commits" \
+		-q '[.[] | select(.commit.message | startswith("fixup!"))] | length')
+	labels=$(gh api "repos/$repo/pulls/$n" -q '[.labels[].name] | join(",")')
+	sha=$(gh api "repos/$repo/pulls/$n" -q .head.sha)
+	ci=$(gh api "repos/$repo/commits/$sha/check-runs" \
+		-q '[.check_runs[].conclusion] | if length == 0 then "none" else (unique | join(",")) end' 2>/dev/null)
+	[ "$mergeable" = "true" ] || base="$base(!)"
+	printf '%-6s %-26s %-24s %-5s %-7s %-9s %s\n' "#$n" "$branch" "$base" "$commits" "$fixups" "$ci" "${labels:--}"
+done
+

--- a/tools/pr-status.sh
+++ b/tools/pr-status.sh
@@ -11,10 +11,10 @@ repo=${LUNATIK_REPO:-luainkernel/lunatik}
 numbers="$*"
 [ -n "$numbers" ] || numbers=$(gh api "repos/$repo/pulls" --paginate -q '.[].number' | sort -n)
 
-printf '%-6s %-26s %-24s %-5s %-7s %-9s %s\n' PR BRANCH BASE COMM FIXUPS CI LABELS
+printf '%-6s %-26s %-24s %-5s %-7s %-11s %-9s %s\n' PR BRANCH BASE COMM FIXUPS SIZE CI LABELS
 for n in $numbers; do
-	read -r branch base commits mergeable < <(gh api "repos/$repo/pulls/$n" \
-		-q '"\(.head.ref) \(.base.ref) \(.commits) \(.mergeable)"')
+	read -r branch base commits mergeable size < <(gh api "repos/$repo/pulls/$n" \
+		-q '"\(.head.ref) \(.base.ref) \(.commits) \(.mergeable) +\(.additions)/-\(.deletions)"')
 	fixups=$(gh api "repos/$repo/pulls/$n/commits" \
 		-q '[.[] | select(.commit.message | startswith("fixup!"))] | length')
 	labels=$(gh api "repos/$repo/pulls/$n" -q '[.labels[].name] | join(",")')
@@ -22,6 +22,6 @@ for n in $numbers; do
 	ci=$(gh api "repos/$repo/commits/$sha/check-runs" \
 		-q '[.check_runs[].conclusion] | if length == 0 then "none" else (unique | join(",")) end' 2>/dev/null)
 	[ "$mergeable" = "true" ] || base="$base(!)"
-	printf '%-6s %-26s %-24s %-5s %-7s %-9s %s\n' "#$n" "$branch" "$base" "$commits" "$fixups" "$ci" "${labels:--}"
+	printf '%-6s %-26s %-24s %-5s %-7s %-11s %-9s %s\n' "#$n" "$branch" "$base" "$commits" "$fixups" "$size" "$ci" "${labels:--}"
 done
 


### PR DESCRIPTION
A list of pull requests called ready to review was assembled from memory and was wrong on two of three: one had had no reviewer at all, and another was being reviewed while the list was written. The rule against that already exists and was broken anyway, so the answer is to make the reading cost nothing.

`pr-status.sh` prints what GitHub has for every open pull request: base and whether it still merges, commits and how many are unsquashed fixups, the CI conclusion, the labels. What GitHub cannot answer is whether anyone read one, so a review workflow now labels what it finished with `workflow-reviewed`, and the six pull requests a finished workflow reviewed carry it already.
