### PR TITLE
docs: a percpu object holds runtimes, not instances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,16 +241,16 @@ does — the socket layer does not check `kthread_should_stop()`. To wait indefi
 * Objects a C module pre allocates but exposes to Lua use `lunatik_createobject` plus
   `lunatik_cloneobject`, which requires `.shared = true`.
 
-A registration a percpu script makes once for all its instances, a hook or a kernel thread, lives
+A registration a percpu script makes once for all its runtimes, a hook or a kernel thread, lives
 in the private of an object from `lunatik_percpudata`, of a class the binding declares for it, whose
-`release` the percpu object runs before closing the instances. A binding that keeps a global list
-or a use count of its own to find what the other instances registered is doing the object's job.
+`release` the percpu object runs before closing the runtimes. A binding that keeps a global list
+or a use count of its own to find what the other runtimes registered is doing the object's job.
 
-That registration arms before the set exists. `lunatik_percpu` creates the instances one at a time and
-writes each per-CPU slot last, after that instance's script body has run, so a hook or a kprobe armed
+That registration arms before the set exists. `lunatik_percpu` creates the runtimes one at a time and
+writes each per-CPU slot last, after that runtime's script body has run, so a hook or a kprobe armed
 from the first body fires while the other slots are still NULL — and the body is where it must be armed,
 since `lunatik_percpudata` refuses to create shared data once the runtime is ready. Whatever dispatches
-through a percpu object therefore has to survive an instance that is not published yet: `lunatik_run`
+through a percpu object therefore has to survive a runtime that is not published yet: `lunatik_run`
 answers `-ENXIO`, as it already does for a runtime whose script is still loading. A kprobe on a syscall
 found this by dereferencing a NULL slot on every CPU at once and taking the machine down.
 
@@ -445,7 +445,7 @@ Tests are shell scripts emitting KTAP plus a kernel side Lua script.
   first, since restoring is a `git checkout --` that takes any uncommitted work with it;
 * a case whose stimulus only exists on a busy machine is forced, not waited for: the probe test picks a
   syscall an idle host never makes, which is why it never hit the creation window that crashed the host,
-  and covering that window meant pinning the call to the CPU whose instance is published last. A test
+  and covering that window meant pinning the call to the CPU whose runtime is published last. A test
   that passes because the race is rare is not covering the race;
 * a test for an exactly once property runs on the path where that property is structural, and the
   header says which path and why. The same assertion on a path that can migrate CPUs mid way passes

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [
 * `status`: show which Lunatik kernel modules are currently loaded
 * `test [suite]`: run installed test suites (see [Testing](#testing))
 * `list`: show which runtime environments are currently running
-* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime instance per CPU id, dispatched to the instance of the CPU the callback runs on. The script runs once per instance and can read its id with `lunatik.cpu()`; the instances share a netfilter hook, and constructors whose registration is global fail at load in a percpu instance
+* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime per CPU id, dispatched to the runtime of the CPU the callback runs on. The script runs once per runtime and can read its id with `lunatik.cpu()`; the runtimes share a netfilter hook, and constructors whose registration is global fail at load in a percpu runtime
 * `spawn`: create a new runtime environment and spawn a thread to run the script `/lib/modules/lua/<script>.lua`
 * `stop`: stop the runtime environment created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_
@@ -402,7 +402,7 @@ This script drops any outbound DNS packet with question matching the blacklist p
 ```
 sudo make examples_install              # installs examples
 sudo lunatik run examples/dnsblock/nf_dnsblock softirq	# runs the Lua kernel script
-sudo lunatik run examples/dnsblock/nf_dnsblock softirq percpu	# or one instance per CPU, sharing the hook
+sudo lunatik run examples/dnsblock/nf_dnsblock softirq percpu	# or one runtime per CPU, sharing the hook
 ```
 
 ### dnsdoctor
@@ -422,7 +422,7 @@ dig lunatik.com
 
 # run the Lua kernel script
 sudo lunatik run examples/dnsdoctor/nf_dnsdoctor softirq
-sudo lunatik run examples/dnsdoctor/nf_dnsdoctor softirq percpu	# or one instance per CPU, sharing the hook
+sudo lunatik run examples/dnsdoctor/nf_dnsdoctor softirq percpu	# or one runtime per CPU, sharing the hook
 
 # test the setup, a response with IP 10.1.2.3 should be returned
 dig lunatik.com

--- a/doc/capi.md
+++ b/doc/capi.md
@@ -119,7 +119,7 @@ If the Lua state has been closed, `ret` is set with `-ENXIO`;
 otherwise, `ret` is set with the result of `handler(L, ...)` call.
 Then, it restores the Lua stack and unlocks the `runtime` environment.
 A `percpu` object, which the caller keeps referenced across the call, is resolved first
-to the instance of the CPU the caller runs on, and the caller stays on that CPU until the
+to the runtime of the CPU the caller runs on, and the caller stays on that CPU until the
 call returns.
 It is defined as a macro.
 
@@ -194,16 +194,16 @@ only instantiated in a compatible runtime.
 ```C
 lunatik_object_t *lunatik_percpudata(lua_State *L, const lunatik_class_t *class, size_t size);
 ```
-Returns the object of `class` a `percpu` object holds for its instances: the first instance to ask
+Returns the object of `class` a `percpu` object holds for its runtimes: the first runtime to ask
 creates it, as `lunatik_createobject(class, size, LUNATIK_OPT_NONE)` does, with its private zeroed;
-the following ones get the same object, so every instance sees one. The `percpu` object owns it:
+the following ones get the same object, so every runtime sees one. The `percpu` object owns it:
 `percpu:stop()` closes it (`lunatik_closeprivate`, which runs the class's `release` in process
-context) before closing the instances, then drops it, and an object with such data outstanding is
-released by `stop`, never by collection. A registration a script makes once for all its instances,
+context) before closing the runtimes, then drops it, and an object with such data outstanding is
+released by `stop`, never by collection. A registration a script makes once for all its runtimes,
 a netfilter hook, say, lives in the private of such an object, with the class's `release`
-unregistering it. Only the script body may ask, while the instance loads; it raises a Lua error
-afterwards. Returns `NULL` on a plain runtime, which has no instances to share with;
-`lunatik_getpercpu(L)` tells the two apart, returning the `percpu` object owning the instance `L`,
+unregistering it. Only the script body may ask, while the runtime loads; it raises a Lua error
+afterwards. Returns `NULL` on a plain runtime, which has no runtimes to share with;
+`lunatik_getpercpu(L)` tells the two apart, returning the `percpu` object owning the runtime `L`,
 or `NULL`.
 
 ---

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -25,7 +25,7 @@ typedef struct luanetfilter_hook_s {
 
 /***
 * Registered Netfilter hook. Garbage collecting this object unregisters the hook, or detaches
-* the instance from the hook its percpu script shares.
+* the runtime from the hook its percpu script shares.
 * @type netfilter_hook
 */
 typedef struct luanetfilter_s {
@@ -211,13 +211,13 @@ static const lunatik_class_t luanetfilter_class = {
 
 /***
 * Registers a Netfilter hook.
-* In a percpu script the instances share one hook: the first registration installs it, the
-* others attach their callbacks, and a packet reaches the instance of the CPU it arrived on.
+* In a percpu script the runtimes share one hook: the first registration installs it, the
+* others attach their callbacks, and a packet reaches the runtime of the CPU it arrived on.
 * @function register
 * @tparam table opts Hook options: `hook` (function), `pf`, `hooknum`, `priority` (integers),
 *   and optionally `mark` (integer, default 0).
 * @treturn netfilter_hook Registered hook handle.
-* @raise if the hook cannot be registered; in a percpu script, if this instance already
+* @raise if the hook cannot be registered; in a percpu script, if this runtime already
 *   registered the same `pf`, `hooknum`, `priority` and `mark`, or if called after module load
 */
 static int luanetfilter_register(lua_State *L)
@@ -234,7 +234,7 @@ static int luanetfilter_register(lua_State *L)
 	luanetfilter_hook_t *hook = percpu != NULL ? luanetfilter_sharehook(L, percpu, &spec) : luanetfilter_ownhook(L, nf, &spec);
 	luaskb_attach(L, nf, skb);
 	lunatik_registerobject(L, 1, object);
-	lunatik_register(L, -1, hook); /* the callback finds this instance's registration by the hook they share */
+	lunatik_register(L, -1, hook); /* the callback finds this runtime's registration by the hook they share */
 	return 1;
 }
 

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -48,9 +48,9 @@ end
 -- @tparam string script path or name of the Lua script to run. The ".lua" extension will be trimmed.
 -- @tparam[opt] string context Execution context: `"process"` (default) or `"softirq"` (for netfilter/XDP hooks).
 -- @tparam[opt] boolean ispercpu create one runtime per CPU id, dispatched by the CPU a
---   callback fires on; the script runs once per instance and can read its id with
---   `lunatik.cpu()`. The instances share a netfilter hook; constructors whose
---   registration is global refuse to run in an instance.
+--   callback fires on; the script runs once per runtime and can read its id with
+--   `lunatik.cpu()`. The runtimes share a netfilter hook; constructors whose
+--   registration is global refuse to run in a percpu runtime.
 -- @treturn table created Lunatik runtime object, or the percpu object when `ispercpu` is set.
 -- @raise error if the script is already running.
 function runner.run(script, context, ispercpu)

--- a/lunatik_conf.h
+++ b/lunatik_conf.h
@@ -78,8 +78,8 @@ struct lunatik_object_s;
 typedef struct lunatik_runtime_s {
 	struct lunatik_object_s *runtime;
 	bool ready;
-	int cpu;	/* percpu instance id; LUNATIK_CPU_NONE on a plain runtime */
-	struct lunatik_object_s *percpu;	/* the object owning a percpu instance; NULL on a plain runtime */
+	int cpu;	/* the CPU this runtime serves; LUNATIK_CPU_NONE on a plain runtime */
+	struct lunatik_object_s *percpu;	/* the object owning this runtime; NULL on a plain runtime */
 } lunatik_runtime_t;
 
 #undef LUA_EXTRASPACE

--- a/lunatik_core.c
+++ b/lunatik_core.c
@@ -151,10 +151,10 @@ static int lunatik_lresume(lua_State *L)
 }
 
 /***
-* Returns the CPU id of a percpu runtime instance.
+* Returns the CPU id a percpu runtime serves.
 * Ranges from `0` to `linux.numcpus() - 1`; see `runner.run`.
 * @function cpu
-* @treturn integer instance CPU id, or `nil` on a plain runtime
+* @treturn integer CPU id, or `nil` on a plain runtime
 * @within lunatik
 */
 static int lunatik_cpu(lua_State *L)

--- a/lunatik_percpu.c
+++ b/lunatik_percpu.c
@@ -16,7 +16,7 @@ LUNATIK_OPENER(lunatik);
 
 /***
 * Set of runtimes, one per CPU id, running the same script. A callback dispatched
-* through it reaches the instance of the CPU it fired on.
+* through it reaches the runtime of the CPU it fired on.
 * @type percpu
 */
 static lunatik_object_t *lunatik_finddata(lunatik_percpu_t *percpu, const lunatik_class_t *class)
@@ -64,7 +64,7 @@ static void lunatik_stopdata(lunatik_object_t *object)
 	unsigned int i;
 
 	for (i = 0; i < percpu->ndata; i++) {
-		lunatik_closeprivate(percpu->data[i]); /* the class's release runs here, before the instances close */
+		lunatik_closeprivate(percpu->data[i]); /* the class's release runs here, before the runtimes close */
 		lunatik_putobject(percpu->data[i]);
 		lunatik_putobject(object);
 	}
@@ -73,16 +73,16 @@ static void lunatik_stopdata(lunatik_object_t *object)
 	percpu->data = NULL;
 }
 
-#define lunatik_foreachinstance(percpu, cpu, runtime)	\
+#define lunatik_foreachruntime(percpu, cpu, runtime)	\
 	for_each_possible_cpu(cpu)			\
 		if ((runtime = *per_cpu_ptr((percpu)->runtimes, cpu)) != NULL)
 
-static void lunatik_closeinstances(lunatik_percpu_t *percpu)
+static void lunatik_closeruntimes(lunatik_percpu_t *percpu)
 {
 	lunatik_object_t *runtime;
 	int cpu;
 
-	lunatik_foreachinstance(percpu, cpu, runtime)
+	lunatik_foreachruntime(percpu, cpu, runtime)
 		lunatik_closeprivate(runtime);
 }
 
@@ -95,13 +95,13 @@ static void lunatik_releasepercpu(void *private)
 	if (percpu->runtimes == NULL)
 		return;
 
-	lunatik_foreachinstance(percpu, cpu, runtime)
+	lunatik_foreachruntime(percpu, cpu, runtime)
 		lunatik_putobject(runtime); /* may run in softirq: a put, never a stop */
 	free_percpu(percpu->runtimes);
 }
 
 /***
-* Closes the objects the instances share, then every instance, releasing their Lua states.
+* Closes the objects the runtimes share, then every runtime, releasing their Lua states.
 * @function stop
 */
 static int lunatik_stoppercpu(lua_State *L)
@@ -109,7 +109,7 @@ static int lunatik_stoppercpu(lua_State *L)
 	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &lunatik_percpu_class);
 
 	lunatik_stopdata(object);
-	lunatik_closeinstances(lunatik_topercpu(object));
+	lunatik_closeruntimes(lunatik_topercpu(object));
 	return 0;
 }
 
@@ -130,12 +130,12 @@ const lunatik_class_t lunatik_percpu_class = {
 
 /***
 * Creates one runtime per CPU id, each loading the given script in the calling context.
-* The instances are dispatched by CPU: see `lunatik.cpu` and `runner.run`.
+* The runtimes are dispatched by CPU: see `lunatik.cpu` and `runner.run`.
 * @function percpu
 * @tparam string script script name (e.g., `"mymod"` loads `/lib/modules/lua/mymod.lua`)
 * @tparam[opt="process"] string context execution context, as in `lunatik.runtime`
 * @treturn percpu
-* @raise if allocation fails or the script errors on load, after releasing the instances
+* @raise if allocation fails or the script errors on load, after releasing the runtimes
 *   already created
 * @within lunatik
 */
@@ -154,7 +154,7 @@ int lunatik_percpu(lua_State *L)
 	for_each_possible_cpu(cpu) {
 		if (lunatik_newruntime(per_cpu_ptr(percpu->runtimes, cpu), L, script, opt, object, cpu) != 0) {
 			lunatik_stopdata(object);
-			lunatik_closeprivate(object); /* release the instances now, not on collection */
+			lunatik_closeprivate(object); /* release the runtimes now, not on collection */
 			lua_error(L);
 		}
 	}

--- a/tests/README.md
+++ b/tests/README.md
@@ -197,7 +197,7 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   successful `netfilter.register()` call. The fix, under the runtime
   spinlock, nulls `runtime->private`, calls `lua_close(L)` to fire the
   hook finalizer (`nf_unregister_net_hook` + `symbol_put_addr`), and
-  then releases the runtime. The percpu case errors on the last instance, so
+  then releases the runtime. The percpu case errors on the last runtime, so
   the rollback has the hooks of the earlier ones, which the shared registration
   holds, to release; it needs more than one CPU and skips otherwise.
 
@@ -242,20 +242,20 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   as `rcu`) keeps the class metatables the first open created.
 
 - **percpu**: `run <script> percpu` registers one object holding a
-  runtime per possible CPU id, and runs the script once per instance,
+  runtime per possible CPU id, and runs the script once per runtime,
   each seeing its own id via `lunatik.cpu()`, which a plain runtime
   sees as `nil`; the script is listed once, by name; `stop` drops every
-  instance and lets it run again; `spawn` refuses percpu without
-  creating any runtime; and a script that fails on one instance rolls
+  runtime and lets it run again; `spawn` refuses percpu without
+  creating any runtime; and a script that fails on one runtime rolls
   back the ones already created before the run returns.
 
 - **percpu_object**: `lunatik.percpu()` runs the script once per possible
   CPU id, each runtime stamping its own id; `stop` closes every runtime
   and the object can be created again; `stop` refuses an object of another
-  class; a script that fails on one instance raises with its error instead of
+  class; a script that fails on one runtime raises with its error instead of
   returning an object.
 
-- **percpu_refuse**: a registration a percpu instance cannot own fails
+- **percpu_refuse**: a registration a percpu runtime cannot own fails
   at load, naming percpu, with a clean rollback, and the same script
   runs as a plain runtime: `device.new`, whose registration is global.
 
@@ -339,7 +339,7 @@ BTF, or `bpftool`, `clang` or `tc` is unavailable.
   suite's `packet.isping`, since the namespace emits autoconf traffic of its own.
 
 - **tc drop**: `action.ACT_SHOT` blocks the ping; the runtime is percpu,
-  covering the dispatch to a percpu instance.
+  covering the dispatch to a percpu runtime.
 
 - **tc reattach**: the script attaches one callback and then a second in the
   same runtime; the ping passes because only the last callback runs, exercising
@@ -393,7 +393,7 @@ BTF, or `bpftool` or `clang` is unavailable.
   runtime is plain, covering the plain-name kfunc lookup.
 
 - **xdp drop**: `action.DROP` blocks the ping; the runtime is percpu,
-  covering the dispatch to a percpu instance.
+  covering the dispatch to a percpu runtime.
 
 - **xdp detach**: the callback drops the first ping and calls `xdp.detach()`
   from inside the callback, letting other traffic through; traffic resumes
@@ -415,5 +415,5 @@ BTF, or `bpftool` or `clang` is unavailable.
 
 - **xdp percpu**: with the ping pinned to the last online CPU, which is where
   the veth runs the receive softirq, the callback of a percpu script reports
-  that CPU as its instance id, and no other; skipped on a single CPU.
+  that CPU as its own id, and no other; skipped on a single CPU.
 

--- a/tests/runtime/percpu.sh
+++ b/tests/runtime/percpu.sh
@@ -5,9 +5,9 @@
 #
 # Regression test for percpu runtimes: `run <script> percpu` registers one
 # object holding one runtime per possible CPU id, and the script runs once per
-# instance; the script is listed once, by name; stopping it drops every
-# instance and lets it run again; `spawn` refuses percpu without creating any
-# runtime; and a script that fails on one instance rolls back the ones already
+# runtime; the script is listed once, by name; stopping it drops every
+# runtime and lets it run again; `spawn` refuses percpu without creating any
+# runtime; and a script that fails on one runtime rolls back the ones already
 # created, before the failed run returns.
 #
 # Usage: sudo bash tests/runtime/percpu.sh
@@ -42,7 +42,7 @@ lunatik stop "$CHECK" > /dev/null 2>&1
 
 listed=$(lunatik list)
 case "$listed" in
-	*"$SCRIPT,"*"$SCRIPT"*) fail "list shows an entry per instance: $listed" ;;
+	*"$SCRIPT,"*"$SCRIPT"*) fail "list shows an entry per runtime: $listed" ;;
 	*"$SCRIPT"*)            ktap_pass "the script is listed once, by name" ;;
 	*)                      fail "the script is not listed: $listed" ;;
 esac
@@ -54,7 +54,7 @@ case "$listed" in
 esac
 run_script "$SCRIPT" percpu
 lunatik stop "$SCRIPT" > /dev/null 2>&1
-ktap_pass "stop drops every instance and lets the script run again"
+ktap_pass "stop drops every runtime and lets the script run again"
 
 output=$(lunatik spawn "$SCRIPT" percpu 2>&1)
 echo "$output" | grep -q "spawn does not support percpu" || \
@@ -65,10 +65,10 @@ case "$listed" in
 esac
 ktap_pass "spawn refuses percpu without creating runtimes"
 
-# the rollback needs a second instance to fail, so it runs only with >1 possible CPU
+# the rollback needs a second runtime to fail, so it runs only with >1 possible CPU
 if [ "$(nproc --all)" -ge 2 ]; then
 	output=$(lunatik run "$FAIL_SCRIPT" percpu 2>&1)
-	echo "$output" | grep -q "intentional error on the second instance" || \
+	echo "$output" | grep -q "intentional error on the second runtime" || \
 		fail "the percpu run did not fail as intended: $output"
 	listed=$(lunatik list)
 	case "$listed" in
@@ -78,9 +78,9 @@ if [ "$(nproc --all)" -ge 2 ]; then
 	run_script "$FAIL_SCRIPT"
 	check_dmesg || { ktap_totals; exit 1; }
 	lunatik stop "$FAIL_SCRIPT" > /dev/null 2>&1
-	ktap_pass "a failing instance rolls back the ones already created"
+	ktap_pass "a failing runtime rolls back the ones already created"
 else
-	ktap_skip "a failing instance rolls back the ones already created (needs >1 CPU)"
+	ktap_skip "a failing runtime rolls back the ones already created (needs >1 CPU)"
 fi
 
 ktap_totals

--- a/tests/runtime/percpu_check.lua
+++ b/tests/runtime/percpu_check.lua
@@ -15,9 +15,9 @@ local env = lunatik._ENV
 
 test("percpu registers one object, running the script on every CPU id", function()
 	assert(env.runtimes[script] ~= nil, "the percpu script is not registered")
-	assert(env[stamp .. linux.numcpus()] == nil, "an instance ran beyond the last CPU id")
+	assert(env[stamp .. linux.numcpus()] == nil, "a runtime ran beyond the last CPU id")
 	for cpu = 0, linux.numcpus() - 1 do
-		assert(env[stamp .. cpu], "no instance stamped CPU " .. cpu)
+		assert(env[stamp .. cpu], "no runtime stamped CPU " .. cpu)
 		env[stamp .. cpu] = nil
 	end
 end)

--- a/tests/runtime/percpu_fail.lua
+++ b/tests/runtime/percpu_fail.lua
@@ -7,7 +7,7 @@
 local lunatik = require("lunatik")
 
 if lunatik.cpu() == 1 then
-	error("intentional error on the second instance")
+	error("intentional error on the second runtime")
 end
 
 return function() end

--- a/tests/runtime/percpu_netfilter_check.lua
+++ b/tests/runtime/percpu_netfilter_check.lua
@@ -13,7 +13,7 @@ local COUNT  <const> = 5
 
 local env = lunatik._ENV
 
-test("the marked requests were counted once, by one instance", function()
+test("the marked requests were counted once, by one runtime", function()
 	local counted = {}
 	rcu.map(env, function (key, count)
 		if key:sub(1, #PREFIX) == PREFIX then
@@ -22,7 +22,7 @@ test("the marked requests were counted once, by one instance", function()
 			assert(count == COUNT, key .. " counted " .. count .. " of " .. COUNT)
 		end
 	end)
-	assert(#counted == 1, #counted .. " instances counted")
+	assert(#counted == 1, #counted .. " runtimes counted")
 	env[counted[1]] = nil
 end)
 

--- a/tests/runtime/percpu_object.lua
+++ b/tests/runtime/percpu_object.lua
@@ -15,9 +15,9 @@ local stamp   <const> = "percpu_cpu:"
 local env = lunatik._ENV
 
 local function stamped()
-	assert(env[stamp .. linux.numcpus()] == nil, "an instance ran beyond the last CPU id")
+	assert(env[stamp .. linux.numcpus()] == nil, "a runtime ran beyond the last CPU id")
 	for cpu = 0, linux.numcpus() - 1 do
-		assert(env[stamp .. cpu], "no instance stamped CPU " .. cpu)
+		assert(env[stamp .. cpu], "no runtime stamped CPU " .. cpu)
 		env[stamp .. cpu] = nil
 	end
 end
@@ -27,7 +27,7 @@ test("percpu runs the script once per possible CPU id", function()
 	stamped()
 end)
 
-test("stop closes every instance and the script runs again", function()
+test("stop closes every runtime and the script runs again", function()
 	local percpu = lunatik.percpu(body)
 	percpu:stop()
 	stamped()
@@ -45,10 +45,10 @@ test("stop refuses an object of another class", function()
 end)
 
 if linux.numcpus() > 1 then
-	test("a failing instance raises with its error", function()
+	test("a failing runtime raises with its error", function()
 		local ok, err = pcall(lunatik.percpu, failing)
 		assert(not ok, "percpu returned an object for a failing script")
-		assert(err:match("intentional error on the second instance"), "unexpected error: " .. err)
+		assert(err:match("intentional error on the second runtime"), "unexpected error: " .. err)
 	end)
 end
 

--- a/tests/runtime/percpu_object.sh
+++ b/tests/runtime/percpu_object.sh
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: MIT OR GPL-2.0-only
 #
 # Regression test for the percpu object: lunatik.percpu() runs the script once per
-# possible CPU id, each instance seeing its own id; stop closes every instance and
+# possible CPU id, each runtime seeing its own id; stop closes every runtime and
 # the object can be created again; stop refuses an object of another class; and a
-# script that fails on one instance raises with its error instead of returning an object.
+# script that fails on one runtime raises with its error instead of returning an object.
 #
 # Usage: sudo bash tests/runtime/percpu_object.sh
 

--- a/tests/runtime/percpu_refuse.sh
+++ b/tests/runtime/percpu_refuse.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
 # SPDX-License-Identifier: MIT OR GPL-2.0-only
 #
-# Regression test for the percpu refusal: a registration a percpu instance
+# Regression test for the percpu refusal: a registration a percpu runtime
 # cannot own must fail at load, naming percpu, and the rollback must leave
 # nothing registered; the same script runs fine as a plain runtime. Covered
 # here by device.new, whose registration is global.
@@ -29,7 +29,7 @@ refuse()
 		fail "percpu run did not refuse the registration: $output"
 	listed=$(lunatik list)
 	case "$listed" in
-		*"$script"*) fail "the refused run left instances behind: $listed" ;;
+		*"$script"*) fail "the refused run left runtimes behind: $listed" ;;
 	esac
 }
 
@@ -41,7 +41,7 @@ ktap_plan 2
 
 refuse "$SCRIPT"
 [ -e /dev/percpu_refuse ] && fail "the refused run left the device registered"
-ktap_pass "global registration fails at load in a percpu instance"
+ktap_pass "global registration fails at load in a percpu runtime"
 
 mark_dmesg
 run_script "$SCRIPT"

--- a/tests/runtime/refcnt_leak.sh
+++ b/tests/runtime/refcnt_leak.sh
@@ -55,20 +55,20 @@ after=$(cat /sys/module/$MODULE/refcnt 2>/dev/null)
 ktap_pass "$MODULE refcnt restored after failed script"
 
 [ "$(sed 's/.*-//' /sys/devices/system/cpu/possible)" -gt 0 ] || {
-	echo "# SKIP: the percpu rollback needs an instance before the one that fails"
-	ktap_skip "$MODULE refcnt restored after a percpu script failed on its last instance"
+	echo "# SKIP: the percpu rollback needs a runtime before the one that fails"
+	ktap_skip "$MODULE refcnt restored after a percpu script failed on its last runtime"
 	ktap_totals
 	exit 0
 }
 
 mark_dmesg
 output=$(lunatik run "$PERCPU" softirq percpu 2>&1)
-echo "$output" | grep -q "intentional error on the last instance" || \
+echo "$output" | grep -q "intentional error on the last runtime" || \
 	fail "percpu script did not reach the intentional error: $output"
 check_dmesg || { ktap_totals; exit 1; }
 after=$(cat /sys/module/$MODULE/refcnt 2>/dev/null)
-[ "$before" = "$after" ] || fail "$MODULE refcnt leaked: $before -> $after (the rollback left a hook of an earlier instance)"
-ktap_pass "$MODULE refcnt restored after a percpu script failed on its last instance"
+[ "$before" = "$after" ] || fail "$MODULE refcnt leaked: $before -> $after (the rollback left a hook of an earlier runtime)"
+ktap_pass "$MODULE refcnt restored after a percpu script failed on its last runtime"
 
 ktap_totals
 

--- a/tests/runtime/refcnt_leak_percpu.lua
+++ b/tests/runtime/refcnt_leak_percpu.lua
@@ -3,8 +3,8 @@
 -- SPDX-License-Identifier: MIT OR GPL-2.0-only
 --
 -- Kernel-side script for the percpu refcnt leak test (see refcnt_leak.sh):
--- every instance registers a hook and the last one errors, so the rollback
--- has hooks of earlier instances to release.
+-- every runtime registers a hook and the last one errors, so the rollback
+-- has hooks of earlier runtimes to release.
 
 local lunatik   = require("lunatik")
 local linux     = require("linux")
@@ -24,6 +24,6 @@ netfilter.register{
 }
 
 if lunatik.cpu() == linux.numcpus() - 1 then
-	error("intentional error on the last instance")
+	error("intentional error on the last runtime")
 end
 


### PR DESCRIPTION
A percpu object holds its runtimes in a field called `runtimes`, walks them with a variable called `runtime`, and answers with `lunatik.cpu()` which CPU one serves. Instance was a third word for that same thing, spread over the macro, the doc blocks, the comments, the README and the test assertions.

The word is gone from everything that means a percpu runtime: `lunatik_foreachruntime`, `lunatik_closeruntimes`, and the prose around them. It stays where it means an instance of a class, in the Lua module patterns of `AGENTS.md` and in the object flags of `doc/capi.md`, which are a different subject.

Full suite green on the branch, and the assertions that carry the wording changed with the scripts that raise it.
