### PR TITLE
checks: refuse a lunatik operation while the device is busy

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/lunatik-lock.sh\""
+          },
+          {
+            "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/review-post-guard.sh\""
           },
           {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,10 @@ wrong, over rules that were already written and already broken, adds a paragraph
 or a "Test plan" section; `pr-body-guard.sh`, wired before a shell call like `crash-guard.sh`,
 blocks a `gh` write to pulls that carries a body file the check fails on.
 
+`lunatik-lock.sh`, wired before a shell call, refuses a command that touches the device while another
+operation is already on it, naming the processes it found; a process in D state among them is a wedged
+device, which no waiting clears. `LUNATIK_LOCK_OK=1` overrides it once they are known to be stale.
+
 `consumers.sh` names the out-of-tree scripts that load a binding the changed files touch, reading the
 clones listed in `LUNATIK_CONSUMERS`; `consumers-guard.sh`, wired before a shell call, blocks opening or
 editing a pull request that changes such a binding until the command carries `CONSUMERS_OK=1`, set once

--- a/tools/checks/lunatik-lock.sh
+++ b/tools/checks/lunatik-lock.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PreToolUse (Bash) hook: one lunatik operation at a time. Concurrent ones wedge
+# /dev/lunatik and leave processes in D state, which only a reboot clears, so a
+# command that touches the device is refused (exit 2) while another is running.
+# Reads the tool command on stdin. Pass LUNATIK_LOCK_OK=1 to override, once the
+# processes it names are known to be stale.
+
+input=$(cat)
+
+case "$input" in
+	*"lunatik test"*|*"lunatik reload"*|*"lunatik load"*|*"lunatik unload"*|\
+	*"lunatik run"*|*"lunatik spawn"*|*"lunatik stop"*|*"make install"*) ;;
+	*) exit 0 ;;
+esac
+case "$input" in
+	*LUNATIK_LOCK_OK=1*) exit 0 ;;
+esac
+
+busy=$(ps -eo pid,stat,args | awk '
+	$3 ~ /lunatik$/ || $0 ~ /sbin\/lunatik (test|reload|load|unload|run|spawn|stop)/ ||
+	$0 ~ /share\/lunatik\/tests/ || $0 ~ /tests\/[a-z]+\/run\.sh/ { print "  " $0 }')
+[ -n "$busy" ] || exit 0
+
+{
+	echo "lunatik-lock: the device is busy; a second operation wedges it."
+	echo "$busy"
+	echo "Wait for it to finish. A process in D state never will: that is a wedged device,"
+	echo "which the maintainer clears with a reboot. Override with LUNATIK_LOCK_OK=1 only"
+	echo "when what is listed is known to be stale."
+} >&2
+exit 2
+


### PR DESCRIPTION
Two lunatik operations at once wedge `/dev/lunatik` and leave processes in D state, which only a reboot clears. The rule against it is the oldest one in the file and was broken here anyway: a suite was started while a review workflow held the device, and the machine has been waiting for a reboot since.

`lunatik-lock.sh` reads the tool command before it runs and refuses anything that touches the device while another operation is on it, naming the processes it found. A process in D state among them is the wedge itself, which no waiting clears, and the message says so. `LUNATIK_LOCK_OK=1` overrides it once what it lists is known to be stale.

Tested against the wedged device as it stands: it blocks `lunatik test`, stays quiet for a plain `make` and for unrelated commands, and honours the override.
