### PR TITLE
lib: hid owns its id_table before the walk that can raise

### DIFF
--- a/lib/luahid.c
+++ b/lib/luahid.c
@@ -79,24 +79,21 @@ static const lunatik_class_t luahid_class = {
 
 #define LUAHID_MAXIDS	(4096)
 
-static const struct hid_device_id *luahid_setidtable(lua_State *L, int idx)
+static void luahid_setidtable(lua_State *L, int idx, struct hid_driver *driver)
 {
-	size_t len = luaL_len(L, idx);
+	lunatik_checkfield(L, idx, "id_table", LUA_TTABLE);
+	size_t len = luaL_len(L, -1);
 
 	if (len > LUAHID_MAXIDS)
 		luaL_error(L, "'id_table' is too long");
 
-	struct hid_device_id *user_table = lunatik_checkalloc(L, sizeof(struct hid_device_id) * (len + 1));
-
-	struct hid_device_id *cur_id = user_table;
+	struct hid_device_id *id_table = lunatik_checkalloc(L, sizeof(struct hid_device_id) * (len + 1));
+	struct hid_device_id *cur_id = id_table;
 	size_t i;
+
+	driver->id_table = id_table; /* own id_table before the walk can raise, so release frees it */
 	for (i = 0; i < len; i++, cur_id++) {
-		if (lua_geti(L, idx, i + 1) != LUA_TTABLE) { /* table entry */
-			lua_pop(L, 1); /* table entry */
-			lunatik_free(user_table);
-			user_table = NULL;
-			goto out;
-		}
+		luaL_argcheck(L, lua_geti(L, -1, i + 1) == LUA_TTABLE, idx, "invalid id_table"); /* table entry */
 
 		lunatik_optinteger(L, -1, cur_id, bus, HID_BUS_ANY);
 		lunatik_optinteger(L, -1, cur_id, group, HID_GROUP_ANY);
@@ -108,9 +105,7 @@ static const struct hid_device_id *luahid_setidtable(lua_State *L, int idx)
 	}
 
 	memset(cur_id, 0, sizeof(struct hid_device_id));
-out:
 	lua_pop(L, 1); /* id_table */
-	return user_table;
 }
 
 #define luahid_setfield(L, idx, obj, field)	\
@@ -300,8 +295,7 @@ static int luahid_register(lua_State *L)
 	driver->name = lunatik_checkalloc(L, NAME_MAX);
 	lunatik_setstring(L, 1, driver, name, NAME_MAX);
 
-	lunatik_checkfield(L, 1, "id_table", LUA_TTABLE);
-	luaL_argcheck(L, (driver->id_table = luahid_setidtable(L, -1)) != NULL, 1, "invalid id_table");
+	luahid_setidtable(L, 1, driver);
 
 	driver->probe = luahid_probe;
 	driver->report_fixup = luahid_report_fixup;

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,10 +92,19 @@ Covers the `crypto` module: `shash`, `skcipher`, `aead`, `rng`, `hkdf`,
 
 ### hid
 
-- **register**: `hid.register()` accepts an `id_table` of one entry and of
-  `LUAHID_MAXIDS`, under a vendor no device on the bus carries, and refuses
-  both a longer table and a length fabricated by a `__len` metamethod.
-  Skips when the kernel has no HID bus.
+- **register**: what `hid.register()` makes of an `id_table`. It accepts one
+  of a single entry and one of `LUAHID_MAXIDS`, under a vendor no device on
+  the bus carries, and registers again after every refusal; the accepted
+  drivers reach `/sys/bus/hid/drivers` and leave it with the runtime. A
+  longer table, a length a `__len` metamethod fabricates, a length that is
+  not an integer, an entry that is not a table and an entry that raises
+  while it is read are each refused, and each refusal forces the refused
+  driver's finalizer. Skips when the kernel has no HID bus.
+- **idtable_leak**: an `id_table` whose entries raise from `__index` leaves
+  nothing allocated behind. The refusal is repeated until what a leak would
+  hold is tens of MiB in `SUnreclaim`, and the script then holds as many
+  live buffers of the same size; skips when the counter does not move for
+  that probe either.
 
 ### io
 

--- a/tests/hid/idtable_leak.lua
+++ b/tests/hid/idtable_leak.lua
@@ -1,0 +1,61 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the idtable_leak test (see idtable_leak.sh).
+
+local data = require("data")
+local hid = require("hid")
+local insert = table.insert
+
+local MAXIDS <const> = 4096 -- LUAHID_MAXIDS, so each refusal strands the largest block one can
+local BLOCK <const> = (MAXIDS + 1) * 24 -- sizeof(struct hid_device_id) is 24 on a 64-bit kernel
+local REFUSALS <const> = 512 -- that many blocks is 64 MiB, far past the noise in SUnreclaim
+local ENOMEM <const> = "not enough memory"
+local SKIP <const> = "hid/idtable_leak: the kernel could not serve a block of this size" -- read by the .sh
+
+PROBE = {} -- global: measured alive, so a freed id_table reads apart from a size the counter ignores
+
+local function raise()
+	error("id_table entry")
+end
+
+local entry = setmetatable({}, {__index = raise})
+
+local function entrylen()
+	return MAXIDS
+end
+
+local function pushentry()
+	return entry
+end
+
+local id_table = setmetatable({}, {__len = entrylen, __index = pushentry})
+
+local function walked()
+	local ok, err = pcall(hid.register, {name = "lunatik_leak", id_table = id_table})
+	assert(not ok, "hid.register accepted an id_table whose entries raise")
+	if err:match(ENOMEM) then
+		return false
+	end
+	assert(err:match("id_table entry"), "hid.register refused before it allocated: " .. err)
+	return true
+end
+
+local function fill()
+	for _ = 1, REFUSALS do
+		insert(PROBE, data.new(BLOCK))
+	end
+end
+
+for _ = 1, REFUSALS do
+	if not walked() then
+		print(SKIP)
+		return
+	end
+end
+
+if not pcall(fill) then
+	print(SKIP)
+end
+

--- a/tests/hid/idtable_leak.sh
+++ b/tests/hid/idtable_leak.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for the id_table hid.register() allocates before it walks the
+# table the script handed it. lua_geti() and the field reads behind
+# lunatik_optinteger() both honour __index, so a metamethod written in Lua can
+# raise from inside the walk; the longjmp then skipped the free and the block
+# stayed allocated for the rest of the boot. The fix hands the table to the
+# driver before the walk, so the object's release frees it.
+#
+# LUAHID_MAXIDS entries is past the largest kmalloc cache but well short of what
+# one leak would show in a counter, so the script repeats the refusal until what
+# a leak holds is tens of MiB and the harness reads SUnreclaim. Each refusal
+# asserts that it came from the walk, so a refusal at the length bound fails the
+# case instead of passing it with nothing to leak; a block this host cannot serve
+# is the host and not the code, and the script says so and stops for a skip.
+#
+# The script then holds as many live buffers of the same size. That probe is what
+# tells the two zero deltas apart: it is allocated the same way, so if the counter
+# does not move for it either, this kernel does not account an allocation of this
+# size where the test reads and there is nothing to measure - skip, never pass.
+#
+# Usage: sudo bash tests/hid/idtable_leak.sh
+
+SCRIPT="tests/hid/idtable_leak"
+LEAK_MIB=32
+SKIP="hid/idtable_leak: the kernel could not serve a block of this size" # printed by the script
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() { lunatik stop "$SCRIPT" > /dev/null 2>&1; }
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 1
+
+slab_mib() { echo $(( $(grep SUnreclaim /proc/meminfo | awk '{print $2}') / 1024 )); }
+
+mark_dmesg
+
+before=$(slab_mib)
+run_script "$SCRIPT"
+alive=$(slab_mib)
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+after=$(slab_mib)
+
+probe=$((alive - after))
+leaked=$((after - before))
+
+if ! check_dmesg; then
+	ktap_totals
+	exit 1
+elif dmesg_since | grep -qF "$SKIP"; then
+	ktap_skip "$SKIP"
+elif [ "$probe" -lt "$LEAK_MIB" ]; then
+	ktap_skip "hid/idtable_leak: SUnreclaim does not account an id_table of this size (probe ${probe}MiB)"
+elif [ "$leaked" -ge "$LEAK_MIB" ]; then
+	ktap_fail "hid/idtable_leak: the id_table leaked ${leaked}MiB when the walk raised"
+else
+	ktap_pass "hid/idtable_leak"
+fi
+
+ktap_totals
+[ $KTAP_FAIL -eq 0 ]
+

--- a/tests/hid/register.lua
+++ b/tests/hid/register.lua
@@ -17,6 +17,18 @@ local function hugelen()
 	return HUGE_IDS
 end
 
+local function onelen()
+	return 1
+end
+
+local function badlen()
+	return "eight"
+end
+
+local function raise()
+	error("id_table entry")
+end
+
 local function ids(n)
 	local id_table = {}
 	for i = 1, n do
@@ -29,10 +41,11 @@ local function register(name, id_table)
 	hid.register({name = name, id_table = id_table})
 end
 
-local function refuses(name, id_table)
+local function refuses(name, id_table, expected)
 	local ok, err = pcall(register, name, id_table)
-	assert(not ok, "hid.register accepted an id_table of " .. #id_table .. " entries")
-	assert(err:match("'id_table' is too long"), "hid.register raised something else: " .. err)
+	assert(not ok, "hid.register accepted " .. name)
+	assert(err:match(expected), "hid.register raised something else: " .. err)
+	collectgarbage() -- run the refused driver's finalizer now, while the test can still see a crash
 end
 
 test("hid.register accepts an id_table it serves", function()
@@ -41,10 +54,18 @@ test("hid.register accepts an id_table it serves", function()
 end)
 
 test("hid.register refuses an id_table it cannot serve", function()
-	refuses("lunatik_hid_over", ids(MAXIDS + 1))
+	refuses("lunatik_hid_over", ids(MAXIDS + 1), "'id_table' is too long")
+	refuses("lunatik_hid_huge", setmetatable({}, {__len = hugelen}), "'id_table' is too long")
+	refuses("lunatik_hid_len", setmetatable({}, {__len = badlen}), "not an integer")
 end)
 
-test("hid.register refuses a fabricated id_table length", function()
-	refuses("lunatik_hid_huge", setmetatable({}, {__len = hugelen}))
+test("hid.register refuses an entry it cannot read", function()
+	refuses("lunatik_hid_entry", {{vendor = VENDOR}, 42}, "invalid id_table")
+	refuses("lunatik_hid_raise", {setmetatable({}, {__index = raise})}, "id_table entry")
+	refuses("lunatik_hid_walk", setmetatable({}, {__len = onelen, __index = raise}), "id_table entry")
+end)
+
+test("hid.register serves the next driver after a refusal", function()
+	register("lunatik_hid_after", ids(1))
 end)
 

--- a/tests/hid/run.sh
+++ b/tests/hid/run.sh
@@ -7,11 +7,19 @@
 #
 # register: hid.register() sizes the driver's id_table from the Lua table it is
 # given, through luaL_len(), which a __len metamethod answers with any number the
-# script likes. It registers the id_tables the binding serves, one entry and
-# LUAHID_MAXIDS of them, under a vendor no device on the bus carries, and refuses
-# both a longer table and a fabricated length, whose byte size overflows. The
-# accepted ones are read back from /sys/bus/hid/drivers, since a driver that
-# raised nothing has still not necessarily reached the bus.
+# script likes, and reads every entry through lua_geti() and lua_getfield(), which
+# an __index metamethod answers however it likes. It registers the id_tables the
+# binding serves, one entry and LUAHID_MAXIDS of them, under a vendor no device on
+# the bus carries, and refuses a longer table, a fabricated length, a length that
+# is not an integer, an entry that is not a table and an entry that raises while it
+# is read. The accepted ones are read back from /sys/bus/hid/drivers, since a
+# driver that raised nothing has still not necessarily reached the bus, and read
+# again after the runtime stops, since they leave the bus with it.
+#
+# The refusals carry the weight: hid.register() hands the id_table to the driver
+# before the walk that can raise, so the object's release owns it from then on, and
+# a fix that also freed the table by hand would free it twice. The finalizer the
+# script forces after each refusal is where that lands.
 #
 # hid.register needs a softirq runtime: its class is LUNATIK_OPT_SOFTIRQ and
 # lunatik_setruntime() refuses any other context.
@@ -24,18 +32,27 @@ source "$DIR/../lib.sh"
 
 SCRIPT=tests/hid/register
 DRIVERS=/sys/bus/hid/drivers
-NAMES="lunatik_hid_one lunatik_hid_max"
+NAMES="lunatik_hid_one lunatik_hid_max lunatik_hid_after"
+TOTAL=$(echo $NAMES | wc -w)
 
 skip() { ktap_header; ktap_plan 1; ktap_skip "$1"; ktap_totals; exit 0; }
 
-cleanup() { lunatik stop "$SCRIPT" 2>/dev/null; }
+cleanup() { lunatik stop "$SCRIPT" > /dev/null 2>&1; }
 trap cleanup EXIT
 cleanup
 
 [ -d /sys/bus/hid ] || skip "hid: the kernel has no HID bus"
 
 ktap_header
-ktap_plan 2
+ktap_plan 3
+
+onbus() {
+	local name count=0
+	for name in $NAMES; do
+		[ -d "$DRIVERS/$name" ] && count=$((count + 1))
+	done
+	echo $count
+}
 
 if run_test "$SCRIPT" softirq; then
 	ktap_pass "hid/register"
@@ -43,16 +60,26 @@ else
 	ktap_fail "hid/register"
 fi
 
-missing=""
-for name in $NAMES; do
-	[ -d "$DRIVERS/$name" ] || missing="$missing $name"
-done
-if [ -z "$missing" ]; then
+count=$(onbus)
+if [ "$count" -eq "$TOTAL" ]; then
 	ktap_pass "hid/register: the accepted drivers are on the hid bus"
 else
-	ktap_fail "hid/register: missing from $DRIVERS:$missing"
+	ktap_fail "hid/register: $count of $TOTAL drivers under $DRIVERS"
+fi
+
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+count=$(onbus)
+if [ "$count" -eq 0 ]; then
+	ktap_pass "hid/register: the drivers leave the hid bus with the runtime"
+else
+	ktap_fail "hid/register: $count drivers outlived their runtime under $DRIVERS"
 fi
 
 ktap_totals
-[ $KTAP_FAIL -eq 0 ]
+RESULT=0
+[ $KTAP_FAIL -eq 0 ] || RESULT=1
+
+echo ""
+bash "$DIR/idtable_leak.sh" || RESULT=1
+exit $RESULT
 


### PR DESCRIPTION
`hid.register()` allocated the `id_table` and then walked a table the script owns. `lua_geti()` honours `__index`, and `lunatik_optinteger()` expands to `lua_getfield()`, which honours it too, so a metamethod written in Lua raises from inside the walk; the longjmp skips the `lunatik_free()` on the error path and the block stays allocated for the rest of the boot.

The table is handed to the driver before the walk, the way `luaset_build()` hands over its offsets, so `luahid_release()` frees it on every path out, and the explicit free and the NULL return go with it. `tests/hid` gains `idtable_leak`, which reads out of `SUnreclaim` the 64 MiB that 512 refusals of a full-length table strand, and `register` covers the entries the walk accepts and the ones it refuses.

Based on #810, which creates `tests/hid` and bounds the length this walk reads.
