### PR TITLE
docs: rules for a silenced build, an unbuildable A/B and conflict markers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,6 +517,10 @@ old factory — kept building and broke at the first packet.
 * Read the commit before pushing it, not only the working tree: `git show` the diff that is about to
   be published. Instrumentation added while debugging — a `pr_err`, a hardcoded branch — is invisible
   in a passing test and lands in the pull request.
+* After resolving a rebase or a merge, `git grep -n '^<<<<<<< '` before committing. `git add -A`
+  stages a conflict marker without complaining, and `git rebase --continue` runs no pre-commit hook,
+  so the markers reach the branch and surface far from the resolution: a `tests/run.sh` carrying one
+  dies at ``syntax error near unexpected token `<<<'``.
 * Change only what the task requires. Do not reformat untouched lines, do not move code, do not
   rename variables in passing. Compare `git diff` against `git diff -w` before committing to catch
   stray whitespace.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,10 @@ on a `linux.*` constant, not a build error. Regenerate cleanly with
 
 A worktree that has not run `make` cannot install: `scripts_install` needs the autogen output and
 fails, and an install whose output was silenced fails unseen while the previous install stays in
-place, so every run after it tests the wrong tree. Keep the install's output visible, and before
-reading a result confirm that what sits under `/lib/modules/lua/` is the tree under test: its
-timestamp, or a grep for a symbol only the branch has.
+place, so every run after it tests the wrong tree. A silenced `make` does the same one step earlier:
+the chain stops at the build and the suite run next reports on the modules already installed. Keep the
+build's and the install's output visible, and before reading a result confirm that what sits under
+`/lib/modules/lua/` is the tree under test: its timestamp, or a grep for a symbol only the branch has.
 
 `lunatik test` reloads the modules before the suite and unloads them after it. A test script run
 directly afterwards (`bash tests/<suite>/<test>.sh`) skips with `not loaded` until the next
@@ -442,7 +443,10 @@ Tests are shell scripts emitting KTAP plus a kernel side Lua script.
 * coverage means the matrix of operation by type by outcome, including the successes, not a list of
   features and not only the error paths;
 * prove the test discriminates: disable the mechanism it covers, watch it fail, restore. Commit
-  first, since restoring is a `git checkout --` that takes any uncommitted work with it;
+  first, since restoring is a `git checkout --` that takes any uncommitted work with it. The defective
+  side has to compile: a header reverted while its callers still pass the argument it drops stops at
+  `too many arguments`, the suite then runs against the modules already installed, and that green run
+  reads as a test that does not discriminate;
 * a case whose stimulus only exists on a busy machine is forced, not waited for: the probe test picks a
   syscall an idle host never makes, which is why it never hit the creation window that crashed the host,
   and covering that window meant pinning the call to the CPU whose runtime is published last. A test


### PR DESCRIPTION
Three failures in the last round were not covered by AGENTS.md: a silenced `make` left the chain reporting on the modules already installed, an A/B whose defective side did not compile gave a green suite that read as a test which does not discriminate, and conflict markers reached a branch because `git add -A` stages them without complaining and `git rebase --continue` runs no pre-commit hook.

Each becomes one rule where it belongs: a sentence in the paragraph on a silenced install, a clause on the bullet that asks a test to prove it discriminates, and a new bullet in "Patches and commits". The srcversion comparison and the silenced install were already written, so neither is repeated.

Documentation only, and nothing depends on it.
