### PR TITLE
docs: list the tc suite among the ones lunatik test takes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ sudo make install
 sudo lunatik test           # run all suites
 sudo lunatik test thread    # run a specific suite (bpf, crypto, io, linux,
                             # monitor, netlink, notifier, probe, rcu, runtime,
-                            # set, skb, socket, struct, task, thread, xdp)
+                            # set, skb, socket, struct, task, tc, thread, xdp)
 ```
 
 `lunatik test` reloads the modules before the run and unloads them


### PR DESCRIPTION
`README.md` lists the suites `lunatik test <suite>` takes and leaves `tc` out, so the one suite that needs a compiled BPF object reads as unsupported.

`tests/tc` has been in `tests/run.sh` since it was added and `tests/README.md` describes it; only that list was missing it.
