### PR TITLE
lunatik: lunatik_setstring leaves room for the terminator

### DIFF
--- a/doc/capi.md
+++ b/doc/capi.md
@@ -445,7 +445,8 @@ Falls back to `opt` if the field is absent or nil.
 void lunatik_setstring(lua_State *L, int idx, hook, field, maxlen);
 ```
 Reads a required string field named `field` from the table at `idx` into `hook->field`,
-truncated to `maxlen` bytes. Raises a Lua error if the field is missing or not a string.
+a buffer of `maxlen` bytes holding the string and its terminator. Raises a Lua error if
+the field is missing, is not a string, or is too long.
 
 ---
 

--- a/lunatik.h
+++ b/lunatik.h
@@ -421,7 +421,7 @@ do {								\
 	size_t len;						\
 	lunatik_checkfield(L, idx, #field, LUA_TSTRING);	\
 	const char *str = lua_tolstring(L, -1, &len);		\
-	if (len > maxlen)					\
+	if (len >= maxlen)					\
 		luaL_error(L, "'%s' is too long", #field);	\
 	strncpy((char *)hook->field, str, maxlen);		\
 	lua_pop(L, 1);						\

--- a/tests/README.md
+++ b/tests/README.md
@@ -99,7 +99,9 @@ Covers the `crypto` module: `shash`, `skcipher`, `aead`, `rng`, `hkdf`,
   longer table, a length a `__len` metamethod fabricates, a length that is
   not an integer, an entry that is not a table and an entry that raises
   while it is read are each refused, and each refusal forces the refused
-  driver's finalizer. Skips when the kernel has no HID bus.
+  driver's finalizer. A name filling `NAME_MAX` with no room for its
+  terminator is refused too, and the longest that does leave room reaches
+  the bus intact. Skips when the kernel has no HID bus.
 - **idtable_leak**: an `id_table` whose entries raise from `__index` leaves
   nothing allocated behind. The refusal is repeated until what a leak would
   hold is tens of MiB in `SUnreclaim`, and the script then holds as many

--- a/tests/hid/register.lua
+++ b/tests/hid/register.lua
@@ -11,6 +11,7 @@ local insert = table.insert
 local BUS      <const> = 0x03   -- BUS_USB
 local VENDOR   <const> = 0xf055 -- no device on the hid bus carries this vendor, so nothing binds
 local MAXIDS   <const> = 4096   -- LUAHID_MAXIDS, the longest id_table hid.register serves
+local MAXNAME  <const> = 255    -- NAME_MAX, the buffer the driver name and its terminator share
 local HUGE_IDS <const> = 1 << 40
 
 local function hugelen()
@@ -63,6 +64,13 @@ test("hid.register refuses an entry it cannot read", function()
 	refuses("lunatik_hid_entry", {{vendor = VENDOR}, 42}, "invalid id_table")
 	refuses("lunatik_hid_raise", {setmetatable({}, {__index = raise})}, "id_table entry")
 	refuses("lunatik_hid_walk", setmetatable({}, {__len = onelen, __index = raise}), "id_table entry")
+end)
+
+test("hid.register refuses a name that fills its buffer", function()
+	local ok, err = pcall(register, string.rep("x", MAXNAME), ids(1))
+	assert(not ok, "hid.register accepted a name with no room for its terminator")
+	assert(err:match("'name' is too long"), "hid.register raised something else: " .. err)
+	register(string.rep("x", MAXNAME - 1), ids(1))
 end)
 
 test("hid.register serves the next driver after a refusal", function()

--- a/tests/hid/run.sh
+++ b/tests/hid/run.sh
@@ -12,9 +12,11 @@
 # binding serves, one entry and LUAHID_MAXIDS of them, under a vendor no device on
 # the bus carries, and refuses a longer table, a fabricated length, a length that
 # is not an integer, an entry that is not a table and an entry that raises while it
-# is read. The accepted ones are read back from /sys/bus/hid/drivers, since a
-# driver that raised nothing has still not necessarily reached the bus, and read
-# again after the runtime stops, since they leave the bus with it.
+# is read. It also refuses a name that fills NAME_MAX with no room for its
+# terminator, and accepts the longest one that does leave room. The accepted ones
+# are read back from /sys/bus/hid/drivers, since a driver that raised nothing has
+# still not necessarily reached the bus, and read again after the runtime stops,
+# since they leave the bus with it.
 #
 # The refusals carry the weight: hid.register() hands the id_table to the driver
 # before the walk that can raise, so the object's release owns it from then on, and
@@ -32,7 +34,8 @@ source "$DIR/../lib.sh"
 
 SCRIPT=tests/hid/register
 DRIVERS=/sys/bus/hid/drivers
-NAMES="lunatik_hid_one lunatik_hid_max lunatik_hid_after"
+LONGNAME=$(printf 'x%.0s' $(seq 1 254)) # NAME_MAX - 1, the longest name hid.register serves
+NAMES="lunatik_hid_one lunatik_hid_max lunatik_hid_after $LONGNAME"
 TOTAL=$(echo $NAMES | wc -w)
 
 skip() { ktap_header; ktap_plan 1; ktap_skip "$1"; ktap_totals; exit 0; }


### PR DESCRIPTION
`lunatik_setstring` refused a string longer than `maxlen` and then copied it with `strncpy(str, maxlen)`, so one of exactly `maxlen` bytes filled the buffer and left no terminator. Its one caller is `hid.register()`, whose `driver->name` is a `NAME_MAX` allocation, so `hid.register{name = ("x"):rep(255)}` had `hid_register_driver()` read past the end of it and the driver reached `/sys/bus/hid/drivers` under whatever followed.

`maxlen` is the buffer, so the string has to fit in it with its terminator. Test: the `hid/register` case that refuses a name filling the buffer and checks that the longest one which does leave room reaches the bus intact.

Based on #818, which is where `tests/hid` and its bus check come from.
