### PR TITLE
notifier: report the index and the namespace of the device an event is about

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,9 @@ sudo lunatik stop examples/ifquarantine/control    # stops both runtimes
 Pre-existing interfaces are covered as well: `register_netdevice_notifier`
 synchronously replays `NETDEV_REGISTER` (and `NETDEV_UP`) for each existing
 netdev when the notifier block is registered, so they enter quarantine at
-script start too.
+script start too. The replay spans every network namespace, and the example
+keeps the devices of the one its netfilter hook acts on, comparing the
+namespace each event carries against `linux.netns()`.
 
 ### filter
 

--- a/README.md
+++ b/README.md
@@ -334,17 +334,19 @@ execution contexts.
 sudo make examples_install                         # installs examples
 sudo lunatik run examples/ifquarantine/control     # starts control+filter
 sudo cat /dev/ifquarantine                         # lists known interfaces and verdict
-sudo sh -c "echo 'allow=eth0' > /dev/ifquarantine" # lift quarantine on eth0
-sudo sh -c "echo 'deny=eth0'  > /dev/ifquarantine" # re-apply quarantine
+sudo sh -c "echo 'deny=eth0'  > /dev/ifquarantine" # quarantine eth0
+sudo sh -c "echo 'allow=eth0' > /dev/ifquarantine" # lift the quarantine
 sudo lunatik stop examples/ifquarantine/control    # stops both runtimes
 ```
 
-Pre-existing interfaces are covered as well: `register_netdevice_notifier`
-synchronously replays `NETDEV_REGISTER` (and `NETDEV_UP`) for each existing
-netdev when the notifier block is registered, so they enter quarantine at
-script start too. The replay spans every network namespace, and the example
-keeps the devices of the one its netfilter hook acts on, comparing the
-namespace each event carries against `linux.netns()`.
+The interfaces that already exist are recorded and allowed, not quarantined:
+`register_netdevice_notifier` synchronously replays `NETDEV_REGISTER` (and
+`NETDEV_UP`) for each existing netdev when the notifier block is registered,
+and a policy that denied those would take the machine off the network, `lo`
+and the uplink included. They are listed by `cat /dev/ifquarantine` and can
+be quarantined with `deny=<name>`. The replay spans every network namespace,
+and the example keeps the devices of the one its netfilter hook acts on,
+comparing the namespace each event carries against `linux.netns()`.
 
 ### filter
 

--- a/examples/ifquarantine/control.lua
+++ b/examples/ifquarantine/control.lua
@@ -16,6 +16,7 @@ local filter      <const> = "examples/ifquarantine/filter"
 local NETNS       <const> = linux.netns()
 local quarantined         = rcu.table()   -- tostring(ifindex) -> true
 local known               = {}            -- name -> ifindex
+local replaying           = true          -- the registration below replays REGISTER for every device
 
 local function info(...)
 	print("ifquarantine: " .. string.format(...))
@@ -40,7 +41,12 @@ local function callback(event, name, ifindex, netns)
 		return notify.OK
 	end
 	if event == netdev.REGISTER then
-		quarantine(name, ifindex)
+		if replaying then
+			known[name] = ifindex
+			info("%s (ifindex=%d) already present", name, ifindex)
+		else
+			quarantine(name, ifindex)
+		end
 	elseif event == netdev.UNREGISTER then
 		release(name)
 		known[name] = nil
@@ -88,4 +94,5 @@ driver.sentinel = setmetatable({}, {__gc = function()
 end})
 
 notifier.netdevice(callback)
+replaying = false
 

--- a/examples/ifquarantine/control.lua
+++ b/examples/ifquarantine/control.lua
@@ -13,6 +13,7 @@ local notify   = require("linux.notify")
 local stat     = require("linux.stat")
 
 local filter      <const> = "examples/ifquarantine/filter"
+local NETNS       <const> = linux.netns()
 local quarantined         = rcu.table()   -- tostring(ifindex) -> true
 local known               = {}            -- name -> ifindex
 
@@ -34,12 +35,12 @@ local function release(name)
 	end
 end
 
-local function callback(event, name)
+local function callback(event, name, ifindex, netns)
+	if netns ~= NETNS then   -- the netfilter hook only acts on the initial namespace
+		return notify.OK
+	end
 	if event == netdev.REGISTER then
-		local ok, idx = pcall(linux.ifindex, name)
-		if ok and idx then
-			quarantine(name, idx)
-		end
+		quarantine(name, ifindex)
 	elseif event == netdev.UNREGISTER then
 		release(name)
 		known[name] = nil

--- a/lib/lualinux.c
+++ b/lib/lualinux.c
@@ -184,6 +184,7 @@ static int lualinux_lookup(lua_State *L)
 
 /***
 * Gets the interface index for a network device name.
+* The name is resolved in the namespace `netns` returns.
 *
 * @function ifindex
 * @tparam string interface_name network interface name (e.g., "eth0").
@@ -206,6 +207,7 @@ static int lualinux_ifindex(lua_State *L)
 
 /***
 * Gets the HW address for the network interface index.
+* The index is resolved in the namespace `netns` returns.
 *
 * @function ifaddr
 * @tparam integer ifindex interface index number.
@@ -227,6 +229,26 @@ static int lualinux_ifaddr(lua_State *L)
 	memcpy(addr, dev->dev_addr, len);
 	dev_put(dev);
 	luaL_pushresultsize(&B, len);
+	return 1;
+}
+
+/***
+* Gets the network namespace Lunatik's device lookups resolve in.
+* It is the initial namespace: the number a `net:[...]` link under
+* `/proc/<pid>/ns/net` names for a process of the machine itself. A
+* `notifier.netdevice` callback compares the `netns` it is given against this
+* to tell a device `ifindex` can resolve from one it cannot.
+*
+* @function netns
+* @treturn integer inode number of the network namespace.
+* @usage
+*   local NETNS <const> = linux.netns()
+*   -- inside a notifier.netdevice callback
+*   if netns == NETNS then print("own device") end
+*/
+static int lualinux_netns(lua_State *L)
+{
+	lua_pushinteger(L, (lua_Integer)init_net.ns.inum);
 	return 1;
 }
 
@@ -273,6 +295,7 @@ static const luaL_Reg lualinux_lib[] = {
 	{"lookup", lualinux_lookup},
 	{"ifindex", lualinux_ifindex},
 	{"ifaddr", lualinux_ifaddr},
+	{"netns", lualinux_netns},
 	{"errname", lualinux_errname},
 	{"numcpus", lualinux_numcpus},
 	{NULL, NULL}

--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -124,7 +124,9 @@ static int luanotifier_netdevice_handler(lua_State *L, void *data)
 	struct net_device *dev = netdev_notifier_info_to_dev(data);
 
 	lua_pushstring(L, dev->name);
-	return 1;
+	lua_pushinteger(L, (lua_Integer)dev->ifindex);
+	lua_pushinteger(L, (lua_Integer)dev_net(dev)->ns.inum);
+	return 3;
 }
 
 /***
@@ -132,9 +134,13 @@ static int luanotifier_netdevice_handler(lua_State *L, void *data)
 * runtime (the default).
 *
 * @function netdevice
-* @tparam function callback invoked as `callback(event, name)` — `event`
-*   is a `linux.netdev` code and `name` is the device name (e.g. `"eth0"`).
-*   Returns a `linux.notify` status code.
+* @tparam function callback invoked as `callback(event, name, ifindex, netns)`
+*   — `event` is a `linux.netdev` code, `name` is the device name (e.g.
+*   `"eth0"`), `ifindex` is the device's index and `netns` is the inode number
+*   of its network namespace. Every namespace is reported, and a name or an
+*   index identifies a device only within one, so a callback that means the
+*   machine's own devices compares `netns` against `linux.netns()`. Returns a
+*   `linux.notify` status code.
 * @treturn notifier
 * @raise if called from a percpu runtime
 * @within notifier

--- a/tests/README.md
+++ b/tests/README.md
@@ -165,6 +165,11 @@ higher-level `netlink.*` modules built on top of it.
   the synchronous `NETDEV_REGISTER` replay `register_netdevice_notifier`
   performs for existing devices.
 
+- **device_identity**: the netdevice chain is global, so the same device name
+  in the initial namespace and in another one must both be reported, each with
+  the `ifindex` and the namespace inode number that identify it, on the replay
+  and on live register and unregister.
+
 ### probe
 
 - **kprobe_concurrent**: registers kprobes on every syscall and runs

--- a/tests/notifier/device_identity.lua
+++ b/tests/notifier/device_identity.lua
@@ -1,0 +1,32 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Reports every netdevice event with the index and the namespace of the device
+-- it is about, so the shell can tell a device of the initial namespace from a
+-- homonymous one elsewhere. See tests/notifier/device_identity.sh.
+--
+
+local linux    = require("linux")
+local notifier = require("notifier")
+local netdev   = require("linux.netdev")
+local notify   = require("linux.notify")
+
+local format = string.format
+
+local NETNS <const> = linux.netns()
+local events = {[netdev.REGISTER] = "register", [netdev.UNREGISTER] = "unregister"}
+
+print(format("device_identity: netns %d", NETNS))
+
+local function callback(event, name, ifindex, netns)
+	local kind = events[event]
+	if kind then
+		print(format("device_identity: %s %s %d %d %s", kind, name, ifindex, netns,
+			netns == NETNS and "own" or "foreign"))
+	end
+	return notify.OK
+end
+
+notifier.netdevice(callback)
+

--- a/tests/notifier/device_identity.sh
+++ b/tests/notifier/device_identity.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# The netdevice chain is global: register_netdevice_notifier replays and
+# delivers events for every network namespace, and a device name is unique only
+# within one. So a callback given the name alone cannot tell a device it can
+# resolve from a homonymous one it cannot, and resolving the wrong one silently
+# acts on another device.
+#
+# The test creates the same device name in the initial namespace and in another
+# one, and asserts that both are reported, each carrying the index and the
+# namespace inode number that identify it. It deliberately does not assert that
+# a foreign device is hidden: narrowing the chain to one namespace is the shape
+# this replaced, and a green test for it would make restoring generality a
+# regression.
+#
+# Ground truth comes from the shell: /sys/class/net/<dev>/ifindex for the index
+# and /proc/self/ns/net for the namespace, read on each side. That ground truth
+# needs the suite to run in the initial namespace, read as PID 1 sharing its
+# namespace: a container whose PID 1 is inside one too passes that check and
+# fails the first case instead of skipping.
+#
+# Usage: sudo bash tests/notifier/device_identity.sh
+
+SCRIPT="tests/notifier/device_identity"
+NETNS="lunatik_ni"
+REPLAYDEV="lnid0"
+LIVEDEV="lnid1"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() {
+	lunatik stop "$SCRIPT" 2>/dev/null
+	ip netns del "$NETNS" 2>/dev/null
+	ip link del "$REPLAYDEV" 2>/dev/null
+	ip link del "$LIVEDEV" 2>/dev/null
+}
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 8
+
+skip_all() {
+	echo "# SKIP: $1"
+	ktap_skip "linux.netns() names the namespace the suite runs in"
+	ktap_skip "replay reports a device of the initial namespace as its own"
+	ktap_skip "replay reports a homonymous device of another namespace as foreign"
+	ktap_skip "live register reports a device of the initial namespace as its own"
+	ktap_skip "live register reports a homonymous device of another namespace as foreign"
+	ktap_skip "live unregister reports the foreign device with the identity it had"
+	ktap_skip "live unregister reports the own device with the identity it had"
+	ktap_skip "no Lua errors in kernel"
+	ktap_totals
+	exit 0
+}
+
+# the inode number readlink prints as net:[<inum>], which is what the binding reports
+netns_inum() {
+	local link
+	link=$("$@" readlink /proc/self/ns/net) || return 1
+	link="${link#net:\[}"
+	echo "${link%\]}"
+}
+
+command -v ip > /dev/null 2>&1 || skip_all "ip not available"
+[ "$(readlink /proc/1/ns/net)" = "$(readlink /proc/self/ns/net)" ] ||
+	skip_all "suite runs in a network namespace of its own, no ground truth for linux.netns()"
+ip link add "$REPLAYDEV" type dummy 2>/dev/null || skip_all "cannot create a dummy device"
+ip netns add "$NETNS" 2>/dev/null || skip_all "cannot create a network namespace"
+ip netns exec "$NETNS" ip link add "$REPLAYDEV" type dummy 2>/dev/null ||
+	skip_all "cannot create a dummy device in another namespace"
+
+OWN_NETNS=$(netns_inum) || fail "cannot read the namespace of the suite"
+FOREIGN_NETNS=$(netns_inum ip netns exec "$NETNS") || fail "cannot read the namespace of $NETNS"
+[ "$OWN_NETNS" != "$FOREIGN_NETNS" ] || fail "$NETNS reports the namespace the suite runs in"
+
+own_replay=$(cat "/sys/class/net/$REPLAYDEV/ifindex")
+foreign_replay=$(ip netns exec "$NETNS" cat "/sys/class/net/$REPLAYDEV/ifindex")
+
+mark_dmesg
+run_script "$SCRIPT"
+
+dmesg_since | grep -qF "device_identity: netns $OWN_NETNS" ||
+	fail "linux.netns() did not report $OWN_NETNS"
+ktap_pass "linux.netns() names the namespace the suite runs in"
+
+dmesg_since | grep -qF "device_identity: register $REPLAYDEV $own_replay $OWN_NETNS own" ||
+	fail "replay did not report $REPLAYDEV of the initial namespace (ifindex $own_replay)"
+ktap_pass "replay reports a device of the initial namespace as its own"
+
+dmesg_since | grep -qF "device_identity: register $REPLAYDEV $foreign_replay $FOREIGN_NETNS foreign" ||
+	fail "replay did not report $REPLAYDEV of $NETNS (ifindex $foreign_replay)"
+ktap_pass "replay reports a homonymous device of another namespace as foreign"
+
+ip link add "$LIVEDEV" type dummy || fail "cannot create $LIVEDEV"
+own_live=$(cat "/sys/class/net/$LIVEDEV/ifindex")
+dmesg_since | grep -qF "device_identity: register $LIVEDEV $own_live $OWN_NETNS own" ||
+	fail "live register did not report $LIVEDEV of the initial namespace (ifindex $own_live)"
+ktap_pass "live register reports a device of the initial namespace as its own"
+
+ip netns exec "$NETNS" ip link add "$LIVEDEV" type dummy || fail "cannot create $LIVEDEV in $NETNS"
+foreign_live=$(ip netns exec "$NETNS" cat "/sys/class/net/$LIVEDEV/ifindex")
+dmesg_since | grep -qF "device_identity: register $LIVEDEV $foreign_live $FOREIGN_NETNS foreign" ||
+	fail "live register did not report $LIVEDEV of $NETNS (ifindex $foreign_live)"
+ktap_pass "live register reports a homonymous device of another namespace as foreign"
+
+ip netns exec "$NETNS" ip link del "$LIVEDEV" || fail "cannot delete $LIVEDEV from $NETNS"
+dmesg_since | grep -qF "device_identity: unregister $LIVEDEV $foreign_live $FOREIGN_NETNS foreign" ||
+	fail "live unregister did not report $LIVEDEV of $NETNS (ifindex $foreign_live)"
+ktap_pass "live unregister reports the foreign device with the identity it had"
+
+ip link del "$LIVEDEV" || fail "cannot delete $LIVEDEV"
+dmesg_since | grep -qF "device_identity: unregister $LIVEDEV $own_live $OWN_NETNS own" ||
+	fail "live unregister did not report $LIVEDEV of the initial namespace (ifindex $own_live)"
+ktap_pass "live unregister reports the own device with the identity it had"
+
+check_dmesg && ktap_pass "no Lua errors in kernel"
+
+ktap_totals
+

--- a/tests/notifier/run.sh
+++ b/tests/notifier/run.sh
@@ -11,7 +11,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
 SEP=$'\n'
-for t in "$DIR"/context_mismatch.sh "$DIR"/init_dispatch.sh; do
+for t in "$DIR"/context_mismatch.sh "$DIR"/init_dispatch.sh "$DIR"/device_identity.sh; do
 	echo "${SEP}# --- $(basename "$t") ---"
 	bash "$t" || FAILED=$((FAILED+1))
 done


### PR DESCRIPTION
Superseded by #797, which fixes the same defect the other way round. Kept open until #797 merges, as the record of the alternative that was weighed.

The defect: `notifier.netdevice` hands the callback a device name, and the chain is global, so a device created in another network namespace arrives under a name that means a different device in the initial one. Bringing up a namespace put the host's `lo` back into DROP in the `ifquarantine` example after an operator had allowed it. This branch keeps the global chain and appends `dev->ifindex` and `dev_net(dev)->ns.inum`, so a callback reads `(event, name, ifindex, netns)` and compares against a new `linux.netns()`, deciding for itself which devices it means.

What decided against it: nothing else in Lunatik can act outside the initial namespace, since `lualinux`, `luanetfilter`, `luasocket` and `luanetlink` all pass `&init_net`, so the generality this preserves is that of a script which can only print foreign names, while the cost is that the fix becomes opt-in and every script must remember it. The out-of-tree `dome/vlan.lua` would keep running unchanged and keep the bug. What was worth keeping here was carried over: the PID-1 ground-truth precondition into `netns_scope`, and the example's replay policy as #831.
