### PR TITLE
docs: what the notifier namespace round taught

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,6 +500,12 @@ old factory — kept building and broke at the first packet.
   what it costs; prevalence says whether it is common, never whether it is right, and a tree can be
   wrong in a hundred places. When the only support for a line is a precedent, say so and judge it
   again.
+* The core and its bindings are not shaped by a consumer or by an example. An example that cannot
+  be written, or that reaches what it needs through a channel no contract states, is evidence of a
+  gap in the API; what fills that gap is decided from what the binding is for, and the commit and
+  the pull request argue it that way. Narrowing `notifier.netdevice` to the initial namespace fixed
+  the `ifquarantine` example, whose callback resolved a reported name there, and took away the
+  script that watches containers.
 
 ## Patches and commits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,9 @@ A worktree named for a task may belong to another session on the same machine. C
 `git worktree list` and the branch a worktree holds before a checkout or a reset there, and never
 reset a branch checked out elsewhere. A review, or a build of a branch not your own, runs in a
 worktree created for it (`git worktree add`, then `git submodule update --init`) and removed at the
-end.
+end. A `git checkout` carries what is uncommitted onto the new HEAD, where an edit made against the
+old base reads as a change to the new one: switch branches in a tree with nothing pending, or read
+the other branch in a worktree of its own.
 
 A tree with a conflict pending (`git status` showing `UU`) is not a test subject: a suite run over a
 half-applied rebase or cherry-pick measures neither side. Resolve and commit, then build.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,6 +439,9 @@ Tests are shell scripts emitting KTAP plus a kernel side Lua script.
 * a test does not depend on what else runs on the host: when a host process — a network manager, say
   — can race it by acting on a resource the test created, make the test robust to any such process,
   not wired to silence one by name, which does not carry to another distro or to CI;
+* a case pins a refusal the API makes, never a capability it gave up: a notifier narrowed to the
+  initial namespace came with a case asserting that a device of another namespace is not reported,
+  so a lost capability became the contract and restoring it has to delete a green test;
 * coverage means the matrix of operation by type by outcome, including the successes, not a list of
   features and not only the error paths;
 * prove the test discriminates: disable the mechanism it covers, watch it fail, restore. Commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -470,6 +470,12 @@ compiles against a Lua module and only fails when its code path runs: `skb.attr`
 `.new` and a pure attribute view, and `sniclassify`'s `skbattr(...)` / `skb:data()` — written for the
 old factory — kept building and broke at the first packet.
 
+The kernel a consumer builds on bounds what a change may use, and not every consumer sits inside
+the range this file declares: a product built on Lunatik can ship on an older vendor kernel, and
+`register_netdevice_notifier_net`, which arrived in v5.5, does not exist on the 5.4 one of them runs
+on. An API newer than a known consumer's kernel is a decision taken here, with the floor it sets
+named, not one discovered at that consumer's build.
+
 * Do not land an implementation you already intend to replace. A guarantee that holds only on some
   paths is not a guarantee: make it structural or do not offer it. Merging a half measure and opening
   a follow up that deletes it pollutes the history across pull requests the same way a commit that


### PR DESCRIPTION
Four rules this file did not have, each broken in the round that reshaped `notifier.netdevice`: a binding argued from the example that needed it, a consumer whose kernel is older than the range declared here, a test case that pinned a narrowing as the contract, and a `git checkout` that carried an uncommitted edit onto another branch.

Each lands where its subject already lives, one paragraph or one bullet, naming the case it came from. `AGENTS.md` is the only file touched.

Independent of everything open. It merges clean over #796, #814, #816, #817 and #819, which change other parts of the same file.
