### PR TITLE
checks: stop a script that takes the host off the network

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,10 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/consumers-guard.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/example-guard.sh\""
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,15 @@ wrong, over rules that were already written and already broken, adds a paragraph
 or a "Test plan" section; `pr-body-guard.sh`, wired before a shell call like `crash-guard.sh`,
 blocks a `gh` write to pulls that carries a body file the check fails on.
 
+`tools/watchdog.sh` runs a script and stops it when the host loses the connectivity it had before the
+run, comparing against the loopback and the default route's gateway and holding nothing against the
+script that was already unreachable. `example-guard.sh`, wired before a shell call like the guards
+above, refuses `lunatik run` and `spawn` of anything under `examples/` that does not go through it,
+unless the command carries `NETWORK_LOSS_OK=1`. An example arms real hooks on the machine that runs
+it, and one that cuts the network off cannot be stopped afterwards, because the command that would
+stop it has nowhere to be typed: that has cost this tree two reboots. The watchdog covers the loss of
+connectivity, not a wedged device, which is what the lock guard above is for.
+
 `consumers.sh` names the out-of-tree scripts that load a binding the changed files touch, reading the
 clones listed in `LUNATIK_CONSUMERS`; `consumers-guard.sh`, wired before a shell call, blocks opening or
 editing a pull request that changes such a binding until the command carries `CONSUMERS_OK=1`, set once

--- a/tools/checks/example-guard.sh
+++ b/tools/checks/example-guard.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# PreToolUse (Bash) hook: an example is loaded through tools/watchdog.sh, which
+# stops it when the host loses the connectivity it had. An example arms real
+# hooks on the machine that runs it, and one that cuts the network off cannot be
+# stopped afterwards: the command that would stop it has nowhere to be typed.
+# Reads the tool command on stdin. Pass NETWORK_LOSS_OK=1 to run one bare, on a
+# machine whose connectivity is expendable.
+
+input=$(cat)
+
+case "$input" in
+	*NETWORK_LOSS_OK=1*|*watchdog.sh*) exit 0 ;;
+esac
+case "$input" in
+	*"lunatik run examples/"*|*"lunatik spawn examples/"*) ;;
+	*) exit 0 ;;
+esac
+
+{
+	echo "example-guard: load an example through the watchdog, which stops it if the host"
+	echo "loses the connectivity it had:"
+	echo "  bash tools/watchdog.sh <script> [softirq|hardirq] [percpu]"
+	echo "An example that takes the network down cannot be stopped by hand afterwards, and"
+	echo "that has cost this tree two reboots. Pass NETWORK_LOSS_OK=1 to run one bare."
+} >&2
+exit 2
+

--- a/tools/watchdog.sh
+++ b/tools/watchdog.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Runs a Lunatik script and stops it if the host loses the connectivity it had
+# before the run. A script that cuts the machine off cannot be stopped by hand
+# afterwards, since the terminal that would type the command is gone, and on
+# this tree that has cost two reboots.
+#
+# It compares against what worked before the run and nothing else: the loopback,
+# and the gateway of the default route when there is one. A check that already
+# failed is not held against the script.
+#
+# Usage: bash tools/watchdog.sh <script> [softirq|hardirq] [percpu]
+#        LUNATIK_WATCHDOG_GRACE=<seconds> before the check, default 3
+
+GRACE=${LUNATIK_WATCHDOG_GRACE:-3}
+SCRIPT=$1
+
+[ -n "$SCRIPT" ] || { echo "usage: $0 <script> [softirq|hardirq] [percpu]" >&2; exit 2; }
+shift
+
+reachable() { ping -c 1 -W 1 "$1" > /dev/null 2>&1; }
+
+gateway=$(ip route show default 2>/dev/null | awk '/^default/ {print $3; exit}')
+
+targets=""
+for t in 127.0.0.1 $gateway; do
+	reachable "$t" && targets="$targets $t"
+done
+[ -n "$targets" ] || echo "# watchdog: nothing was reachable before the run, nothing to compare against"
+
+lunatik run "$SCRIPT" "$@" || exit $?
+sleep "$GRACE"
+
+lost=""
+for t in $targets; do
+	reachable "$t" || lost="$lost $t"
+done
+[ -n "$lost" ] || exit 0
+
+echo "watchdog: $SCRIPT took the host off the network, unreachable now:$lost; stopping it" >&2
+if timeout 30 lunatik stop "$SCRIPT"; then
+	for t in $lost; do
+		reachable "$t" || echo "watchdog: $t is still unreachable after the stop" >&2
+	done
+else
+	echo "watchdog: the stop did not return; the device is wedged and this needs a reboot" >&2
+fi
+exit 1
+


### PR DESCRIPTION
An example arms real hooks on the machine that runs it, and one that cuts the network off cannot be stopped afterwards, because the command that would stop it has nowhere to be typed. That has cost this tree two reboots, both from a reviewer loading `examples/ifquarantine/control` to prove it worked.

`tools/watchdog.sh` runs a script, then compares what was reachable before it against what is reachable after, and stops it when something it had is gone. `tools/checks/example-guard.sh` refuses `lunatik run` and `spawn` of anything under `examples/` that does not go through the watchdog, unless the command carries `NETWORK_LOSS_OK=1`. The guard keys on loading an example, not on the name of one already known to misbehave, which would cover only the damage that has been paid for.

Verified against a scratch script that drops on the loopback and nothing else: the watchdog reported it, stopped it, and the loopback came back, while a script of the same shape that accepts was left running. The watchdog covers the loss of connectivity, not a device wedged by something in the kernel, which is what #816 is for.
