### PR TITLE
harness: one pull request for the seven open on the checks and the rules

### DIFF
--- a/.agents/skills/lunatik-cycle/SKILL.md
+++ b/.agents/skills/lunatik-cycle/SKILL.md
@@ -37,6 +37,9 @@ only a reboot clears. Before starting one:
 
     ps -eo pid,stat,cmd | grep -E 'lua5.4.*lunatik|[[]lunatik]'   # any D state = wedged
 
+`lunatik-lock.sh` looks for the same processes before a shell call and refuses the second operation;
+`LUNATIK_LOCK_OK=1` on the command overrides it once what it lists is known to be stale.
+
 A lunatik command that timed out in your tool did not die: the sudo child keeps holding the
 device, and killing the wrapper does not kill it. Confirm the child is gone before relaunching;
 run long operations one at a time and wait for completion.

--- a/.agents/skills/lunatik-cycle/SKILL.md
+++ b/.agents/skills/lunatik-cycle/SKILL.md
@@ -29,6 +29,11 @@ needs the maintainer's authorization first, and `CRASH_AB_OK=1` on the command r
 `lunatik test` unloads the modules when it finishes: `sudo lunatik reload` before a direct
 `bash tests/<suite>/<test>.sh` afterwards, or it skips with `not loaded`.
 
+An example is run through `sudo bash tools/watchdog.sh examples/<script> [softirq|hardirq] [percpu]`,
+which stops it if the host loses the connectivity it had; `example-guard.sh` refuses a bare
+`lunatik run examples/...`, and `NETWORK_LOSS_OK=1` on the command runs one bare on a machine whose
+connectivity is expendable.
+
 # One operation at a time
 
 Never run two lunatik operations concurrently (`test`, `run`, `reload`, a suite's run.sh): the

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -37,4 +37,7 @@ marker to the command.
 - Fix a submitted review's body: `gh api -X PUT repos/.../pulls/<N>/reviews/<id> -F body=@file`.
 - A submitted review cannot be deleted, only dismissed. Getting the placement wrong means
   editing the body down to the verdict and re-posting each finding inline — rework, not repair.
+- Once the review is posted, label the pull request as read end to end:
+  `gh api -X POST repos/.../issues/<N>/labels -f 'labels[]=workflow-reviewed'`; `tools/pr-status.sh`
+  reads that label as the sign that someone read it.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/lunatik-lock.sh\""
+          },
+          {
+            "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/review-post-guard.sh\""
           },
           {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,10 @@
           },
           {
             "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/example-guard.sh\""
+          },
+          {
+            "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/tools/checks/pr-body-guard.sh\""
           },
           {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -588,6 +588,11 @@ named, not one discovered at that consumer's build.
 * Corrections to a commit on your own branch are `git commit --fixup=<hash>`, not a standalone
   "address review comments" commit. Never fixup a commit that is already on `master`; that becomes a
   new commit on a new branch.
+* A fixup is pushed as soon as it is made. It adds a commit, so it fast-forwards the branch and moves
+  nothing a reviewer already read; what waits for the maintainer is the squash, and a rewrite is said
+  out loud. A fixup that lives only on the machine that wrote it is outside the review, and a cleared
+  worktree or a reboot takes it. The same holds for work handed to a reviewing agent: telling it not to
+  push leaves the push owed by whoever gave the instruction.
 * If a branch adds something in one commit and removes it in another, the second is a fixup of the
   first.
 * After squashing, re read the comments and commit bodies so they describe the final state rather than

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,10 @@ on a `linux.*` constant, not a build error. Regenerate cleanly with
 
 A worktree that has not run `make` cannot install: `scripts_install` needs the autogen output and
 fails, and an install whose output was silenced fails unseen while the previous install stays in
-place, so every run after it tests the wrong tree. Keep the install's output visible, and before
-reading a result confirm that what sits under `/lib/modules/lua/` is the tree under test: its
-timestamp, or a grep for a symbol only the branch has.
+place, so every run after it tests the wrong tree. A silenced `make` does the same one step earlier:
+the chain stops at the build and the suite run next reports on the modules already installed. Keep the
+build's and the install's output visible, and before reading a result confirm that what sits under
+`/lib/modules/lua/` is the tree under test: its timestamp, or a grep for a symbol only the branch has.
 
 `lunatik test` reloads the modules before the suite and unloads them after it. A test script run
 directly afterwards (`bash tests/<suite>/<test>.sh`) skips with `not loaded` until the next
@@ -465,7 +466,10 @@ Tests are shell scripts emitting KTAP plus a kernel side Lua script.
 * coverage means the matrix of operation by type by outcome, including the successes, not a list of
   features and not only the error paths;
 * prove the test discriminates: disable the mechanism it covers, watch it fail, restore. Commit
-  first, since restoring is a `git checkout --` that takes any uncommitted work with it;
+  first, since restoring is a `git checkout --` that takes any uncommitted work with it. The defective
+  side has to compile: a header reverted while its callers still pass the argument it drops stops at
+  `too many arguments`, the suite then runs against the modules already installed, and that green run
+  reads as a test that does not discriminate;
 * a case whose stimulus only exists on a busy machine is forced, not waited for: the probe test picks a
   syscall an idle host never makes, which is why it never hit the creation window that crashed the host,
   and covering that window meant pinning the call to the CPU whose runtime is published last. A test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,9 @@ A worktree named for a task may belong to another session on the same machine. C
 `git worktree list` and the branch a worktree holds before a checkout or a reset there, and never
 reset a branch checked out elsewhere. A review, or a build of a branch not your own, runs in a
 worktree created for it (`git worktree add`, then `git submodule update --init`) and removed at the
-end.
+end. A `git checkout` carries what is uncommitted onto the new HEAD, where an edit made against the
+old base reads as a change to the new one: switch branches in a tree with nothing pending, or read
+the other branch in a worktree of its own.
 
 A tree with a conflict pending (`git status` showing `UU`) is not a test subject: a suite run over a
 half-applied rebase or cherry-pick measures neither side. Resolve and commit, then build.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,10 +128,10 @@ the last one.
 
 `tools/checks/` holds the mechanical checks: comment and LDoc style on framework files
 (`module-conventions.sh`), test scripts that cannot detect a failed load (`test-harness.sh`),
-cppcheck on userspace test C (`cppcheck-tests.sh`), and the trailing blank line rule (`pre-commit`).
-Each takes file paths and skips what does not apply, so any editor, assistant, or CI can run them.
-The `Checks` workflow runs them over a pull request's diff: the trailing blank line rule fails the
-run, the heuristic checks annotate it. Install the commit gate with:
+cppcheck on userspace test C (`cppcheck-tests.sh`), and the trailing blank line rule and the refusal
+of a staged conflict marker (`pre-commit`). Each takes file paths and skips what does not apply, so any
+editor, assistant, or CI can run them. The `Checks` workflow runs them over a pull request's diff:
+`pre-commit` fails the run, the heuristic checks annotate it. Install the commit gate with:
 
     ln -s ../../tools/checks/pre-commit .git/hooks/pre-commit
 
@@ -540,6 +540,10 @@ old factory — kept building and broke at the first packet.
 * Read the commit before pushing it, not only the working tree: `git show` the diff that is about to
   be published. Instrumentation added while debugging — a `pr_err`, a hardcoded branch — is invisible
   in a passing test and lands in the pull request.
+* After resolving a rebase or a merge, `git grep -n '^<<<<<<< '` before committing. `git add -A`
+  stages a conflict marker without complaining, and `git rebase --continue` runs no pre-commit hook,
+  so the markers reach the branch and surface far from the resolution: a `tests/run.sh` carrying one
+  dies at ``syntax error near unexpected token `<<<'``.
 * Change only what the task requires. Do not reformat untouched lines, do not move code, do not
   rename variables in passing. Compare `git diff` against `git diff -w` before committing to catch
   stray whitespace.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -538,6 +538,12 @@ named, not one discovered at that consumer's build.
   what it costs; prevalence says whether it is common, never whether it is right, and a tree can be
   wrong in a hundred places. When the only support for a line is a precedent, say so and judge it
   again.
+* The core and its bindings are not shaped by a consumer or by an example. An example that cannot
+  be written, or that reaches what it needs through a channel no contract states, is evidence of a
+  gap in the API; what fills that gap is decided from what the binding is for, and the commit and
+  the pull request argue it that way. Narrowing `notifier.netdevice` to the initial namespace fixed
+  the `ifquarantine` example, whose callback resolved a reported name there, and took away the
+  script that watches containers.
 
 ## Patches and commits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -502,6 +502,12 @@ compiles against a Lua module and only fails when its code path runs: `skb.attr`
 `.new` and a pure attribute view, and `sniclassify`'s `skbattr(...)` / `skb:data()` — written for the
 old factory — kept building and broke at the first packet.
 
+The kernel a consumer builds on bounds what a change may use, and not every consumer sits inside
+the range this file declares: a product built on Lunatik can ship on an older vendor kernel, and
+`register_netdevice_notifier_net`, which arrived in v5.5, does not exist on the 5.4 one of them runs
+on. An API newer than a known consumer's kernel is a decision taken here, with the floor it sets
+named, not one discovered at that consumer's build.
+
 * Do not land an implementation you already intend to replace. A guarantee that holds only on some
   paths is not a guarantee: make it structural or do not offer it. Merging a half measure and opening
   a follow up that deletes it pollutes the history across pull requests the same way a commit that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,10 +339,12 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
 * An assignment used as a value inside a condition is parenthesised: `<` binds tighter than `=`, so
   `n = f() < 0` stores the comparison and not the count. That one went unnoticed for two years and left
   `runtime:resume` returning nothing while its documentation promised the values.
-* A size, length or count that arrives from Lua is bounded before it reaches an allocator, with
-  `lunatik_checkbounds`. `kvmalloc` warns above `INT_MAX` and returns NULL, so an unbounded argument
-  turns a script's mistake into a kernel `WARNING`, and the multiplication that sizes the object can
-  overflow before the allocator ever sees it.
+* A size, length or count that arrives from Lua is bounded with `lunatik_checkbounds`, for what the
+  binding itself can serve: `roundup_pow_of_two` is undefined at zero, `__kfifo_alloc` truncates to an
+  unsigned int, and the multiplication that sizes an object wraps before any allocator sees it. What
+  the bound does not buy is silence from the kernel: a script reaches the Lua state's allocator with a
+  size no binding named, `("x"):rep(1 << 40)` among them, so it is that allocator that asks for
+  `__GFP_NOWARN`, since Lua turns the NULL into an error the script sees.
 * The minimal representation: a raw pointer where a struct would wrap one field, a fresh allocation
   where a cache would need invalidating, a function where a macro is not clearer. A structure earns
   its place by what it buys, not by looking more complete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,15 @@ reload, a run or a suite, while another operation is on it, naming the processes
 D state among them is the wedged device, which no waiting clears. `LUNATIK_LOCK_OK=1` overrides it once
 what it lists is known to be stale.
 
+`tools/watchdog.sh` runs a script and stops it when the host loses the connectivity it had before the
+run, comparing against the loopback and the default route's gateway and holding nothing against the
+script that was already unreachable; a stop that does not return is a wedged device, which it reports
+and only a reboot clears. `example-guard.sh`, wired before a shell call, refuses `lunatik run` and
+`spawn` of anything under `examples/` that does not go through it, unless the command carries
+`NETWORK_LOSS_OK=1`: an example arms real hooks on the machine that runs it, and one that cuts the
+network off cannot be stopped afterwards, because the command that would stop it has nowhere to be
+typed. The guard keys on loading an example, not on the name of one already known to misbehave.
+
 `consumers.sh` names the out-of-tree scripts that load a binding the changed files touch, reading the
 clones listed in `LUNATIK_CONSUMERS`; `consumers-guard.sh`, wired before a shell call, blocks opening or
 editing a pull request that changes such a binding until the command carries `CONSUMERS_OK=1`, set once

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,11 @@ wrong, over rules that were already written and already broken, adds a paragraph
 or a "Test plan" section; `pr-body-guard.sh`, wired before a shell call like `crash-guard.sh`,
 blocks a `gh` write to pulls that carries a body file the check fails on.
 
+`lunatik-lock.sh`, wired before a shell call, refuses a command that touches the device, an install, a
+reload, a run or a suite, while another operation is on it, naming the processes it found; a process in
+D state among them is the wedged device, which no waiting clears. `LUNATIK_LOCK_OK=1` overrides it once
+what it lists is known to be stale.
+
 `consumers.sh` names the out-of-tree scripts that load a binding the changed files touch, reading the
 clones listed in `LUNATIK_CONSUMERS`; `consumers-guard.sh`, wired before a shell call, blocks opening or
 editing a pull request that changes such a binding until the command carries `CONSUMERS_OK=1`, set once
@@ -170,7 +175,7 @@ test suite, preparing a pull request — as agent skills in the open `SKILL.md` 
 ([agentskills.io](https://agentskills.io)), discovered by any compatible assistant. Each one
 defers to this file as the authority and orders the steps; none replaces reading it.
 
-For Claude Code, `CLAUDE.md` imports this file, `.claude/settings.json` runs `review-post-guard.sh`
+For Claude Code, `CLAUDE.md` imports this file, `.claude/settings.json` runs the command guards
 and the file checks as hooks, and `.claude/skills/` links to `.agents/skills/`; nothing there holds
 logic of its own.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,6 +465,9 @@ Tests are shell scripts emitting KTAP plus a kernel side Lua script.
 * a test does not depend on what else runs on the host: when a host process — a network manager, say
   — can race it by acting on a resource the test created, make the test robust to any such process,
   not wired to silence one by name, which does not carry to another distro or to CI;
+* a case pins a refusal the API makes, never a capability it gave up: a notifier narrowed to the
+  initial namespace came with a case asserting that a device of another namespace is not reported,
+  so a lost capability became the contract and restoring it has to delete a green test;
 * coverage means the matrix of operation by type by outcome, including the successes, not a list of
   features and not only the error paths;
 * prove the test discriminates: disable the mechanism it covers, watch it fail, restore. Commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,13 @@ those scripts were read. A product built on Lunatik is a consumer this tree cann
 what a binding reports was proposed here as a fix until the script that reads that notifier turned up in
 another repository, using exactly what the change removed.
 
+`tools/pr-status.sh` prints the open pull requests as GitHub has them: base and whether it still merges,
+commits and how many are unsquashed fixups, the size, the CI conclusion, and the labels; `--ready` keeps
+the ones a maintainer can pick up. What GitHub cannot see is whether anyone read one, so the review
+workflow labels what it finished with `workflow-reviewed`, and a pull request without that label has
+had no second reader. Which pull requests are open, reviewed or ready is read from it, not from memory:
+a list called ready was assembled from memory here and was wrong on two of three.
+
 `review-post-guard.sh` reads the tool command on stdin instead of a file, for an assistant wired
 to run it before a shell call (`PreToolUse`): it blocks a `gh` write to reviews or comments unless
 the command carries the `REVIEW_POST_OK` marker, set once the exact text has been shown to the

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ sudo make install
 sudo lunatik test           # run all suites
 sudo lunatik test thread    # run a specific suite (bpf, crypto, io, linux,
                             # monitor, netlink, notifier, probe, rcu, runtime,
-                            # set, skb, socket, struct, task, thread, xdp)
+                            # set, skb, socket, struct, task, tc, thread, xdp)
 ```
 
 `lunatik test` reloads the modules before the run and unloads them

--- a/tools/Readme.md
+++ b/tools/Readme.md
@@ -28,6 +28,18 @@ tools/oops.sh > scratch/oops-$(date +%F).txt
 A saved dump, `journalctl -k -b -1 -o cat` after the reboot where the journal is persistent,
 is read the same way: `tools/oops.sh <dump>`.
 
+## pr-status.sh
+
+Reports the open pull requests as GitHub has them: base and mergeability, commits and unsquashed
+fixups, size, CI conclusion and labels. `--ready` keeps the ones reviewed by a workflow, green on
+CI, with no fixup pending and mergeable.
+
+```sh
+GH_TOKEN=... bash tools/pr-status.sh            # every open pull request
+GH_TOKEN=... bash tools/pr-status.sh --ready    # what a maintainer can pick up
+GH_TOKEN=... bash tools/pr-status.sh 814 822    # these ones
+```
+
 ## watchdog.sh
 
 Runs a Lunatik script and stops it if the host loses the connectivity it had before the run,

--- a/tools/Readme.md
+++ b/tools/Readme.md
@@ -27,3 +27,15 @@ tools/oops.sh > scratch/oops-$(date +%F).txt
 
 A saved dump, `journalctl -k -b -1 -o cat` after the reboot where the journal is persistent,
 is read the same way: `tools/oops.sh <dump>`.
+
+## watchdog.sh
+
+Runs a Lunatik script and stops it if the host loses the connectivity it had before the run,
+the loopback or the default route's gateway; a script that cuts the machine off cannot be
+stopped by hand afterwards.
+
+```sh
+sudo bash tools/watchdog.sh examples/ifquarantine/control
+sudo LUNATIK_WATCHDOG_GRACE=10 bash tools/watchdog.sh examples/filter/sni softirq percpu
+```
+

--- a/tools/checks/crash-guard.sh
+++ b/tools/checks/crash-guard.sh
@@ -12,7 +12,7 @@
 input=$(cat)
 
 case "$input" in
-	*"make install"*|*"lunatik reload"*|*"lunatik run"*|*"lunatik spawn"*|*"lunatik test"*|*"bash tests/"*|*"/run.sh"*) ;;
+	*"make install"*|*"lunatik reload"*|*"lunatik run"*|*"lunatik spawn"*|*"lunatik test"*|*"bash tests/"*|*"/run.sh"*|*"watchdog.sh"*) ;;
 	*) exit 0 ;;
 esac
 

--- a/tools/checks/example-guard.sh
+++ b/tools/checks/example-guard.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# PreToolUse (Bash) hook: an example is loaded through tools/watchdog.sh, which
+# stops it when the host loses the connectivity it had. An example arms real
+# hooks on the machine that runs it, and one that cuts the network off cannot be
+# stopped afterwards: the command that would stop it has nowhere to be typed.
+# Blocks (exit 2) a lunatik run or spawn of anything under examples/ that does
+# not go through the watchdog. Reads the tool command on stdin. Pass
+# NETWORK_LOSS_OK=1 to run one bare, on a machine whose connectivity is expendable.
+
+input=$(cat)
+
+case "$input" in
+	*"lunatik run examples/"*|*"lunatik spawn examples/"*) ;;
+	*) exit 0 ;;
+esac
+case "$input" in
+	*NETWORK_LOSS_OK=1*|*watchdog.sh*) exit 0 ;;
+esac
+
+{
+	echo "example-guard: load an example through the watchdog, which stops it if the host loses the connectivity it had:"
+	echo "  sudo bash tools/watchdog.sh <script> [softirq|hardirq] [percpu]"
+	echo "example-guard: an example that takes the network down cannot be stopped by hand afterwards. Re-run with NETWORK_LOSS_OK=1 as a command prefix only on a machine whose connectivity is expendable."
+} >&2
+exit 2
+

--- a/tools/checks/lunatik-lock.sh
+++ b/tools/checks/lunatik-lock.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# PreToolUse (Bash) hook: one lunatik operation at a time. Concurrent ones wedge
+# /dev/lunatik and leave processes in D state, which only a reboot clears, so a
+# command that touches the device is refused (exit 2) while another is running:
+# a CLI process, which the shebang shows as lua5.4 .../sbin/lunatik and, once its
+# command line is gone, as [lunatik]; or a test script, installed or in the tree.
+# Reads the tool command on stdin. Pass LUNATIK_LOCK_OK=1 to override, once the
+# processes it names are known to be stale.
+
+input=$(cat)
+
+case "$input" in
+	*"lunatik test"*|*"lunatik reload"*|*"lunatik load"*|*"lunatik unload"*|\
+	*"lunatik run"*|*"lunatik spawn"*|*"lunatik stop"*|*"make install"*|\
+	*"bash tests/"*|*"/run.sh"*|*"watchdog.sh"*) ;;
+	*) exit 0 ;;
+esac
+case "$input" in
+	*LUNATIK_LOCK_OK=1*) exit 0 ;;
+esac
+
+busy=$(ps -eo pid,stat,args | awk '
+	$3 == "[lunatik]" || ($3 ~ /lua/ && $4 ~ /bin\/lunatik$/) ||
+	($3 ~ /(^|\/)(ba)?sh$/ && $4 ~ /tests\/([a-z]+\/)*[a-z_]+\.sh$/) { print "  " $0 }')
+[ -n "$busy" ] || exit 0
+
+{
+	echo "lunatik-lock: the device is busy; a second operation wedges it:"
+	echo "$busy"
+	echo "lunatik-lock: wait for it; one in D state never returns, and only a reboot clears it. Re-run with LUNATIK_LOCK_OK=1 as a command prefix only when what is listed is known to be stale."
+} >&2
+exit 2
+

--- a/tools/pr-status.sh
+++ b/tools/pr-status.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Reports the state of the open pull requests, so a claim about them is read
+# rather than remembered: base, mergeability, commit count and how many of those
+# are unsquashed fixups, the size, the CI conclusion, and the labels the review
+# workflows leave behind.
+#
+# With --ready, lists only what a maintainer can pick up: reviewed by a workflow,
+# green on CI, no unsquashed fixup, and mergeable as GitHub has computed it.
+#
+# Usage: GH_TOKEN=... bash tools/pr-status.sh [--ready] [<number>...]
+
+repo=${LUNATIK_REPO:-luainkernel/lunatik}
+fmt='%-6s %-26s %-24s %-5s %-7s %-11s %-9s %s\n'
+
+ready=0
+[ "$1" = "--ready" ] && { ready=1; shift; }
+numbers="$*"
+[ -n "$numbers" ] || numbers=$(gh api "repos/$repo/pulls" --paginate -q '.[].number' | sort -n)
+
+printf "$fmt" PR BRANCH BASE COMM FIXUPS SIZE CI LABELS
+for n in $numbers; do
+	pr=$(gh api "repos/$repo/pulls/$n" \
+		-q '[.head.ref, .base.ref, (.commits|tostring), (.mergeable|tostring), "+\(.additions)/-\(.deletions)", .head.sha, ([.labels[].name] | join(",") // "")] | @tsv') || continue
+	IFS=$'\t' read -r branch base commits mergeable size sha labels <<< "$pr"
+	fixups=$(gh api "repos/$repo/pulls/$n/commits" \
+		-q '[.[] | select(.commit.message | startswith("fixup!"))] | length')
+	ci=$(gh api "repos/$repo/commits/$sha/check-runs" \
+		-q '[.check_runs[].conclusion] | if length == 0 then "none" else (unique | join(",")) end' 2>/dev/null)
+
+	if [ "$ready" = 1 ]; then
+		[ "$mergeable" = "true" ] && [ "$fixups" = 0 ] && [ "$ci" = "success" ] || continue
+		case "$labels" in *workflow-reviewed*) ;; *) continue ;; esac
+	fi
+	case "$mergeable" in true) ;; null) base="$base(?)" ;; *) base="$base(!)" ;; esac
+	printf "$fmt" "#$n" "$branch" "$base" "$commits" "$fixups" "$size" "$ci" "${labels:--}"
+done
+

--- a/tools/watchdog.sh
+++ b/tools/watchdog.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Runs a Lunatik script and stops it if the host loses the connectivity it had
+# before the run: a script that cuts the machine off cannot be stopped by hand
+# afterwards, since the terminal that would type the command is gone.
+#
+# It compares against what worked before the run and nothing else: the loopback,
+# and the gateway of the default route when there is one. A check that already
+# failed is not held against the script.
+#
+# Usage: sudo bash tools/watchdog.sh <script> [softirq|hardirq] [percpu]
+#        LUNATIK_WATCHDOG_GRACE=<seconds> before the check, default 3
+
+GRACE=${LUNATIK_WATCHDOG_GRACE:-3}
+SCRIPT=$1
+
+[ -n "$SCRIPT" ] || { echo "usage: $0 <script> [softirq|hardirq] [percpu]" >&2; exit 2; }
+shift
+
+reachable() { ping -c 1 -W 1 "$1" > /dev/null 2>&1; }
+
+gateway=$(ip route show default 2>/dev/null | awk '/^default/ {print $3; exit}')
+
+targets=""
+for t in 127.0.0.1 $gateway; do
+	reachable "$t" && targets="$targets $t"
+done
+[ -n "$targets" ] || echo "# watchdog: nothing was reachable before the run, nothing to compare against"
+
+lunatik run "$SCRIPT" "$@" || exit $?
+sleep "$GRACE"
+
+lost=""
+for t in $targets; do
+	reachable "$t" || lost="$lost $t"
+done
+[ -n "$lost" ] || exit 0
+
+echo "watchdog: $SCRIPT took the host off the network, unreachable now:$lost; stopping it" >&2
+if timeout 30 lunatik stop "$SCRIPT"; then
+	for t in $lost; do
+		reachable "$t" || echo "watchdog: $t is still unreachable after the stop" >&2
+	done
+else
+	echo "watchdog: the stop did not return; the device is wedged and only a reboot clears it" >&2
+fi
+exit 1
+


### PR DESCRIPTION
Seven pull requests, six on the harness and one README line, are open against the same sections of AGENTS.md and the same hook list, so reading them means seven overlapping diffs where one would do.

This branch carries them as one history regrouped by change: the device lock, the network watchdog with its example guard, the pull request status report, the rules from the notifier, bounds and finishing rounds, and the tc suite in the README list. On the way the lock's process match is fixed to what ps shows (the CLI as lua5.4 .../sbin/lunatik, a wedged one as [lunatik], a test script by its command word, so a shell that merely mentions a test path is not "busy"), the lock and crash guards take a run through the watchdog as a run, the review-pr skill applies the workflow-reviewed label that pr-status.sh --ready reads, and the paragraph #814 pushed into the file's first principle is folded into the tool's own, since that principle already ends with "say so instead of asserting".

Supersedes #814, #816, #817, #819, #822, #827 and #828, which close once this is open. Depends on nothing.
