### PR TITLE
notifier: return NOTIFY_DONE when the runtime does not take the event

### DIFF
--- a/lib/luanotifier.c
+++ b/lib/luanotifier.c
@@ -8,6 +8,8 @@
 * This library allows Lua scripts to register callback functions that are
 * invoked when specific kernel events occur, such as keyboard input,
 * network device status changes, or virtual terminal events.
+* A callback returns a `linux.notify` code; anything else, and an event that
+* reaches a runtime not ready to take it, counts as `notify.DONE`.
 *
 * @module notifier
 */
@@ -74,7 +76,7 @@ static int luanotifier_call(struct notifier_block *nb, unsigned long event, void
 	else
 		lunatik_run(notifier->runtime, luanotifier_handler, ret, notifier, event, data);
 
-	return ret;
+	return max(ret, NOTIFY_DONE); /* negative errno sets NOTIFY_STOP_MASK */
 }
 
 static void luanotifier_release(void *private)

--- a/tests/README.md
+++ b/tests/README.md
@@ -165,6 +165,12 @@ higher-level `netlink.*` modules built on top of it.
   the synchronous `NETDEV_REGISTER` replay `register_netdevice_notifier`
   performs for existing devices.
 
+- **chain_continues**: a netdevice block whose runtime is being torn down
+  returns `notify.DONE`, not the `-ENXIO` of `lunatik_run`, whose
+  `NOTIFY_STOP_MASK` bit stopped the chain: a device created while one
+  runtime holds its teardown reaches the block a second runtime registered
+  after it.
+
 ### probe
 
 - **kprobe_concurrent**: registers kprobes on every syscall and runs

--- a/tests/notifier/chain_continues.sh
+++ b/tests/notifier/chain_continues.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# A block whose runtime cannot take an event returned lunatik_run's -ENXIO as
+# its verdict, and a negative errno has NOTIFY_STOP_MASK set, so the chain
+# stopped at Lunatik's block and every notifier registered after it missed the
+# event. The path exercised is the teardown: lunatik_closeprivate clears the
+# runtime's private before lua_close runs the finalizers, and the block is
+# unregistered by the notifier's own finalizer, so while an earlier finalizer
+# holds lua_close the block is registered and the runtime is not ready. The
+# body of a script past notifier.netdevice() is the other window, but reaching
+# it takes a second lunatik operation while the first is in progress, which is
+# not allowed.
+#
+# Two runtimes register in order: chain_continues_held first, whose sentinel
+# finalizer sleeps at teardown, and chain_continues_after, which prints every
+# REGISTER it is given. The first is stopped in the background and a dummy
+# device is created inside its hold; the second must report it. The test checks
+# that the stop was still running when the device was created, so a pass is
+# never the hold having ended before the event.
+#
+# Usage: sudo bash tests/notifier/chain_continues.sh
+
+HELD="tests/notifier/chain_continues_held"
+AFTER="tests/notifier/chain_continues_after"
+DEV="chaincont0"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	wait 2> /dev/null
+	lunatik stop "$AFTER" > /dev/null 2>&1
+	lunatik stop "$HELD" > /dev/null 2>&1
+	ip link del "$DEV" 2> /dev/null
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 3
+
+command -v ip > /dev/null 2>&1 || {
+	echo "# SKIP: ip not available"
+	ktap_skip "the device is created while the first runtime holds its teardown"
+	ktap_skip "the runtime registered after sees the device"
+	ktap_skip "no Lua errors in kernel"
+	ktap_totals
+	exit 0
+}
+
+run_script "$HELD"
+run_script "$AFTER"
+
+mark_dmesg
+lunatik stop "$HELD" > /dev/null 2>&1 &
+STOP=$!
+sleep 1
+ip link add "$DEV" type dummy 2> /dev/null
+added=$?
+kill -0 "$STOP" 2> /dev/null
+held=$?
+wait "$STOP"
+
+[ "$added" = 0 ] || fail "cannot create $DEV"
+[ "$held" = 0 ] || fail "the hold ended before $DEV was created"
+ktap_pass "the device is created while the first runtime holds its teardown"
+
+dmesg_since | grep -qF "chain continues: register $DEV" || fail "the runtime registered after missed $DEV"
+ktap_pass "the runtime registered after sees the device"
+
+check_dmesg && ktap_pass "no Lua errors in kernel"
+
+ktap_totals
+

--- a/tests/notifier/chain_continues_after.lua
+++ b/tests/notifier/chain_continues_after.lua
@@ -1,0 +1,20 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Prints every device the netdevice chain reports as registered, from a block
+-- registered after chain_continues_held's. See tests/notifier/chain_continues.sh.
+
+local notifier = require("notifier")
+local netdev   = require("linux.netdev")
+local notify   = require("linux.notify")
+
+local function callback(event, name)
+	if event == netdev.REGISTER then
+		print("chain continues: register " .. name)
+	end
+	return notify.OK
+end
+
+notifier.netdevice(callback)
+

--- a/tests/notifier/chain_continues_held.lua
+++ b/tests/notifier/chain_continues_held.lua
@@ -1,0 +1,25 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Registers a netdevice notifier and holds its own teardown from a finalizer,
+-- so the block is still registered while the runtime cannot take an event.
+-- See tests/notifier/chain_continues.sh.
+
+local linux    = require("linux")
+local notifier = require("notifier")
+local notify   = require("linux.notify")
+
+local HOLD <const> = 5000
+
+local function callback()
+	return notify.OK
+end
+
+local function hold()
+	linux.schedule(HOLD)
+end
+
+notifier.netdevice(callback)
+sentinel = setmetatable({}, {__gc = hold})
+

--- a/tests/notifier/run.sh
+++ b/tests/notifier/run.sh
@@ -11,7 +11,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
 SEP=$'\n'
-for t in "$DIR"/context_mismatch.sh "$DIR"/init_dispatch.sh; do
+for t in "$DIR"/context_mismatch.sh "$DIR"/init_dispatch.sh "$DIR"/chain_continues.sh; do
 	echo "${SEP}# --- $(basename "$t") ---"
 	bash "$t" || FAILED=$((FAILED+1))
 done


### PR DESCRIPTION
A netdevice event reaching a Lunatik block whose runtime is not ready, during the script body past `notifier.netdevice()` or during teardown, was answered with `lunatik_run`'s `-ENXIO` as the verdict. Every negative errno has bit 15 set, which is `NOTIFY_STOP_MASK`, so `notifier_call_chain` stopped there and every notifier registered after Lunatik's block missed the event, while `notifier_to_errno` reported no error and the caller went on as if all had seen it.

`luanotifier_call` now returns `notify.DONE` for anything negative, and the module doc says so. Test: `chain_continues`, on the teardown window, which a finalizer that sleeps holds open: a second runtime registered after the first must see a device created while the first is being stopped, and the test checks the stop was still running when the device was created, so it cannot pass with the window already closed.

Independent of #797, which registers the block on the per-netns chain and would widen the stopped chain from the blocks after Lunatik's to every global notifier. Not run on a device this round: the tree builds clean and the test has not been executed.
