### PR TITLE
docs: two rules from the review round on #795

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -757,7 +757,9 @@ is how a mutex in softirq and a crash reachable from Lua were passed.
   hard half of the finding in hand. A dismissal is held to a finding's own standard: runs that came
   back clean do not dispose of a symptom that appeared once, because an absence measures the runs and
   not the code. Either the mechanism is traced to why it cannot happen, or it is still a finding and
-  leaves as one.
+  leaves as one. Handing a call back to the maintainer is a deferral like any other and takes the same
+  issue: a design costed in a review thread, with its trade written out and no number on it, is lost
+  the day the pull request is merged, and the next reader pays for the analysis again.
 * Cover the whole change, and flag across all of it — the author's code and your own fixups alike.
   "It is the author's code" or "my line, not the feature" is never a reason to pass over a defect;
   what is scoped is the fixup, which touches only what a finding requires, not the finding. A review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -607,6 +607,10 @@ named, not one discovered at that consumer's build.
 * A force-push that restructures a branch is not done until the pull request title and body are
   re-read against it. They describe the branch; a rewrite that drops or replaces a mechanism turns
   them into fiction the reviewer reads first.
+* A report of a push names the ref it moved and, separately, what it was rebased onto. "Force-pushed
+  onto current master" reads as the one thing nobody may do, and a reader who has to parse a sentence
+  to find out whether `master` was rewritten has already been alarmed for nothing. Say which branch
+  took the push; the base is a different clause.
 * Do not commit directly to `master`.
 * Copyright years: a new file carries the current year; a modified file extends its range to include
   it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -743,12 +743,17 @@ is how a mutex in softirq and a crash reachable from Lua were passed.
 * A defect found on the way is fixed, not reported and left: a pre-existing one, in code the change
   does not touch, becomes a commit of its own, or a pull request of its own when it stands apart, and
   the hand-back says which. Asking whether to fix it is asking the maintainer to decide what the
-  rules already decide.
+  rules already decide. "It is not this pull request's" names where the fix goes, never whether it is
+  owed: the finding leaves with a branch or an issue and the report carries its number, since a defect
+  handed back as prose is a defect nobody owns.
 * A finding is resolved, not parked. When something looks wrong, run it to ground — reproduce it, find
   the cause, then fix it or dismiss it. "I'll flag it to the author", "let's look into it separately",
   or asking whether to investigate is dropping it, not handling it. Deferral is for work that belongs
   in another pull request, captured as an issue linked from the comment that defers it — not for the
-  hard half of the finding in hand.
+  hard half of the finding in hand. A dismissal is held to a finding's own standard: runs that came
+  back clean do not dispose of a symptom that appeared once, because an absence measures the runs and
+  not the code. Either the mechanism is traced to why it cannot happen, or it is still a finding and
+  leaves as one.
 * Cover the whole change, and flag across all of it — the author's code and your own fixups alike.
   "It is the author's code" or "my line, not the feature" is never a reason to pass over a defect;
   what is scoped is the fixup, which touches only what a finding requires, not the finding. A review


### PR DESCRIPTION
Three rules out of one review round. Reviewing #795, an agent saw `examples/systrack`'s handler index a nil upvalue, ran it six times without seeing it again, and handed it back as prose: pre-existing, master's code, a separate commit. It named the right disposition and did not take it, and nothing left the review with it. Five loads out of five reproduced the symptom afterwards, and the fix is #832.

The same report described its work as "force-pushed onto current master", which is not what happened and cost a check of master's history to settle; and it costed a generalization of the shared registration, wrote the trade out in a review thread, and left the decision there with no number on it, which is now #834.

So: a dismissal carries a finding's own burden, because runs that came back clean measure the runs and not the code; "it is not this pull request's" names where a fix goes without saying whether it is owed; a call handed back to the maintainer is a deferral and takes the same issue; and a report of a push names the ref it moved, with the base in a different clause. The first three sharpen rules already in the file rather than adding paragraphs over rules already written.
