### PR TITLE
lunatik: one shared registration for the runtimes of a percpu set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,11 +294,12 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
   index is `ix`, a callback `cb`. Importing `arg` or `callback_ref` where the base settled on a
   shorter word is a deviation.
 * A helper's name is the verb the tree already uses for that step: `match`, `find`, `register`,
-  `free`, `share`, `own`, `attach`, `detach`. The noun joins the verb only when that verb has more
-  than one kind to act on in the file, as `luarcu_newentry` does beside `luarcu_newtable` and
-  `lunatik_finddata` beside the runtimes the same object holds; it does not when it only repeats
-  what the type already says, which is what `luanetfilter_findhook` did in a file whose only list
-  holds hooks.
+  `free`, `share`, `own`, `attach`, `detach`. The noun joins the verb when that verb has more than
+  one kind to act on — `luarcu_newentry` beside `luarcu_newtable`, `luacrypto_aead_newrequest`
+  beside `luacrypto_aead_new` — or when the mirror it pairs with carries one, as
+  `luadarken_freerequest` does beside `luadarken_setrequest`; it does not when it only repeats what
+  the type already says, which is what `luanetfilter_findhook` did in a file whose only list holds
+  hooks.
 * Kernel headers first, then a blank line, then `#include <lunatik.h>`. Do not remove that blank line.
 * `<lua.h>` and `<lauxlib.h>` are already pulled in by `lunatik.h`.
 * Every file ends with a trailing blank line. `tools/checks/pre-commit` rejects a commit that does

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,13 +293,13 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
 * A name matches what the tree already calls the same thing; grep for it before choosing. A Lua stack
   index is `ix`, a callback `cb`. Importing `arg` or `callback_ref` where the base settled on a
   shorter word is a deviation.
-* A helper's name is the verb the tree already uses for that step: `match`, `find`, `register`,
-  `free`, `share`, `own`, `attach`, `detach`. The noun joins the verb when that verb has more than
-  one kind to act on — `luarcu_newentry` beside `luarcu_newtable`, `luacrypto_aead_newrequest`
-  beside `luacrypto_aead_new` — or when the mirror it pairs with carries one, as
-  `luadarken_freerequest` does beside `luadarken_setrequest`; it does not when it only repeats what
-  the type already says, which is what `luanetfilter_findhook` did in a file whose only list holds
-  hooks.
+* A helper's name is the verb the tree already uses for that step, `match`, `find`, `register`,
+  `free`, `share`, `own`, `attach` and `detach` being the ones in place. The noun joins the verb
+  when that verb has more than one kind to act on — `luarcu_newentry` beside `luarcu_newtable`,
+  `luacrypto_aead_newrequest` beside `luacrypto_aead_new` — or when the mirror it pairs with
+  carries one, as `luadarken_freerequest` does beside `luadarken_setrequest`; it does not when it
+  only repeats what the type already says, which is what `luanetfilter_findhook` did in a file
+  whose only list holds hooks.
 * Kernel headers first, then a blank line, then `#include <lunatik.h>`. Do not remove that blank line.
 * `<lua.h>` and `<lauxlib.h>` are already pulled in by `lunatik.h`.
 * Every file ends with a trailing blank line. `tools/checks/pre-commit` rejects a commit that does

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,10 +294,11 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
   index is `ix`, a callback `cb`. Importing `arg` or `callback_ref` where the base settled on a
   shorter word is a deviation.
 * A helper's name is the verb the tree already uses for that step: `match`, `find`, `register`,
-  `free`, `share`, `own`, `attach`, `detach`. The noun joins the verb only when the file has two
-  kinds to tell apart, as `luarcu_newentry` does beside `luarcu_table` and `lunatik_finddata`
-  beside the runtime; it does not when it only repeats what the type already says, which is what
-  `luanetfilter_findhook` did in a file whose only list holds hooks.
+  `free`, `share`, `own`, `attach`, `detach`. The noun joins the verb only when that verb has more
+  than one kind to act on in the file, as `luarcu_newentry` does beside `luarcu_newtable` and
+  `lunatik_finddata` beside the runtimes the same object holds; it does not when it only repeats
+  what the type already says, which is what `luanetfilter_findhook` did in a file whose only list
+  holds hooks.
 * Kernel headers first, then a blank line, then `#include <lunatik.h>`. Do not remove that blank line.
 * `<lua.h>` and `<lauxlib.h>` are already pulled in by `lunatik.h`.
 * Every file ends with a trailing blank line. `tools/checks/pre-commit` rejects a commit that does

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,11 @@ afterwards) is used by `lib/luanetfilter.c` for its `skb`. Follow it rather than
 * A name matches what the tree already calls the same thing; grep for it before choosing. A Lua stack
   index is `ix`, a callback `cb`. Importing `arg` or `callback_ref` where the base settled on a
   shorter word is a deviation.
+* A helper's name is the verb the tree already uses for that step: `match`, `find`, `register`,
+  `free`, `share`, `own`, `attach`, `detach`. The noun joins the verb only when the file has two
+  kinds to tell apart, as `luarcu_newentry` does beside `luarcu_table` and `lunatik_finddata`
+  beside the runtime; it does not when it only repeats what the type already says, which is what
+  `luanetfilter_findhook` did in a file whose only list holds hooks.
 * Kernel headers first, then a blank line, then `#include <lunatik.h>`. Do not remove that blank line.
 * `<lua.h>` and `<lauxlib.h>` are already pulled in by `lunatik.h`.
 * Every file ends with a trailing blank line. `tools/checks/pre-commit` rejects a commit that does

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [
 * `status`: show which Lunatik kernel modules are currently loaded
 * `test [suite]`: run installed test suites (see [Testing](#testing))
 * `list`: show which runtime environments are currently running
-* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime per CPU id, dispatched to the runtime of the CPU the callback runs on. The script runs once per runtime and can read its id with `lunatik.cpu()`; the runtimes share a netfilter hook, and constructors whose registration is global fail at load in a percpu runtime
+* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime per CPU id, dispatched to the runtime of the CPU the callback runs on. The script runs once per runtime and can read its id with `lunatik.cpu()`; the runtimes share a netfilter hook and a kprobe, and constructors whose registration is global fail at load in a percpu runtime
 * `spawn`: create a new runtime environment and spawn a thread to run the script `/lib/modules/lua/<script>.lua`
 * `stop`: stop the runtime environment created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_

--- a/doc/capi.md
+++ b/doc/capi.md
@@ -223,9 +223,9 @@ or `NULL`.
 ```
 Defines `static const lunatik_class_t prefix_class`, named `cname`, for the data a `percpu` object
 holds for the registrations its runtimes share, as [`lunatik_percpudata`](#lunatik_percpudata)
-creates it: a private that is a `struct hlist_head` of `T` entries linked through their
-`struct hlist_node node`, whose `release`, `prefix_release`, unlinks every entry and passes it to
-`free`. For example,
+creates it: a private that is a `struct hlist_head` of `T` entries, each beginning with the
+[`lunatik_shared_t`](#lunatik_share) that links them, whose `release`, `prefix_release`, unlinks
+every entry and passes it to `free`. For example,
 `LUNATIK_PERCPUDATA(luaprobe_kprobes, "probe.kprobes", luaprobe_kprobe_t, luaprobe_free)`
 defines `luaprobe_kprobes_class`.
 

--- a/doc/capi.md
+++ b/doc/capi.md
@@ -229,6 +229,39 @@ creates it: a private that is a `struct hlist_head` of `T` entries linked throug
 `LUNATIK_PERCPUDATA(luaprobe_kprobes, "probe.kprobes", luaprobe_kprobe_t, luaprobe_free)`
 defines `luaprobe_kprobes_class`.
 
+### lunatik\_share
+```C
+typedef struct lunatik_shared_s {
+	struct hlist_node node;
+	lunatik_object_t *runtime;
+} lunatik_shared_t;
+
+lunatik_shared_t *lunatik_share(lua_State *L, lunatik_object_t *percpu, const lunatik_sharing_t *sharing,
+	const lunatik_shared_t *spec);
+lunatik_shared_t *lunatik_own(lua_State *L, lunatik_object_t *runtime, const lunatik_sharing_t *sharing,
+	const lunatik_shared_t *spec);
+```
+One registration the runtimes of a `percpu` set share: the first call installs it, the others find
+it and attach to it, and a callback dispatched through `shared.runtime` reaches the runtime of the
+CPU it fired on. A registration begins with a `lunatik_shared_t`, and `sharing` says how to handle
+it:
+
+```C
+typedef struct lunatik_sharing_s {
+	const lunatik_class_t *class;	/* percpu data holding the list of registrations */
+	size_t size;			/* of the registration, which begins with lunatik_shared_t */
+	lunatik_match_t match;		/* bool (*)(const lunatik_shared_t *, const lunatik_shared_t *) */
+	lunatik_arm_t arm;		/* void (*)(lua_State *, lunatik_shared_t *) */
+	const char *registered;		/* raised when this runtime already registered the same target */
+} lunatik_sharing_t;
+```
+
+`lunatik_share` copies `size` bytes of `spec`, sets the runtime and calls `arm`, which registers
+with the kernel and, if it cannot, frees the registration before raising. `lunatik_own` does the
+same for a plain runtime, which holds a reference of its own; a `percpu` object is held by its
+data instead. `class` is what [`LUNATIK_PERCPUDATA`](#lunatik_percpudata) defines, and its
+`release` frees the list.
+
 ---
 
 ## Object Lifecycle

--- a/doc/capi.md
+++ b/doc/capi.md
@@ -217,6 +217,18 @@ afterwards. Returns `NULL` on a plain runtime, which has no runtimes to share wi
 `lunatik_getpercpu(L)` tells the two apart, returning the `percpu` object owning the runtime `L`,
 or `NULL`.
 
+### LUNATIK\_PERCPUDATA
+```C
+#define LUNATIK_PERCPUDATA(prefix, cname, T, free)
+```
+Defines `static const lunatik_class_t prefix_class`, named `cname`, for the data a `percpu` object
+holds for the registrations its runtimes share, as [`lunatik_percpudata`](#lunatik_percpudata)
+creates it: a private that is a `struct hlist_head` of `T` entries linked through their
+`struct hlist_node node`, whose `release`, `prefix_release`, unlinks every entry and passes it to
+`free`. For example,
+`LUNATIK_PERCPUDATA(luaprobe_kprobes, "probe.kprobes", luaprobe_kprobe_t, luaprobe_free)`
+defines `luaprobe_kprobes_class`.
+
 ---
 
 ## Object Lifecycle

--- a/doc/capi.md
+++ b/doc/capi.md
@@ -238,8 +238,6 @@ typedef struct lunatik_shared_s {
 
 lunatik_shared_t *lunatik_share(lua_State *L, lunatik_object_t *percpu, const lunatik_sharing_t *sharing,
 	const lunatik_shared_t *spec);
-lunatik_shared_t *lunatik_own(lua_State *L, lunatik_object_t *runtime, const lunatik_sharing_t *sharing,
-	const lunatik_shared_t *spec);
 ```
 One registration the runtimes of a `percpu` set share: the first call installs it, the others find
 it and attach to it, and a callback dispatched through `shared.runtime` reaches the runtime of the
@@ -257,10 +255,19 @@ typedef struct lunatik_sharing_s {
 ```
 
 `lunatik_share` copies `size` bytes of `spec`, sets the runtime and calls `arm`, which registers
-with the kernel and, if it cannot, frees the registration before raising. `lunatik_own` does the
-same for a plain runtime, which holds a reference of its own; a `percpu` object is held by its
-data instead. `class` is what [`LUNATIK_PERCPUDATA`](#lunatik_percpudata) defines, and its
-`release` frees the list.
+with the kernel and, if it cannot, frees the registration before raising. `class` is what
+[`LUNATIK_PERCPUDATA`](#lunatik_percpudata) defines, and its `release` frees the list, which is how
+a shared registration is freed; the `percpu` object is held by that data.
+
+### lunatik\_own
+```C
+lunatik_shared_t *lunatik_own(lua_State *L, lunatik_object_t *runtime, const lunatik_sharing_t *sharing,
+	const lunatik_shared_t *spec);
+```
+The same registration for a plain runtime, which has none to share with, so only `size` and `arm`
+are read of `sharing` and nothing is linked into a list: the runtime is held here rather than by a
+`percpu` object's data, and the caller keeps the pointer, freeing it and releasing the runtime when
+its own object is released.
 
 ---
 

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -110,7 +110,7 @@ static unsigned int luanetfilter_hook(void *priv, struct sk_buff *skb, const str
 	return luanetfilter_docall((luanetfilter_hook_t *)priv, skb);
 }
 
-static luanetfilter_hook_t *luanetfilter_findhook(struct hlist_head *hooks, const luanetfilter_hook_t *spec)
+static luanetfilter_hook_t *luanetfilter_find(struct hlist_head *hooks, const luanetfilter_hook_t *spec)
 {
 	luanetfilter_hook_t *hook;
 
@@ -122,7 +122,7 @@ static luanetfilter_hook_t *luanetfilter_findhook(struct hlist_head *hooks, cons
 	return NULL;
 }
 
-static luanetfilter_hook_t *luanetfilter_newhook(lua_State *L, lunatik_object_t *runtime, const luanetfilter_hook_t *spec)
+static luanetfilter_hook_t *luanetfilter_register(lua_State *L, lunatik_object_t *runtime, const luanetfilter_hook_t *spec)
 {
 	luanetfilter_hook_t *hook = lunatik_checkalloc(L, sizeof(luanetfilter_hook_t));
 	int ret;
@@ -138,13 +138,13 @@ static luanetfilter_hook_t *luanetfilter_newhook(lua_State *L, lunatik_object_t 
 	return hook;
 }
 
-static void luanetfilter_freehook(luanetfilter_hook_t *hook)
+static void luanetfilter_free(luanetfilter_hook_t *hook)
 {
 	nf_unregister_net_hook(&init_net, &hook->nfops);
 	lunatik_free(hook);
 }
 
-LUNATIK_PERCPUDATA(luanetfilter_hooks, "netfilter.hooks", luanetfilter_hook_t, luanetfilter_freehook);
+LUNATIK_PERCPUDATA(luanetfilter_hooks, "netfilter.hooks", luanetfilter_hook_t, luanetfilter_free);
 
 static void luanetfilter_checkspec(lua_State *L, int ix, luanetfilter_hook_t *spec)
 {
@@ -158,13 +158,13 @@ static void luanetfilter_checkspec(lua_State *L, int ix, luanetfilter_hook_t *sp
 	lunatik_optinteger(L, ix, spec, mark, 0);
 }
 
-static luanetfilter_hook_t *luanetfilter_sharehook(lua_State *L, lunatik_object_t *percpu, const luanetfilter_hook_t *spec)
+static luanetfilter_hook_t *luanetfilter_share(lua_State *L, lunatik_object_t *percpu, const luanetfilter_hook_t *spec)
 {
 	struct hlist_head *hooks = lunatik_percpudata(L, &luanetfilter_hooks_class, sizeof(struct hlist_head))->private;
-	luanetfilter_hook_t *hook = luanetfilter_findhook(hooks, spec);
+	luanetfilter_hook_t *hook = luanetfilter_find(hooks, spec);
 
 	if (hook == NULL) {
-		hook = luanetfilter_newhook(L, percpu, spec);
+		hook = luanetfilter_register(L, percpu, spec);
 		hlist_add_head(&hook->node, hooks);
 	}
 	else if (lunatik_getregistry(L, hook) != LUA_TNIL)
@@ -174,9 +174,9 @@ static luanetfilter_hook_t *luanetfilter_sharehook(lua_State *L, lunatik_object_
 	return hook;
 }
 
-static luanetfilter_hook_t *luanetfilter_ownhook(lua_State *L, luanetfilter_t *nf, const luanetfilter_hook_t *spec)
+static luanetfilter_hook_t *luanetfilter_own(lua_State *L, luanetfilter_t *nf, const luanetfilter_hook_t *spec)
 {
-	nf->hook = luanetfilter_newhook(L, nf->runtime, spec);
+	nf->hook = luanetfilter_register(L, nf->runtime, spec);
 	lunatik_getobject(nf->runtime); /* a percpu object is held by its data; a plain runtime is held here */
 	return nf->hook;
 }
@@ -206,7 +206,7 @@ static const lunatik_class_t luanetfilter_class = {
 * @raise if the hook cannot be registered; in a percpu script, if this runtime already
 *   registered the same `pf`, `hooknum`, `priority` and `mark`, or if called after module load
 */
-static int luanetfilter_register(lua_State *L)
+static int luanetfilter_lregister(lua_State *L)
 {
 	luanetfilter_hook_t spec = {.nfops = {.hook = luanetfilter_hook}};
 	luanetfilter_checkspec(L, 1, &spec);
@@ -217,7 +217,7 @@ static int luanetfilter_register(lua_State *L)
 	luanetfilter_t *nf = (luanetfilter_t *)object->private;
 	nf->runtime = runtime;
 
-	luanetfilter_hook_t *hook = percpu != NULL ? luanetfilter_sharehook(L, percpu, &spec) : luanetfilter_ownhook(L, nf, &spec);
+	luanetfilter_hook_t *hook = percpu != NULL ? luanetfilter_share(L, percpu, &spec) : luanetfilter_own(L, nf, &spec);
 	luaskb_attach(L, nf, skb);
 	lunatik_registerobject(L, 1, object);
 	lunatik_register(L, -1, hook); /* the callback finds this runtime's registration by the hook they share */
@@ -225,7 +225,7 @@ static int luanetfilter_register(lua_State *L)
 }
 
 static const luaL_Reg luanetfilter_lib[] = {
-	{"register", luanetfilter_register},
+	{"register", luanetfilter_lregister},
 	{NULL, NULL},
 };
 
@@ -234,7 +234,7 @@ static void luanetfilter_release(void *private)
 	luanetfilter_t *nf = (luanetfilter_t *)private;
 
 	if (nf->hook != NULL) {
-		luanetfilter_freehook(nf->hook);
+		luanetfilter_free(nf->hook);
 		lunatik_putobject(nf->runtime);
 	}
 	lunatik_detach(nf->runtime, nf, skb);

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -144,21 +144,7 @@ static void luanetfilter_freehook(luanetfilter_hook_t *hook)
 	lunatik_free(hook);
 }
 
-static void luanetfilter_stophooks(void *private)
-{
-	luanetfilter_hook_t *hook;
-	struct hlist_node *next;
-
-	hlist_for_each_entry_safe(hook, next, (struct hlist_head *)private, node) {
-		hlist_del(&hook->node);
-		luanetfilter_freehook(hook);
-	}
-}
-
-static const lunatik_class_t luanetfilter_hooks_class = {
-	.name = "netfilter.hooks",
-	.release = luanetfilter_stophooks,
-};
+LUNATIK_PERCPUDATA(luanetfilter_hooks, "netfilter.hooks", luanetfilter_hook_t, luanetfilter_freehook);
 
 static void luanetfilter_checkspec(lua_State *L, int ix, luanetfilter_hook_t *spec)
 {

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -200,7 +200,7 @@ static int luanetfilter_register(lua_State *L)
 		lunatik_own(L, runtime, &luanetfilter_sharing, &spec.shared));
 
 	if (percpu == NULL)
-		nf->hook = hook; /* the percpu object owns the shared one */
+		nf->hook = hook;
 
 	luaskb_attach(L, nf, skb);
 	lunatik_registerobject(L, 1, object);

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -184,7 +184,7 @@ static const lunatik_class_t luanetfilter_class = {
 * @raise if the hook cannot be registered; in a percpu script, if this runtime already
 *   registered the same `pf`, `hooknum`, `priority` and `mark`, or if called after module load
 */
-static int luanetfilter_lregister(lua_State *L)
+static int luanetfilter_register(lua_State *L)
 {
 	luanetfilter_hook_t spec = {.nfops = {.hook = luanetfilter_hook}};
 	luanetfilter_checkspec(L, 1, &spec);
@@ -209,7 +209,7 @@ static int luanetfilter_lregister(lua_State *L)
 }
 
 static const luaL_Reg luanetfilter_lib[] = {
-	{"register", luanetfilter_lregister},
+	{"register", luanetfilter_register},
 	{NULL, NULL},
 };
 

--- a/lib/luanetfilter.c
+++ b/lib/luanetfilter.c
@@ -17,8 +17,7 @@
 #include "luaskb.h"
 
 typedef struct luanetfilter_hook_s {
-	struct hlist_node node;
-	lunatik_object_t *runtime;
+	lunatik_shared_t shared;
 	struct nf_hook_ops nfops;
 	u32 mark;
 } luanetfilter_hook_t;
@@ -101,7 +100,7 @@ static inline unsigned int luanetfilter_docall(luanetfilter_hook_t *hook, struct
 	if (likely(hook->mark != skb->mark))
 		return policy;
 
-	lunatik_run(hook->runtime, luanetfilter_hook_cb, ret, hook, skb);
+	lunatik_run(hook->shared.runtime, luanetfilter_hook_cb, ret, hook, skb);
 	return (ret < 0 || ret > NF_MAX_VERDICT) ? policy : ret;
 }
 
@@ -110,32 +109,26 @@ static unsigned int luanetfilter_hook(void *priv, struct sk_buff *skb, const str
 	return luanetfilter_docall((luanetfilter_hook_t *)priv, skb);
 }
 
-static luanetfilter_hook_t *luanetfilter_find(struct hlist_head *hooks, const luanetfilter_hook_t *spec)
+static bool luanetfilter_match(const lunatik_shared_t *shared, const lunatik_shared_t *spec)
 {
-	luanetfilter_hook_t *hook;
+	const luanetfilter_hook_t *hook = (const luanetfilter_hook_t *)shared;
+	const luanetfilter_hook_t *wanted = (const luanetfilter_hook_t *)spec;
 
-	hlist_for_each_entry(hook, hooks, node) {
-		if (hook->mark == spec->mark && hook->nfops.pf == spec->nfops.pf &&
-		    hook->nfops.hooknum == spec->nfops.hooknum && hook->nfops.priority == spec->nfops.priority)
-			return hook;
-	}
-	return NULL;
+	return hook->mark == wanted->mark && hook->nfops.pf == wanted->nfops.pf &&
+		hook->nfops.hooknum == wanted->nfops.hooknum && hook->nfops.priority == wanted->nfops.priority;
 }
 
-static luanetfilter_hook_t *luanetfilter_register(lua_State *L, lunatik_object_t *runtime, const luanetfilter_hook_t *spec)
+static void luanetfilter_arm(lua_State *L, lunatik_shared_t *shared)
 {
-	luanetfilter_hook_t *hook = lunatik_checkalloc(L, sizeof(luanetfilter_hook_t));
+	luanetfilter_hook_t *hook = (luanetfilter_hook_t *)shared;
 	int ret;
 
-	*hook = *spec;
 	hook->nfops.priv = hook;
-	hook->runtime = runtime;
 
 	if ((ret = nf_register_net_hook(&init_net, &hook->nfops)) != 0) {
 		lunatik_free(hook);
 		lunatik_throw(L, ret);
 	}
-	return hook;
 }
 
 static void luanetfilter_free(luanetfilter_hook_t *hook)
@@ -158,28 +151,13 @@ static void luanetfilter_checkspec(lua_State *L, int ix, luanetfilter_hook_t *sp
 	lunatik_optinteger(L, ix, spec, mark, 0);
 }
 
-static luanetfilter_hook_t *luanetfilter_share(lua_State *L, lunatik_object_t *percpu, const luanetfilter_hook_t *spec)
-{
-	struct hlist_head *hooks = lunatik_percpudata(L, &luanetfilter_hooks_class, sizeof(struct hlist_head))->private;
-	luanetfilter_hook_t *hook = luanetfilter_find(hooks, spec);
-
-	if (hook == NULL) {
-		hook = luanetfilter_register(L, percpu, spec);
-		hlist_add_head(&hook->node, hooks);
-	}
-	else if (lunatik_getregistry(L, hook) != LUA_TNIL)
-		luaL_error(L, "hook already registered");
-	else
-		lua_pop(L, 1);
-	return hook;
-}
-
-static luanetfilter_hook_t *luanetfilter_own(lua_State *L, luanetfilter_t *nf, const luanetfilter_hook_t *spec)
-{
-	nf->hook = luanetfilter_register(L, nf->runtime, spec);
-	lunatik_getobject(nf->runtime); /* a percpu object is held by its data; a plain runtime is held here */
-	return nf->hook;
-}
+static const lunatik_sharing_t luanetfilter_sharing = {
+	.class = &luanetfilter_hooks_class,
+	.size = sizeof(luanetfilter_hook_t),
+	.match = luanetfilter_match,
+	.arm = luanetfilter_arm,
+	.registered = "hook already registered",
+};
 
 static const luaL_Reg luanetfilter_mt[] = {
 	{"__gc", lunatik_deleteobject},
@@ -217,7 +195,13 @@ static int luanetfilter_lregister(lua_State *L)
 	luanetfilter_t *nf = (luanetfilter_t *)object->private;
 	nf->runtime = runtime;
 
-	luanetfilter_hook_t *hook = percpu != NULL ? luanetfilter_share(L, percpu, &spec) : luanetfilter_own(L, nf, &spec);
+	luanetfilter_hook_t *hook = (luanetfilter_hook_t *)(percpu != NULL ?
+		lunatik_share(L, percpu, &luanetfilter_sharing, &spec.shared) :
+		lunatik_own(L, runtime, &luanetfilter_sharing, &spec.shared));
+
+	if (percpu == NULL)
+		nf->hook = hook; /* the percpu object owns the shared one */
+
 	luaskb_attach(L, nf, skb);
 	lunatik_registerobject(L, 1, object);
 	lunatik_register(L, -1, hook); /* the callback finds this runtime's registration by the hook they share */

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -10,17 +10,23 @@
 
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include <linux/kprobes.h>
+#include <linux/list.h>
 #include <linux/string.h>
 
 #include <lunatik.h>
+
+typedef struct luaprobe_kprobe_s {
+	struct hlist_node node;
+	struct kprobe kp;
+	lunatik_object_t *runtime;
+} luaprobe_kprobe_t;
 
 /***
 * Represents a registered kprobe.
 * @type probe
 */
 typedef struct luaprobe_s {
-	struct kprobe kp;
-	lunatik_object_t *runtime;
+	luaprobe_kprobe_t *kprobe;	/* NULL when the percpu object owns the kprobe */
 } luaprobe_t;
 
 static void (*luaprobe_showregs)(struct pt_regs *);
@@ -35,12 +41,12 @@ static int luaprobe_dump(lua_State *L)
 	return 0;
 }
 
-static int luaprobe_handler(lua_State *L, luaprobe_t *probe, const char *handler, struct pt_regs *regs)
+static int luaprobe_handler(lua_State *L, luaprobe_kprobe_t *kprobe, const char *handler, struct pt_regs *regs)
 {
-	struct kprobe *kp = &probe->kp;
+	struct kprobe *kp = &kprobe->kp;
 	const char *symbol = kp->symbol_name;
 
-	if (lunatik_getregistry(L, probe) != LUA_TTABLE) {
+	if (lunatik_getregistry(L, kprobe) != LUA_TTABLE) {
 		pr_err_ratelimited("couldn't find probe table\n");
 		goto out;
 	}
@@ -68,27 +74,27 @@ out:
 
 static int __kprobes luaprobe_pre_handler(struct kprobe *kp, struct pt_regs *regs)
 {
-	luaprobe_t *probe = container_of(kp, luaprobe_t, kp);
+	luaprobe_kprobe_t *kprobe = container_of(kp, luaprobe_kprobe_t, kp);
 	int ret;
 
-	lunatik_run(probe->runtime, luaprobe_handler, ret, probe, "pre", regs);
+	lunatik_run(kprobe->runtime, luaprobe_handler, ret, kprobe, "pre", regs);
 	(void)ret;
 	return 0;
 }
 
 static void __kprobes luaprobe_post_handler(struct kprobe *kp, struct pt_regs *regs, unsigned long flags)
 {
-	luaprobe_t *probe = container_of(kp, luaprobe_t, kp);
+	luaprobe_kprobe_t *kprobe = container_of(kp, luaprobe_kprobe_t, kp);
 	int ret;
 
 	/* flags always seems to be zero; see: https://docs.kernel.org/trace/kprobes.html#api-reference */
-	lunatik_run(probe->runtime, luaprobe_handler, ret, probe, "post", regs);
+	lunatik_run(kprobe->runtime, luaprobe_handler, ret, kprobe, "post", regs);
 	(void)ret;
 }
 
-static void luaprobe_delete(luaprobe_t *probe)
+static void luaprobe_delete(luaprobe_kprobe_t *kprobe)
 {
-	struct kprobe *kp = &probe->kp;
+	struct kprobe *kp = &kprobe->kp;
 	const char *symbol_name = kp->symbol_name;
 
 	if (kp->pre_handler != NULL) {
@@ -104,28 +110,90 @@ static void luaprobe_delete(luaprobe_t *probe)
 	}
 }
 
+static bool luaprobe_match(const struct kprobe *kp, const struct kprobe *spec)
+{
+	if (spec->symbol_name == NULL)
+		return kp->addr == spec->addr;
+	return kp->symbol_name != NULL && strcmp(kp->symbol_name, spec->symbol_name) == 0;
+}
+
+static luaprobe_kprobe_t *luaprobe_find(struct hlist_head *kprobes, const luaprobe_kprobe_t *spec)
+{
+	luaprobe_kprobe_t *kprobe;
+
+	hlist_for_each_entry(kprobe, kprobes, node) {
+		if (luaprobe_match(&kprobe->kp, &spec->kp))
+			return kprobe;
+	}
+	return NULL;
+}
+
+static luaprobe_kprobe_t *luaprobe_register(lua_State *L, lunatik_object_t *runtime, const luaprobe_kprobe_t *spec)
+{
+	luaprobe_kprobe_t *kprobe = lunatik_checkalloc(L, sizeof(luaprobe_kprobe_t));
+	struct kprobe *kp = &kprobe->kp;
+	int ret;
+
+	*kprobe = *spec;
+	kprobe->runtime = runtime;
+
+	if (kp->symbol_name != NULL) {
+		kp->symbol_name = kstrdup(kp->symbol_name, lunatik_gfp(runtime));
+		if (kp->symbol_name == NULL) {
+			lunatik_free(kprobe);
+			lunatik_enomem(L);
+		}
+	}
+
+	if ((ret = register_kprobe(kp)) != 0) {
+		kfree(kp->symbol_name);
+		lunatik_free(kprobe);
+		luaL_error(L, "failed to register probe (%d)", ret);
+	}
+	return kprobe;
+}
+
+static void luaprobe_free(luaprobe_kprobe_t *kprobe)
+{
+	luaprobe_delete(kprobe);
+	lunatik_free(kprobe);
+}
+
+LUNATIK_PERCPUDATA(luaprobe_kprobes, "probe.kprobes", luaprobe_kprobe_t, luaprobe_free);
+
 static void luaprobe_release(void *private)
 {
 	luaprobe_t *probe = (luaprobe_t *)private;
-	luaprobe_delete(probe);
-	if (probe->runtime)
-		lunatik_putobject(probe->runtime);
+	luaprobe_kprobe_t *kprobe = probe->kprobe;
+
+	if (kprobe != NULL) {
+		lunatik_object_t *runtime = kprobe->runtime;
+
+		luaprobe_free(kprobe); /* unregister before the put: the callback reads kprobe->runtime */
+		lunatik_putobject(runtime);
+	}
 }
+
+static const lunatik_class_t luaprobe_class;
+
+#define LUAPROBE_ERR_SHARED	"the percpu object owns this probe"
 
 /***
 * Unregisters and stops the probe.
 * @function stop
+* @raise if the percpu object owns this probe
 */
-static const lunatik_class_t luaprobe_class;
-
 static int luaprobe_stop(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luaprobe_class);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
+	luaprobe_kprobe_t *kprobe = probe->kprobe;
 
-	luaprobe_delete(probe);
+	luaL_argcheck(L, kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
+	luaprobe_delete(kprobe);
+	lunatik_unregister(L, kprobe);
 
-	if (lunatik_toruntime(L) == probe->runtime)
+	if (lunatik_toruntime(L) == kprobe->runtime)
 		lunatik_unregisterobject(L, object);
 	return 0;
 }
@@ -134,14 +202,16 @@ static int luaprobe_stop(lua_State *L)
 * Enables or disables the probe.
 * @function enable
 * @tparam boolean flag true to enable, false to disable
-* @raise if the probe has been stopped
+* @raise if the probe has been stopped, or if the percpu object owns this probe
 */
 static int luaprobe_enable(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luaprobe_class);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
-	struct kprobe *kp = &probe->kp;
 	bool enable = lua_toboolean(L, 2);
+
+	luaL_argcheck(L, probe->kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
+	struct kprobe *kp = &probe->kprobe->kp;
 
 	if (kp->pre_handler == NULL)
 		return luaL_argerror(L, 1, LUNATIK_ERR_NULLPTR);
@@ -158,12 +228,16 @@ static int luaprobe_new(lua_State *L);
 
 /***
 * Creates and registers a new kprobe.
+* In a percpu script the runtimes share one kprobe per symbol or address: the first
+* registration installs it, the others attach their handlers, and a call reaches the
+* runtime of the CPU it ran on.
 * @function new
 * @tparam string|lightuserdata symbol kernel symbol name or address
 * @tparam table handlers table with optional `pre` and `post` callback functions;
 *   each receives the symbol (string or lightuserdata) and a `dump` closure
 * @treturn probe
-* @raise if registration fails, or if called from a percpu runtime
+* @raise if registration fails; in a percpu script, if this runtime already probed the same
+*   symbol or address, or if called after module load
 */
 static const luaL_Reg luaprobe_lib[] = {
 	{"new", luaprobe_new},
@@ -186,41 +260,54 @@ static const lunatik_class_t luaprobe_class = {
 	.opt = LUNATIK_OPT_HARDIRQ | LUNATIK_OPT_SINGLE,
 };
 
+static void luaprobe_checkspec(lua_State *L, int ix, luaprobe_kprobe_t *spec)
+{
+	if (lua_islightuserdata(L, ix))
+		spec->kp.addr = lua_touserdata(L, ix);
+	else
+		spec->kp.symbol_name = luaL_checkstring(L, ix); /* anchored at ix until luaprobe_register copies it */
+}
+
+static luaprobe_kprobe_t *luaprobe_share(lua_State *L, lunatik_object_t *percpu, const luaprobe_kprobe_t *spec)
+{
+	struct hlist_head *kprobes = lunatik_percpudata(L, &luaprobe_kprobes_class, sizeof(struct hlist_head))->private;
+	luaprobe_kprobe_t *kprobe = luaprobe_find(kprobes, spec);
+
+	if (kprobe == NULL) {
+		kprobe = luaprobe_register(L, percpu, spec);
+		hlist_add_head(&kprobe->node, kprobes);
+	}
+	else if (lunatik_getregistry(L, kprobe) != LUA_TNIL)
+		luaL_error(L, "probe already registered");
+	else
+		lua_pop(L, 1);
+	return kprobe;
+}
+
+static luaprobe_kprobe_t *luaprobe_own(lua_State *L, luaprobe_t *probe, lunatik_object_t *runtime,
+	const luaprobe_kprobe_t *spec)
+{
+	probe->kprobe = luaprobe_register(L, runtime, spec);
+	lunatik_getobject(runtime); /* a percpu object is held by its data; a plain runtime is held here */
+	return probe->kprobe;
+}
+
 static int luaprobe_new(lua_State *L)
 {
-	lunatik_checkpercpu(L);
+	luaprobe_kprobe_t spec = {.kp = {.pre_handler = luaprobe_pre_handler, .post_handler = luaprobe_post_handler}};
+	luaprobe_checkspec(L, 1, &spec);
+	luaL_checktype(L, 2, LUA_TTABLE); /* handlers */
+	lunatik_object_t *runtime = lunatik_checkruntime(L, LUNATIK_OPT_HARDIRQ);
+	lunatik_object_t *percpu = lunatik_getpercpu(L);
+
 	lunatik_object_t *object = lunatik_newobject(L, &luaprobe_class, sizeof(luaprobe_t), LUNATIK_OPT_NONE);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
-	struct kprobe *kp = &probe->kp;
-	int ret;
 
-	probe->runtime = lunatik_checkruntime(L, LUNATIK_OPT_HARDIRQ);
-	lunatik_getobject(probe->runtime);
+	luaprobe_kprobe_t *kprobe = percpu != NULL ? luaprobe_share(L, percpu, &spec) :
+		luaprobe_own(L, probe, runtime, &spec);
 
-	if (lua_islightuserdata(L, 1))
-		kp->addr = lua_touserdata(L, 1);
-	else {
-		size_t symbol_len;
-		const char *symbol_name = luaL_checklstring(L, 1, &symbol_len);
-
-		if ((kp->symbol_name = kstrndup(symbol_name, symbol_len, lunatik_gfp(probe->runtime))) == NULL)
-			lunatik_enomem(L);
-	}
-
-	luaL_checktype(L, 2, LUA_TTABLE); /* handlers */
-
-	kp->pre_handler = luaprobe_pre_handler;
-	kp->post_handler = luaprobe_post_handler;
-
-	/* must precede register_kprobe: kprobe may fire immediately */
 	lunatik_registerobject(L, 2, object);
-
-	if ((ret = register_kprobe(kp)) != 0) {
-		kp->pre_handler = NULL; /* shouldn't unregister on release() */
-		lunatik_unregisterobject(L, object);
-		luaL_error(L, "failed to register probe (%d)", ret);
-	}
-
+	lunatik_register(L, 2, kprobe); /* the handler finds this runtime's handlers by the kprobe they share */
 	return 1; /* object */
 }
 

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -138,7 +138,7 @@ static luaprobe_kprobe_t *luaprobe_register(lua_State *L, lunatik_object_t *runt
 	kprobe->runtime = runtime;
 
 	if (kp->symbol_name != NULL) {
-		kp->symbol_name = kstrdup(kp->symbol_name, lunatik_gfp(runtime));
+		kp->symbol_name = kstrdup(kp->symbol_name, lunatik_gfp(lunatik_toruntime(L)));
 		if (kp->symbol_name == NULL) {
 			lunatik_free(kprobe);
 			lunatik_enomem(L);

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -191,10 +191,11 @@ static int luaprobe_stop(lua_State *L)
 
 	luaL_argcheck(L, kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
 	luaprobe_delete(kprobe);
-	lunatik_unregister(L, kprobe);
 
-	if (lunatik_toruntime(L) == kprobe->runtime)
+	if (lunatik_toruntime(L) == kprobe->runtime) {
+		lunatik_unregister(L, kprobe);
 		lunatik_unregisterobject(L, object);
+	}
 	return 0;
 }
 

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -283,7 +283,7 @@ static int luaprobe_new(lua_State *L)
 		lunatik_own(L, runtime, &luaprobe_sharing, &spec.shared));
 
 	if (percpu == NULL)
-		probe->kprobe = kprobe; /* the percpu object owns the shared one */
+		probe->kprobe = kprobe;
 
 	lunatik_registerobject(L, 2, object);
 	lunatik_register(L, 2, kprobe); /* the handler finds this runtime's handlers by the kprobe they share */

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -212,10 +212,11 @@ static int luaprobe_enable(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luaprobe_class);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
+	luaprobe_kprobe_t *kprobe = probe->kprobe;
 	bool enable = lua_toboolean(L, 2);
 
-	luaL_argcheck(L, probe->kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
-	struct kprobe *kp = &probe->kprobe->kp;
+	luaL_argcheck(L, kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
+	struct kprobe *kp = &kprobe->kp;
 
 	if (kp->pre_handler == NULL)
 		return luaL_argerror(L, 1, LUNATIK_ERR_NULLPTR);

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -18,6 +18,7 @@
 typedef struct luaprobe_kprobe_s {
 	struct hlist_node node;
 	struct kprobe kp;
+	kprobe_opcode_t *addr;	/* the address asked for, NULL for a symbol: register_kprobe resolves kp.addr */
 	lunatik_object_t *runtime;
 } luaprobe_kprobe_t;
 
@@ -110,11 +111,13 @@ static void luaprobe_delete(luaprobe_kprobe_t *kprobe)
 	}
 }
 
-static bool luaprobe_match(const struct kprobe *kp, const struct kprobe *spec)
+static bool luaprobe_match(const luaprobe_kprobe_t *kprobe, const luaprobe_kprobe_t *spec)
 {
-	if (spec->symbol_name == NULL)
-		return kp->addr == spec->addr;
-	return kp->symbol_name != NULL && strcmp(kp->symbol_name, spec->symbol_name) == 0;
+	const char *symbol = kprobe->kp.symbol_name;
+
+	if (spec->kp.symbol_name == NULL)
+		return kprobe->addr == spec->addr;
+	return symbol != NULL && strcmp(symbol, spec->kp.symbol_name) == 0;
 }
 
 static luaprobe_kprobe_t *luaprobe_find(struct hlist_head *kprobes, const luaprobe_kprobe_t *spec)
@@ -122,7 +125,7 @@ static luaprobe_kprobe_t *luaprobe_find(struct hlist_head *kprobes, const luapro
 	luaprobe_kprobe_t *kprobe;
 
 	hlist_for_each_entry(kprobe, kprobes, node) {
-		if (luaprobe_match(&kprobe->kp, &spec->kp))
+		if (luaprobe_match(kprobe, spec))
 			return kprobe;
 	}
 	return NULL;
@@ -264,7 +267,7 @@ static const lunatik_class_t luaprobe_class = {
 static void luaprobe_checkspec(lua_State *L, int ix, luaprobe_kprobe_t *spec)
 {
 	if (lua_islightuserdata(L, ix))
-		spec->kp.addr = lua_touserdata(L, ix);
+		spec->addr = spec->kp.addr = lua_touserdata(L, ix);
 	else
 		spec->kp.symbol_name = luaL_checkstring(L, ix); /* anchored at ix until luaprobe_register copies it */
 }

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -16,10 +16,9 @@
 #include <lunatik.h>
 
 typedef struct luaprobe_kprobe_s {
-	struct hlist_node node;
+	lunatik_shared_t shared;
 	struct kprobe kp;
 	kprobe_opcode_t *addr;	/* the address asked for, NULL for a symbol: register_kprobe resolves kp.addr */
-	lunatik_object_t *runtime;
 } luaprobe_kprobe_t;
 
 /***
@@ -78,7 +77,7 @@ static int __kprobes luaprobe_pre_handler(struct kprobe *kp, struct pt_regs *reg
 	luaprobe_kprobe_t *kprobe = container_of(kp, luaprobe_kprobe_t, kp);
 	int ret;
 
-	lunatik_run(kprobe->runtime, luaprobe_handler, ret, kprobe, "pre", regs);
+	lunatik_run(kprobe->shared.runtime, luaprobe_handler, ret, kprobe, "pre", regs);
 	(void)ret;
 	return 0;
 }
@@ -89,7 +88,7 @@ static void __kprobes luaprobe_post_handler(struct kprobe *kp, struct pt_regs *r
 	int ret;
 
 	/* flags always seems to be zero; see: https://docs.kernel.org/trace/kprobes.html#api-reference */
-	lunatik_run(kprobe->runtime, luaprobe_handler, ret, kprobe, "post", regs);
+	lunatik_run(kprobe->shared.runtime, luaprobe_handler, ret, kprobe, "post", regs);
 	(void)ret;
 }
 
@@ -111,34 +110,22 @@ static void luaprobe_delete(luaprobe_kprobe_t *kprobe)
 	}
 }
 
-static bool luaprobe_match(const luaprobe_kprobe_t *kprobe, const luaprobe_kprobe_t *spec)
+static bool luaprobe_match(const lunatik_shared_t *shared, const lunatik_shared_t *spec)
 {
+	const luaprobe_kprobe_t *kprobe = (const luaprobe_kprobe_t *)shared;
+	const luaprobe_kprobe_t *wanted = (const luaprobe_kprobe_t *)spec;
 	const char *symbol = kprobe->kp.symbol_name;
 
-	if (spec->kp.symbol_name == NULL)
-		return kprobe->addr == spec->addr;
-	return symbol != NULL && strcmp(symbol, spec->kp.symbol_name) == 0;
+	if (wanted->kp.symbol_name == NULL)
+		return kprobe->addr == wanted->addr;
+	return symbol != NULL && strcmp(symbol, wanted->kp.symbol_name) == 0;
 }
 
-static luaprobe_kprobe_t *luaprobe_find(struct hlist_head *kprobes, const luaprobe_kprobe_t *spec)
+static void luaprobe_arm(lua_State *L, lunatik_shared_t *shared)
 {
-	luaprobe_kprobe_t *kprobe;
-
-	hlist_for_each_entry(kprobe, kprobes, node) {
-		if (luaprobe_match(kprobe, spec))
-			return kprobe;
-	}
-	return NULL;
-}
-
-static luaprobe_kprobe_t *luaprobe_register(lua_State *L, lunatik_object_t *runtime, const luaprobe_kprobe_t *spec)
-{
-	luaprobe_kprobe_t *kprobe = lunatik_checkalloc(L, sizeof(luaprobe_kprobe_t));
+	luaprobe_kprobe_t *kprobe = (luaprobe_kprobe_t *)shared;
 	struct kprobe *kp = &kprobe->kp;
 	int ret;
-
-	*kprobe = *spec;
-	kprobe->runtime = runtime;
 
 	if (kp->symbol_name != NULL) {
 		kp->symbol_name = kstrdup(kp->symbol_name, lunatik_gfp(lunatik_toruntime(L)));
@@ -153,7 +140,6 @@ static luaprobe_kprobe_t *luaprobe_register(lua_State *L, lunatik_object_t *runt
 		lunatik_free(kprobe);
 		luaL_error(L, "failed to register probe (%d)", ret);
 	}
-	return kprobe;
 }
 
 static void luaprobe_free(luaprobe_kprobe_t *kprobe)
@@ -170,9 +156,9 @@ static void luaprobe_release(void *private)
 	luaprobe_kprobe_t *kprobe = probe->kprobe;
 
 	if (kprobe != NULL) {
-		lunatik_object_t *runtime = kprobe->runtime;
+		lunatik_object_t *runtime = kprobe->shared.runtime;
 
-		luaprobe_free(kprobe); /* unregister before the put: the callback reads kprobe->runtime */
+		luaprobe_free(kprobe); /* unregister before the put: the callback reads the runtime */
 		lunatik_putobject(runtime);
 	}
 }
@@ -195,7 +181,7 @@ static int luaprobe_stop(lua_State *L)
 	luaL_argcheck(L, kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
 	luaprobe_delete(kprobe);
 
-	if (lunatik_toruntime(L) == kprobe->runtime) {
+	if (lunatik_toruntime(L) == kprobe->shared.runtime) {
 		lunatik_unregister(L, kprobe);
 		lunatik_unregisterobject(L, object);
 	}
@@ -270,32 +256,16 @@ static void luaprobe_checkspec(lua_State *L, int ix, luaprobe_kprobe_t *spec)
 	if (lua_islightuserdata(L, ix))
 		spec->addr = spec->kp.addr = lua_touserdata(L, ix);
 	else
-		spec->kp.symbol_name = luaL_checkstring(L, ix); /* anchored at ix until luaprobe_register copies it */
+		spec->kp.symbol_name = luaL_checkstring(L, ix); /* anchored at ix until the registration copies it */
 }
 
-static luaprobe_kprobe_t *luaprobe_share(lua_State *L, lunatik_object_t *percpu, const luaprobe_kprobe_t *spec)
-{
-	struct hlist_head *kprobes = lunatik_percpudata(L, &luaprobe_kprobes_class, sizeof(struct hlist_head))->private;
-	luaprobe_kprobe_t *kprobe = luaprobe_find(kprobes, spec);
-
-	if (kprobe == NULL) {
-		kprobe = luaprobe_register(L, percpu, spec);
-		hlist_add_head(&kprobe->node, kprobes);
-	}
-	else if (lunatik_getregistry(L, kprobe) != LUA_TNIL)
-		luaL_error(L, "probe already registered");
-	else
-		lua_pop(L, 1);
-	return kprobe;
-}
-
-static luaprobe_kprobe_t *luaprobe_own(lua_State *L, luaprobe_t *probe, lunatik_object_t *runtime,
-	const luaprobe_kprobe_t *spec)
-{
-	probe->kprobe = luaprobe_register(L, runtime, spec);
-	lunatik_getobject(runtime); /* a percpu object is held by its data; a plain runtime is held here */
-	return probe->kprobe;
-}
+static const lunatik_sharing_t luaprobe_sharing = {
+	.class = &luaprobe_kprobes_class,
+	.size = sizeof(luaprobe_kprobe_t),
+	.match = luaprobe_match,
+	.arm = luaprobe_arm,
+	.registered = "probe already registered",
+};
 
 static int luaprobe_new(lua_State *L)
 {
@@ -308,8 +278,12 @@ static int luaprobe_new(lua_State *L)
 	lunatik_object_t *object = lunatik_newobject(L, &luaprobe_class, sizeof(luaprobe_t), LUNATIK_OPT_NONE);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
 
-	luaprobe_kprobe_t *kprobe = percpu != NULL ? luaprobe_share(L, percpu, &spec) :
-		luaprobe_own(L, probe, runtime, &spec);
+	luaprobe_kprobe_t *kprobe = (luaprobe_kprobe_t *)(percpu != NULL ?
+		lunatik_share(L, percpu, &luaprobe_sharing, &spec.shared) :
+		lunatik_own(L, runtime, &luaprobe_sharing, &spec.shared));
+
+	if (percpu == NULL)
+		probe->kprobe = kprobe; /* the percpu object owns the shared one */
 
 	lunatik_registerobject(L, 2, object);
 	lunatik_register(L, 2, kprobe); /* the handler finds this runtime's handlers by the kprobe they share */

--- a/lib/luasocket.c
+++ b/lib/luasocket.c
@@ -46,7 +46,7 @@ do {						\
 
 #define LUASOCKET_ADDRMAX	(sizeof_field(struct sockaddr_storage, __data))
 
-static int luasocket_new(lua_State *L);
+static int luasocket_lnew(lua_State *L);
 static int luasocket_accept(lua_State *L);
 
 #define LUASOCKET_ISUNIX(family)	((family) == AF_UNIX || (family) == AF_LOCAL)
@@ -445,7 +445,7 @@ static void luasocket_release(void *private)
 }
 
 static const luaL_Reg luasocket_lib[] = {
-	{"new", luasocket_new},
+	{"new", luasocket_lnew},
 	{NULL, NULL}
 };
 
@@ -474,7 +474,7 @@ static const lunatik_class_t luasocket_class = {
 	.opt = LUNATIK_OPT_MONITOR | LUNATIK_OPT_EXTERNAL,
 };
 
-#define luasocket_newsocket(L)		(lunatik_newobject((L), &luasocket_class, 0, LUNATIK_OPT_NONE))
+#define luasocket_new(L)		(lunatik_newobject((L), &luasocket_class, 0, LUNATIK_OPT_NONE))
 #define luasocket_psocket(object)	((struct socket **)&object->private)
 
 /***
@@ -493,7 +493,7 @@ static int luasocket_accept(lua_State *L)
 {
 	struct socket *socket = luasocket_check(L, 1);
 	int flags = luaL_optinteger(L, 2, 0);
-	lunatik_object_t *object = luasocket_newsocket(L);
+	lunatik_object_t *object = luasocket_new(L);
 
 	lunatik_try(L, kernel_accept, socket, luasocket_psocket(object), flags);
 	return 1; /* object */
@@ -519,12 +519,12 @@ static int luasocket_accept(lua_State *L)
 * @see linux.socket.ipproto
 * @within socket
 */
-static int luasocket_new(lua_State *L)
+static int luasocket_lnew(lua_State *L)
 {
 	int family = luaL_checkinteger(L, 1);
 	int type = luaL_checkinteger(L, 2);
 	int proto = luaL_checkinteger(L, 3);
-	lunatik_object_t *object = luasocket_newsocket(L);
+	lunatik_object_t *object = luasocket_new(L);
 
 	lunatik_try(L, sock_create_kern, &init_net, family, type, proto, luasocket_psocket(object));
 	return 1; /* object */

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -49,8 +49,8 @@ end
 -- @tparam[opt] string context Execution context: `"process"` (default) or `"softirq"` (for netfilter/XDP hooks).
 -- @tparam[opt] boolean ispercpu create one runtime per CPU id, dispatched by the CPU a
 --   callback fires on; the script runs once per runtime and can read its id with
---   `lunatik.cpu()`. The runtimes share a netfilter hook; constructors whose
---   registration is global refuse to run in a percpu runtime.
+--   `lunatik.cpu()`. The runtimes share a netfilter hook and a kprobe; constructors
+--   whose registration is global refuse to run in a percpu runtime.
 -- @treturn table created Lunatik runtime object, or the percpu object when `ispercpu` is set.
 -- @raise error if the script is already running.
 function runner.run(script, context, ispercpu)

--- a/lunatik_percpu.c
+++ b/lunatik_percpu.c
@@ -59,6 +59,57 @@ lunatik_object_t *lunatik_percpudata(lua_State *L, const lunatik_class_t *class,
 }
 EXPORT_SYMBOL(lunatik_percpudata);
 
+static lunatik_shared_t *lunatik_findshared(struct hlist_head *head, const lunatik_sharing_t *sharing,
+	const lunatik_shared_t *spec)
+{
+	lunatik_shared_t *shared;
+
+	hlist_for_each_entry(shared, head, node) {
+		if (sharing->match(shared, spec))
+			return shared;
+	}
+	return NULL;
+}
+
+static lunatik_shared_t *lunatik_newshared(lua_State *L, lunatik_object_t *runtime,
+	const lunatik_sharing_t *sharing, const lunatik_shared_t *spec)
+{
+	lunatik_shared_t *shared = lunatik_checkalloc(L, sharing->size);
+
+	memcpy(shared, spec, sharing->size);
+	shared->runtime = runtime;
+	sharing->arm(L, shared);
+	return shared;
+}
+
+lunatik_shared_t *lunatik_own(lua_State *L, lunatik_object_t *runtime, const lunatik_sharing_t *sharing,
+	const lunatik_shared_t *spec)
+{
+	lunatik_shared_t *shared = lunatik_newshared(L, runtime, sharing, spec);
+
+	lunatik_getobject(runtime); /* a percpu object is held by its data; a plain runtime is held here */
+	return shared;
+}
+EXPORT_SYMBOL(lunatik_own);
+
+lunatik_shared_t *lunatik_share(lua_State *L, lunatik_object_t *percpu, const lunatik_sharing_t *sharing,
+	const lunatik_shared_t *spec)
+{
+	struct hlist_head *head = lunatik_percpudata(L, sharing->class, sizeof(struct hlist_head))->private;
+	lunatik_shared_t *shared = lunatik_findshared(head, sharing, spec);
+
+	if (shared == NULL) {
+		shared = lunatik_newshared(L, percpu, sharing, spec);
+		hlist_add_head(&shared->node, head);
+	}
+	else if (lunatik_getregistry(L, shared) != LUA_TNIL)
+		luaL_error(L, "%s", sharing->registered);
+	else
+		lua_pop(L, 1);
+	return shared;
+}
+EXPORT_SYMBOL(lunatik_share);
+
 static void lunatik_stopdata(lunatik_object_t *object)
 {
 	lunatik_percpu_t *percpu = lunatik_topercpu(object);

--- a/lunatik_percpu.h
+++ b/lunatik_percpu.h
@@ -6,6 +6,7 @@
 #ifndef lunatik_percpu_h
 #define lunatik_percpu_h
 
+#include <linux/list.h>
 #include <linux/percpu.h>
 #include <linux/preempt.h>
 
@@ -50,6 +51,22 @@ extern const lunatik_class_t lunatik_percpu_class;
 
 int lunatik_percpu(lua_State *L);
 lunatik_object_t *lunatik_percpudata(lua_State *L, const lunatik_class_t *class, size_t size);
+
+#define LUNATIK_PERCPUDATA(prefix, cname, T, free)					\
+static void prefix##_release(void *private)					\
+{										\
+	T *entry;								\
+	struct hlist_node *next;						\
+										\
+	hlist_for_each_entry_safe(entry, next, (struct hlist_head *)private, node) {	\
+		hlist_del(&entry->node);					\
+		free(entry);							\
+	}									\
+}										\
+static const lunatik_class_t prefix##_class = {					\
+	.name = cname,								\
+	.release = prefix##_release,						\
+}
 
 #define LUNATIK_ERR_PERCPU	"not allowed in a percpu runtime"
 

--- a/lunatik_percpu.h
+++ b/lunatik_percpu.h
@@ -65,7 +65,7 @@ typedef struct lunatik_sharing_s {
 	const lunatik_class_t *class;	/* percpu data holding the list of registrations */
 	size_t size;			/* of the registration, which begins with lunatik_shared_t */
 	lunatik_match_t match;
-	lunatik_arm_t arm;		/* registers with the kernel; frees what it took before raising */
+	lunatik_arm_t arm;		/* registers with the kernel; frees the registration before raising */
 	const char *registered;		/* raised when this runtime already registered the same target */
 } lunatik_sharing_t;
 

--- a/lunatik_percpu.h
+++ b/lunatik_percpu.h
@@ -52,15 +52,37 @@ extern const lunatik_class_t lunatik_percpu_class;
 int lunatik_percpu(lua_State *L);
 lunatik_object_t *lunatik_percpudata(lua_State *L, const lunatik_class_t *class, size_t size);
 
+/* the head a registration shared by the runtimes of a percpu set begins with */
+typedef struct lunatik_shared_s {
+	struct hlist_node node;
+	lunatik_object_t *runtime;
+} lunatik_shared_t;
+
+typedef bool (*lunatik_match_t)(const lunatik_shared_t *shared, const lunatik_shared_t *spec);
+typedef void (*lunatik_arm_t)(lua_State *L, lunatik_shared_t *shared);
+
+typedef struct lunatik_sharing_s {
+	const lunatik_class_t *class;	/* percpu data holding the list of registrations */
+	size_t size;			/* of the registration, which begins with lunatik_shared_t */
+	lunatik_match_t match;
+	lunatik_arm_t arm;		/* registers with the kernel; frees what it took before raising */
+	const char *registered;		/* raised when this runtime already registered the same target */
+} lunatik_sharing_t;
+
+lunatik_shared_t *lunatik_share(lua_State *L, lunatik_object_t *percpu, const lunatik_sharing_t *sharing,
+	const lunatik_shared_t *spec);
+lunatik_shared_t *lunatik_own(lua_State *L, lunatik_object_t *runtime, const lunatik_sharing_t *sharing,
+	const lunatik_shared_t *spec);
+
 #define LUNATIK_PERCPUDATA(prefix, cname, T, free)					\
 static void prefix##_release(void *private)					\
 {										\
-	T *entry;								\
+	lunatik_shared_t *shared;						\
 	struct hlist_node *next;						\
 										\
-	hlist_for_each_entry_safe(entry, next, (struct hlist_head *)private, node) {	\
-		hlist_del(&entry->node);					\
-		free(entry);							\
+	hlist_for_each_entry_safe(shared, next, (struct hlist_head *)private, node) {	\
+		hlist_del(&shared->node);					\
+		free((T *)shared);						\
 	}									\
 }										\
 static const lunatik_class_t prefix##_class = {					\

--- a/tests/README.md
+++ b/tests/README.md
@@ -219,14 +219,15 @@ higher-level `netlink.*` modules built on top of it.
   the `personality` syscall, which nothing else on an idle host calls: a
   pinned `setarch` is handled exactly once, by the runtime of the CPU it
   ran on, and no runtime is reached through a kprobe it did not register;
-  a call pinned to the CPU whose runtime is published last is dropped while
-  the runtimes are still being created, and counted once they are up;
-  one set holds a kprobe per target, and a second probe on the same symbol in
-  one runtime is refused; `stop` and `enable` are refused in a percpu runtime,
-  where the object owns the kprobe; the same script probes as a plain hardirq
-  runtime; and a plain runtime stops its own probe, twice with no effect, is
-  refused an `enable` afterwards, and refuses a probe on a symbol the kernel
-  does not have.
+  the set arms that one kprobe however many runtimes it has, and unregisters
+  it when it stops; a call pinned to the CPU whose runtime is published last
+  is dropped while the runtimes are still being created, and counted once they
+  are up; one set holds a kprobe per target, and a second probe on the same
+  symbol in one runtime is refused; `stop` and `enable` are refused in a percpu
+  runtime, where the object owns the kprobe; the same script probes as a plain
+  hardirq runtime; and a plain runtime stops its own probe, twice with no
+  effect, is refused an `enable` afterwards, and refuses a probe on a symbol
+  the kernel does not have.
 
 ### rcu
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -215,6 +215,19 @@ higher-level `netlink.*` modules built on top of it.
   one load generator per CPU; `lunatik stop` must complete within 5s
   with no kernel errors under concurrent handler firings.
 
+- **percpu_probe**: the runtimes of a percpu script share one kprobe on
+  the `personality` syscall, which nothing else on an idle host calls: a
+  pinned `setarch` is handled exactly once, by the runtime of the CPU it
+  ran on, and no runtime is reached through a kprobe it did not register;
+  a call pinned to the CPU whose runtime is published last is dropped while
+  the runtimes are still being created, and counted once they are up;
+  one set holds a kprobe per target, and a second probe on the same symbol in
+  one runtime is refused; `stop` and `enable` are refused in a percpu runtime,
+  where the object owns the kprobe; the same script probes as a plain hardirq
+  runtime; and a plain runtime stops its own probe, twice with no effect, is
+  refused an `enable` afterwards, and refuses a probe on a symbol the kernel
+  does not have.
+
 ### rcu
 
 - **map_values**: `rcu.map()` iterates booleans, integers, userdata,

--- a/tests/README.md
+++ b/tests/README.md
@@ -223,11 +223,13 @@ higher-level `netlink.*` modules built on top of it.
   it when it stops; a call pinned to the CPU whose runtime is published last
   is dropped while the runtimes are still being created, and counted once they
   are up; one set holds a kprobe per target, and a second probe on the same
-  symbol in one runtime is refused; `stop` and `enable` are refused in a percpu
-  runtime, where the object owns the kprobe; a probe from a handler, after the
-  script loaded, is refused; the same script probes as a plain hardirq runtime;
-  and a plain runtime stops its own probe, twice with no effect, is refused an
-  `enable` afterwards, and refuses a probe on a symbol the kernel does not have.
+  symbol in one runtime is refused; a probe the kernel refuses is freed, leaving
+  the set with only the kprobe it had already armed and the script unregistered;
+  `stop` and `enable` are refused in a percpu runtime, where the object owns the
+  kprobe; a probe from a handler, after the script loaded, is refused; the same
+  script probes as a plain hardirq runtime; and a plain runtime stops its own
+  probe, twice with no effect, is refused an `enable` afterwards, and refuses a
+  probe on a symbol the kernel does not have.
 
 ### rcu
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -224,10 +224,10 @@ higher-level `netlink.*` modules built on top of it.
   is dropped while the runtimes are still being created, and counted once they
   are up; one set holds a kprobe per target, and a second probe on the same
   symbol in one runtime is refused; `stop` and `enable` are refused in a percpu
-  runtime, where the object owns the kprobe; the same script probes as a plain
-  hardirq runtime; and a plain runtime stops its own probe, twice with no
-  effect, is refused an `enable` afterwards, and refuses a probe on a symbol
-  the kernel does not have.
+  runtime, where the object owns the kprobe; a probe from a handler, after the
+  script loaded, is refused; the same script probes as a plain hardirq runtime;
+  and a plain runtime stops its own probe, twice with no effect, is refused an
+  `enable` afterwards, and refuses a probe on a symbol the kernel does not have.
 
 ### rcu
 

--- a/tests/probe/percpu_probe.lua
+++ b/tests/probe/percpu_probe.lua
@@ -1,0 +1,24 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test (see percpu_probe.sh).
+
+local lunatik = require("lunatik")
+local probe   = require("probe")
+local systab  = require("syscall.table")
+
+local LIMIT <const> = 16
+
+local cpu = lunatik.cpu() or "plain"
+local hits = 0
+
+local function count()
+	hits = hits + 1
+	if hits <= LIMIT then
+		print("percpu probe: cpu " .. tostring(cpu))
+	end
+end
+
+probe.new(systab["personality"], {pre = count})
+

--- a/tests/probe/percpu_probe.sh
+++ b/tests/probe/percpu_probe.sh
@@ -7,14 +7,15 @@
 # kprobe on the personality syscall, so a pinned setarch, which calls it once,
 # is handled exactly once and by the runtime of the CPU it ran on, which for a
 # kprobe is where the syscall executed, with no runtime reached through a kprobe
-# it did not register; a call reaching the shared kprobe while the runtimes are
-# still being created, pinned to the CPU whose runtime is published last, is
-# dropped, and the same call is counted once they are up; one set holds a kprobe
-# per target, and a second probe on the same symbol in one runtime is refused;
-# stop and enable are refused in a percpu runtime, where the object owns the
-# kprobe; the same script probes as a plain hardirq runtime; and a plain runtime
-# stops its own probe, twice with no effect, is refused an enable afterwards, and
-# refuses a probe on a symbol the kernel does not have.
+# it did not register; the set arms that one kprobe however many runtimes it
+# has, and unregisters it when it stops; a call reaching the shared kprobe while
+# the runtimes are still being created, pinned to the CPU whose runtime is
+# published last, is dropped, and the same call is counted once they are up; one
+# set holds a kprobe per target, and a second probe on the same symbol in one
+# runtime is refused; stop and enable are refused in a percpu runtime, where the
+# object owns the kprobe; the same script probes as a plain hardirq runtime; and
+# a plain runtime stops its own probe, twice with no effect, is refused an enable
+# afterwards, and refuses a probe on a symbol the kernel does not have.
 #
 # Usage: sudo bash tests/probe/percpu_probe.sh
 
@@ -25,6 +26,7 @@ PLAIN="tests/probe/percpu_probe_plain"
 EARLY="tests/probe/percpu_probe_early"
 ARMED="percpu probe early: armed"
 TARGETS="percpu probe twice: two targets armed"
+KPROBES="/sys/kernel/debug/kprobes/list"
 COUNT=3
 TRIES=100
 
@@ -37,6 +39,12 @@ cleanup()
 	lunatik stop "$STOP" > /dev/null 2>&1
 	lunatik stop "$PLAIN" > /dev/null 2>&1
 	lunatik stop "$EARLY" > /dev/null 2>&1
+}
+
+# how many kprobes the kernel holds; nothing where debugfs does not say
+kprobes()
+{
+	[ -r "$KPROBES" ] && grep -c "" "$KPROBES"
 }
 
 trigger()
@@ -78,15 +86,22 @@ command -v taskset > /dev/null 2>&1 && command -v setarch > /dev/null 2>&1 || {
 cpu=$(sed 's/.*[-,]//' /sys/devices/system/cpu/online)
 
 mark_dmesg
+idle=$(kprobes)
 run_script "$SCRIPT" hardirq percpu
+armed=$(kprobes)
 trigger "$cpu"
 check_dmesg || { ktap_totals; exit 1; }
 dmesg_since | grep -qF "couldn't find probe table" && fail "a kprobe fired on a runtime that did not register it"
 hits=$(dmesg_since | grep -c "percpu probe: cpu $cpu$")
 others=$(dmesg_since | grep -o "percpu probe: cpu [0-9]*" | grep -vc "cpu $cpu$")
 lunatik stop "$SCRIPT" > /dev/null 2>&1
+stopped=$(kprobes)
 [ "$hits" = "$COUNT" ] || fail "the runtime of CPU $cpu counted $hits of $COUNT"
 [ "$others" = "0" ] || fail "$others hits landed on another runtime: $(dmesg_since | grep -o 'percpu probe: cpu [0-9]*' | sort -u | tr '\n' ' ')"
+if [ -n "$armed" ]; then
+	[ "$armed" = "$((idle + 1))" ] || fail "the runtimes armed $((armed - idle)) kprobes on one target"
+	[ "$stopped" = "$idle" ] || fail "stopping the set left $((stopped - idle)) kprobes armed"
+fi
 ktap_pass "the runtimes share one kprobe: each call is handled once, by the runtime of the CPU it ran on"
 
 mark_dmesg

--- a/tests/probe/percpu_probe.sh
+++ b/tests/probe/percpu_probe.sh
@@ -13,9 +13,11 @@
 # published last, is dropped, and the same call is counted once they are up; one
 # set holds a kprobe per target, and a second probe on the same symbol in one
 # runtime is refused; stop and enable are refused in a percpu runtime, where the
-# object owns the kprobe; the same script probes as a plain hardirq runtime; and
-# a plain runtime stops its own probe, twice with no effect, is refused an enable
-# afterwards, and refuses a probe on a symbol the kernel does not have.
+# object owns the kprobe; a probe from a handler, after the script loaded, is
+# refused before it could sleep in hardirq; the same script probes as a plain
+# hardirq runtime; and a plain runtime stops its own probe, twice with no effect,
+# is refused an enable afterwards, and refuses a probe on a symbol the kernel
+# does not have.
 #
 # Usage: sudo bash tests/probe/percpu_probe.sh
 
@@ -24,6 +26,7 @@ TWICE="tests/probe/percpu_probe_twice"
 STOP="tests/probe/percpu_probe_stop"
 PLAIN="tests/probe/percpu_probe_plain"
 EARLY="tests/probe/percpu_probe_early"
+LATE="tests/probe/percpu_probe_late"
 ARMED="percpu probe early: armed"
 TARGETS="percpu probe twice: two targets armed"
 KPROBES="/sys/kernel/debug/kprobes/list"
@@ -39,6 +42,7 @@ cleanup()
 	lunatik stop "$STOP" > /dev/null 2>&1
 	lunatik stop "$PLAIN" > /dev/null 2>&1
 	lunatik stop "$EARLY" > /dev/null 2>&1
+	lunatik stop "$LATE" > /dev/null 2>&1
 }
 
 # how many kprobes the kernel holds; nothing where debugfs does not say
@@ -69,7 +73,7 @@ trap cleanup EXIT
 cleanup
 
 ktap_header
-ktap_plan 6
+ktap_plan 7
 
 command -v taskset > /dev/null 2>&1 && command -v setarch > /dev/null 2>&1 || {
 	echo "# SKIP: taskset or setarch not available"
@@ -77,6 +81,7 @@ command -v taskset > /dev/null 2>&1 && command -v setarch > /dev/null 2>&1 || {
 	ktap_skip "a call reaching the shared kprobe before the runtimes are published is dropped"
 	ktap_skip "one set holds a kprobe per target; a second probe on the same symbol is refused"
 	ktap_skip "stop and enable are refused in a percpu runtime"
+	ktap_skip "a probe from a handler, after load, is refused"
 	ktap_skip "the same script probes as a plain hardirq runtime"
 	ktap_skip "a plain runtime stops its probe once, refuses enable afterwards and refuses an unknown symbol"
 	ktap_totals
@@ -134,6 +139,16 @@ run_script "$STOP" hardirq percpu
 check_dmesg || { ktap_totals; exit 1; }
 lunatik stop "$STOP" > /dev/null 2>&1
 ktap_pass "stop and enable are refused in a percpu runtime"
+
+mark_dmesg
+run_script "$LATE" hardirq percpu
+trigger "$cpu"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$LATE" > /dev/null 2>&1
+dmesg_since | grep -qF "percpu probe late: " || fail "the handler did not run"
+dmesg_since | grep -q "percpu probe late: not allowed after module load" || \
+	fail "the late probe was not refused: $(dmesg_since | grep 'percpu probe late')"
+ktap_pass "a probe from a handler, after load, is refused"
 
 mark_dmesg
 run_script "$SCRIPT" hardirq

--- a/tests/probe/percpu_probe.sh
+++ b/tests/probe/percpu_probe.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for a kprobe in a percpu script: the runtimes share one
+# kprobe on the personality syscall, so a pinned setarch, which calls it once,
+# is handled exactly once and by the runtime of the CPU it ran on, which for a
+# kprobe is where the syscall executed, with no runtime reached through a kprobe
+# it did not register; a call reaching the shared kprobe while the runtimes are
+# still being created, pinned to the CPU whose runtime is published last, is
+# dropped, and the same call is counted once they are up; one set holds a kprobe
+# per target, and a second probe on the same symbol in one runtime is refused;
+# stop and enable are refused in a percpu runtime, where the object owns the
+# kprobe; the same script probes as a plain hardirq runtime; and a plain runtime
+# stops its own probe, twice with no effect, is refused an enable afterwards, and
+# refuses a probe on a symbol the kernel does not have.
+#
+# Usage: sudo bash tests/probe/percpu_probe.sh
+
+SCRIPT="tests/probe/percpu_probe"
+TWICE="tests/probe/percpu_probe_twice"
+STOP="tests/probe/percpu_probe_stop"
+PLAIN="tests/probe/percpu_probe_plain"
+EARLY="tests/probe/percpu_probe_early"
+ARMED="percpu probe early: armed"
+TARGETS="percpu probe twice: two targets armed"
+COUNT=3
+TRIES=100
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+	lunatik stop "$TWICE" > /dev/null 2>&1
+	lunatik stop "$STOP" > /dev/null 2>&1
+	lunatik stop "$PLAIN" > /dev/null 2>&1
+	lunatik stop "$EARLY" > /dev/null 2>&1
+}
+
+trigger()
+{
+	local cpu="$1" i
+	for ((i = 0; i < COUNT; i++)); do
+		taskset -c "$cpu" setarch "$(uname -m)" -R true > /dev/null 2>&1
+	done
+}
+
+trigger_when_armed()
+{
+	local try
+	for ((try = 0; try < TRIES; try++)); do
+		dmesg_since | grep -qF "$ARMED" && break
+		sleep 0.02
+	done
+	trigger "$1"
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 6
+
+command -v taskset > /dev/null 2>&1 && command -v setarch > /dev/null 2>&1 || {
+	echo "# SKIP: taskset or setarch not available"
+	ktap_skip "the runtimes share one kprobe: each call is handled once, by the runtime of the CPU it ran on"
+	ktap_skip "a call reaching the shared kprobe before the runtimes are published is dropped"
+	ktap_skip "one set holds a kprobe per target; a second probe on the same symbol is refused"
+	ktap_skip "stop and enable are refused in a percpu runtime"
+	ktap_skip "the same script probes as a plain hardirq runtime"
+	ktap_skip "a plain runtime stops its probe once, refuses enable afterwards and refuses an unknown symbol"
+	ktap_totals
+	exit 0
+}
+
+cpu=$(sed 's/.*[-,]//' /sys/devices/system/cpu/online)
+
+mark_dmesg
+run_script "$SCRIPT" hardirq percpu
+trigger "$cpu"
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -qF "couldn't find probe table" && fail "a kprobe fired on a runtime that did not register it"
+hits=$(dmesg_since | grep -c "percpu probe: cpu $cpu$")
+others=$(dmesg_since | grep -o "percpu probe: cpu [0-9]*" | grep -vc "cpu $cpu$")
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+[ "$hits" = "$COUNT" ] || fail "the runtime of CPU $cpu counted $hits of $COUNT"
+[ "$others" = "0" ] || fail "$others hits landed on another runtime: $(dmesg_since | grep -o 'percpu probe: cpu [0-9]*' | sort -u | tr '\n' ' ')"
+ktap_pass "the runtimes share one kprobe: each call is handled once, by the runtime of the CPU it ran on"
+
+mark_dmesg
+trigger_when_armed "$cpu" &
+early=$!
+run_script "$EARLY" hardirq percpu
+wait $early
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -qF "couldn't find probe table" && fail "a kprobe fired for a runtime that did not register it"
+early_hits=$(dmesg_since | grep -c "percpu probe early: cpu")
+trigger "$cpu"
+late_hits=$(dmesg_since | grep -c "percpu probe early: cpu $cpu\$")
+lunatik stop "$EARLY" > /dev/null 2>&1
+[ "$early_hits" = "0" ] || fail "$early_hits calls were handled before the runtimes were published"
+[ "$late_hits" = "$COUNT" ] || fail "the same trigger counted $late_hits of $COUNT once the runtimes were published"
+ktap_pass "a call reaching the shared kprobe before the runtimes are published is dropped"
+
+mark_dmesg
+output=$(lunatik run "$TWICE" hardirq percpu 2>&1)
+echo "$output" | grep -q "probe already registered" || fail "the second registration was not refused: $output"
+dmesg_since | grep -qF "$TARGETS" || fail "the probe on a second target was taken for the one already in the set"
+listed=$(lunatik list)
+case "$listed" in
+	*"$TWICE"*) fail "the refused run left the script registered: $listed" ;;
+esac
+ktap_pass "one set holds a kprobe per target; a second probe on the same symbol is refused"
+
+mark_dmesg
+run_script "$STOP" hardirq percpu
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$STOP" > /dev/null 2>&1
+ktap_pass "stop and enable are refused in a percpu runtime"
+
+mark_dmesg
+run_script "$SCRIPT" hardirq
+trigger "$cpu"
+check_dmesg || { ktap_totals; exit 1; }
+plain=$(dmesg_since | grep -c "percpu probe: cpu plain$")
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+[ "$plain" = "$COUNT" ] || fail "the plain runtime counted $plain of $COUNT"
+ktap_pass "the same script probes as a plain hardirq runtime"
+
+mark_dmesg
+run_script "$PLAIN" hardirq
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$PLAIN" > /dev/null 2>&1
+ktap_pass "a plain runtime stops its probe once, refuses enable afterwards and refuses an unknown symbol"
+
+ktap_totals
+

--- a/tests/probe/percpu_probe.sh
+++ b/tests/probe/percpu_probe.sh
@@ -12,23 +12,26 @@
 # the runtimes are still being created, pinned to the CPU whose runtime is
 # published last, is dropped, and the same call is counted once they are up; one
 # set holds a kprobe per target, and a second probe on the same symbol in one
-# runtime is refused; stop and enable are refused in a percpu runtime, where the
-# object owns the kprobe; a probe from a handler, after the script loaded, is
-# refused before it could sleep in hardirq; the same script probes as a plain
-# hardirq runtime; and a plain runtime stops its own probe, twice with no effect,
-# is refused an enable afterwards, and refuses a probe on a symbol the kernel
-# does not have.
+# runtime is refused; a probe the kernel refuses is freed, leaving the set with
+# only the kprobe it had already armed and the script unregistered; stop and
+# enable are refused in a percpu runtime, where the object owns the kprobe; a
+# probe from a handler, after the script loaded, is refused before it could
+# sleep in hardirq; the same script probes as a plain hardirq runtime; and a
+# plain runtime stops its own probe, twice with no effect, is refused an enable
+# afterwards, and refuses a probe on a symbol the kernel does not have.
 #
 # Usage: sudo bash tests/probe/percpu_probe.sh
 
 SCRIPT="tests/probe/percpu_probe"
 TWICE="tests/probe/percpu_probe_twice"
+UNKNOWN="tests/probe/percpu_probe_unknown"
 STOP="tests/probe/percpu_probe_stop"
 PLAIN="tests/probe/percpu_probe_plain"
 EARLY="tests/probe/percpu_probe_early"
 LATE="tests/probe/percpu_probe_late"
 ARMED="percpu probe early: armed"
 TARGETS="percpu probe twice: two targets armed"
+ARMED_ONE="percpu probe unknown: one target armed"
 KPROBES="/sys/kernel/debug/kprobes/list"
 COUNT=3
 TRIES=100
@@ -39,6 +42,7 @@ cleanup()
 {
 	lunatik stop "$SCRIPT" > /dev/null 2>&1
 	lunatik stop "$TWICE" > /dev/null 2>&1
+	lunatik stop "$UNKNOWN" > /dev/null 2>&1
 	lunatik stop "$STOP" > /dev/null 2>&1
 	lunatik stop "$PLAIN" > /dev/null 2>&1
 	lunatik stop "$EARLY" > /dev/null 2>&1
@@ -73,13 +77,14 @@ trap cleanup EXIT
 cleanup
 
 ktap_header
-ktap_plan 7
+ktap_plan 8
 
 command -v taskset > /dev/null 2>&1 && command -v setarch > /dev/null 2>&1 || {
 	echo "# SKIP: taskset or setarch not available"
 	ktap_skip "the runtimes share one kprobe: each call is handled once, by the runtime of the CPU it ran on"
 	ktap_skip "a call reaching the shared kprobe before the runtimes are published is dropped"
 	ktap_skip "one set holds a kprobe per target; a second probe on the same symbol is refused"
+	ktap_skip "a probe the kernel refuses is freed, and the set unwinds the one it had armed"
 	ktap_skip "stop and enable are refused in a percpu runtime"
 	ktap_skip "a probe from a handler, after load, is refused"
 	ktap_skip "the same script probes as a plain hardirq runtime"
@@ -133,6 +138,22 @@ case "$listed" in
 	*"$TWICE"*) fail "the refused run left the script registered: $listed" ;;
 esac
 ktap_pass "one set holds a kprobe per target; a second probe on the same symbol is refused"
+
+mark_dmesg
+idle=$(kprobes)
+output=$(lunatik run "$UNKNOWN" hardirq percpu 2>&1)
+left=$(kprobes)
+echo "$output" | grep -q "failed to register probe" || \
+	fail "a probe on a symbol the kernel does not have was accepted: $output"
+dmesg_since | grep -qF "$ARMED_ONE" || fail "the set did not arm a kprobe before the one the kernel refuses"
+listed=$(lunatik list)
+case "$listed" in
+	*"$UNKNOWN"*) fail "the refused run left the script registered: $listed" ;;
+esac
+if [ -n "$idle" ]; then
+	[ "$left" = "$idle" ] || fail "the refused run left $((left - idle)) kprobes armed"
+fi
+ktap_pass "a probe the kernel refuses is freed, and the set unwinds the one it had armed"
 
 mark_dmesg
 run_script "$STOP" hardirq percpu

--- a/tests/probe/percpu_probe_early.lua
+++ b/tests/probe/percpu_probe_early.lua
@@ -1,0 +1,24 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test, a call during creation (see percpu_probe.sh).
+
+local lunatik = require("lunatik")
+local probe   = require("probe")
+local systab  = require("syscall.table")
+
+local SPIN <const> = 100000000
+
+local cpu = lunatik.cpu()
+
+local function count()
+	print("percpu probe early: cpu " .. tostring(cpu))
+end
+
+probe.new(systab["personality"], {pre = count})
+
+print("percpu probe early: armed")
+
+for _ = 1, SPIN do end -- widen the gap between arming the kprobe and publishing this runtime
+

--- a/tests/probe/percpu_probe_late.lua
+++ b/tests/probe/percpu_probe_late.lua
@@ -1,0 +1,24 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test, a probe after load (see percpu_probe.sh).
+
+local probe  = require("probe")
+local systab = require("syscall.table")
+
+local reported = false
+
+local function nop() end
+
+local function probe_late()
+	if reported then
+		return
+	end
+	reported = true
+	local ok, err = pcall(probe.new, systab["personality"], {pre = nop})
+	print("percpu probe late: " .. (ok and "registered" or err:gsub("^.-:%d+: ", "")))
+end
+
+probe.new(systab["personality"], {pre = probe_late})
+

--- a/tests/probe/percpu_probe_plain.lua
+++ b/tests/probe/percpu_probe_plain.lua
@@ -1,0 +1,31 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test, the plain runtime methods (see percpu_probe.sh).
+
+local probe  = require("probe")
+local systab = require("syscall.table")
+local test   = require("util").test
+
+local UNKNOWN <const> = "lunatik_no_such_symbol"
+
+local function nop() end
+
+test("a plain runtime stops its probe once and enables it while it lives", function()
+	local p = probe.new(systab["personality"], {pre = nop})
+	p:enable(false)
+	p:enable(true)
+	p:stop()
+	p:stop() -- stopping again is a no-op
+	local ok, err = pcall(p.enable, p, true)
+	assert(not ok, "enable was accepted after stop")
+	assert(err:match("null pointer"), "enable raised something else: " .. tostring(err))
+end)
+
+test("a probe on a symbol the kernel does not have is refused", function()
+	local ok, err = pcall(probe.new, UNKNOWN, {pre = nop})
+	assert(not ok, "a probe on an unknown symbol was accepted")
+	assert(err:match("failed to register probe"), "probe.new raised something else: " .. tostring(err))
+end)
+

--- a/tests/probe/percpu_probe_stop.lua
+++ b/tests/probe/percpu_probe_stop.lua
@@ -1,0 +1,22 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test, stop in a percpu runtime (see percpu_probe.sh).
+
+local probe  = require("probe")
+local systab = require("syscall.table")
+local test   = require("util").test
+
+local function nop() end
+
+test("stop and enable are refused in a percpu runtime", function()
+	local p = probe.new(systab["personality"], {pre = nop})
+	local ok, err = pcall(p.stop, p)
+	assert(not ok, "stop was accepted")
+	assert(err:match("percpu object owns this probe"), "stop raised something else: " .. tostring(err))
+	local okenable, errenable = pcall(p.enable, p, false)
+	assert(not okenable, "enable was accepted")
+	assert(errenable:match("percpu object owns this probe"), "enable raised something else: " .. tostring(errenable))
+end)
+

--- a/tests/probe/percpu_probe_twice.lua
+++ b/tests/probe/percpu_probe_twice.lua
@@ -1,0 +1,20 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test, duplicate registration (see percpu_probe.sh).
+
+local probe  = require("probe")
+local systab = require("syscall.table")
+
+local SYMBOL <const> = "sys_ni_syscall"
+
+local function nop() end
+
+probe.new(systab["personality"], {pre = nop})
+probe.new(SYMBOL, {pre = nop}) -- a second kprobe in the same set, this one found by name
+
+print("percpu probe twice: two targets armed")
+
+probe.new(SYMBOL, {pre = nop})
+

--- a/tests/probe/percpu_probe_unknown.lua
+++ b/tests/probe/percpu_probe_unknown.lua
@@ -1,0 +1,19 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test, a target the kernel refuses (see percpu_probe.sh).
+
+local probe  = require("probe")
+local systab = require("syscall.table")
+
+local UNKNOWN <const> = "lunatik_no_such_symbol"
+
+local function nop() end
+
+probe.new(systab["personality"], {pre = nop})
+
+print("percpu probe unknown: one target armed")
+
+probe.new(UNKNOWN, {pre = nop})
+

--- a/tests/probe/run.sh
+++ b/tests/probe/run.sh
@@ -11,7 +11,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
 SEP=$'\n'
-for t in "$DIR"/kprobe_concurrent.sh; do
+for t in "$DIR"/kprobe_concurrent.sh "$DIR"/percpu_probe.sh; do
 	echo "${SEP}# --- $(basename "$t") ---"
 	bash "$t" || FAILED=$((FAILED+1))
 done


### PR DESCRIPTION
Closes #834, with a recommendation to hold it. `luaprobe` and `luanetfilter` solved the same problem twice: one kernel registration owned by a percpu object and shared by the runtimes of the set, found by a match on the target, armed once and freed on release. A registration now begins with a `lunatik_shared_t`, each binding gives a `lunatik_sharing_t` naming the three points where they differ, and `find`, `share` and `own` move into the core.

The issue asked whether to fold the two consumers now or wait for a third, and the measurement answers it: on aarch64 the bindings lose 42 source lines and 584 bytes of text for 73 lines and 980 bytes in the core, so it breaks even at the fourth binding that shares a registration, not the third. It also trades two typed predicates for `lunatik_shared_t *` callbacks whose first-member cast and `.size` field the compiler cannot check, and `arm` frees an allocation the core made, which is a hazard for whoever writes the third consumer.

Landing it anyway needs two things this branch does not do. #839's `c2966501` reduces to the one rename that survives here, `freehook` to `free`, because the rest of it is undone by this commit; and `arm` should return `-errno` and release only what it took, leaving the free to the core, which changes the message `probe.new` raises and the test that asserts it.
