### PR TITLE
lunatik: read a bare name in the REPL as the expression it is

### DIFF
--- a/bin/lunatik
+++ b/bin/lunatik
@@ -162,13 +162,14 @@ local function repl(read_line)
 	local line = read_line("> ")
 	while line ~= nil do
 		local chunk = line
-		while is_incomplete(chunk) do
+		local expr = try_as_expr(chunk) -- a name or a field also reads as an unfinished assignment
+		while not expr and is_incomplete(chunk) do
 			local more = read_line(">> ")
 			if more == nil then break end
 			chunk = chunk .. "\n" .. more
+			expr = try_as_expr(chunk)
 		end
-		local send = try_as_expr(chunk) and ("return " .. chunk) or chunk
-		local res = dostring(send)
+		local res = dostring(expr and ("return " .. chunk) or chunk)
 		if res ~= "" then print(res) end
 		line = read_line("> ")
 	end


### PR DESCRIPTION
Typing a value on its own in the REPL works for `42` but not for `t`, `t[2]` or `lunatik._ENV`: a name also reads as the start of an assignment, so `load()` stops at `<eof>`, the line is taken for an unfinished statement, and the REPL swallows the next one into it.

The REPL now asks whether the chunk is an expression before asking whether it is unfinished, which is the order `lua.c` uses. Every other shape is unchanged, multi-line constructs included, and what it still refuses (`"a" ..`, a bare `{7,` across lines) it refuses exactly as upstream `lua` does.
