### PR TITLE
tests: cover the second target a percpu netfilter set holds

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -338,9 +338,10 @@ Regression tests for `lunatik_newruntime` and cross-runtime plumbing.
   `LOCAL_IN` hook: with the ping pinned to the last online CPU, each marked
   request is counted exactly once, by the runtime of that CPU; a burst that
   reaches the hook while the runtimes are still being created is accepted
-  without being counted; a second registration of the same hook in one
-  runtime is refused; a registration from a callback, after load, is
-  refused; and the same script registers as a plain softirq runtime.
+  without being counted; one set holds a hook per target, and a second
+  registration of the same one in a runtime is refused; a registration from a
+  callback, after load, is refused; and the same script registers as a plain
+  softirq runtime.
 
 ### set
 

--- a/tests/runtime/percpu_netfilter.sh
+++ b/tests/runtime/percpu_netfilter.sh
@@ -8,13 +8,13 @@
 # runtime of the CPU that received it, which is where the loopback delivers the
 # pinned ping; a marked packet reaching that hook while the runtimes are still
 # being created finds none published on its CPU, and is accepted without being
-# counted; a second registration of the same hook in one runtime is refused; a
-# registration from a callback, after the script loaded, is refused before it
-# could sleep in softirq; and the same script registers as a plain softirq
-# runtime. The exactly-once assertion runs on the shared hook, where it is
-# structural. The burst starts when the script reports the hook armed, and runs
-# inside the spin every runtime does before returning, so it arrives while no
-# runtime is published.
+# counted; one set holds a hook per target, and a second registration of the
+# same one in a runtime is refused; a registration from a callback, after the
+# script loaded, is refused before it could sleep in softirq; and the same
+# script registers as a plain softirq runtime. The exactly-once assertion runs
+# on the shared hook, where it is structural. The burst starts when the script
+# reports the hook armed, and runs inside the spin every runtime does before
+# returning, so it arrives while no runtime is published.
 #
 # Usage: sudo bash tests/runtime/percpu_netfilter.sh
 
@@ -24,6 +24,7 @@ TWICE="tests/runtime/percpu_netfilter_twice"
 LATE="tests/runtime/percpu_netfilter_late"
 EARLY="tests/runtime/percpu_netfilter_early"
 ARMED="percpu netfilter early: armed"
+TARGETS="percpu netfilter twice: two targets armed"
 MODULE="luanetfilter"
 MARK=208
 COUNT=5
@@ -72,7 +73,7 @@ cat /sys/module/$MODULE/refcnt > /dev/null 2>&1 || {
 	echo "# SKIP: $MODULE not loaded"
 	ktap_skip "the runtimes share one hook: each marked request is counted once, by the receiving CPU"
 	ktap_skip "a packet reaching the shared hook before the runtimes are published is accepted, uncounted"
-	ktap_skip "a second registration of the same hook in one runtime is refused"
+	ktap_skip "one set holds a hook per target; a second registration of the same one is refused"
 	ktap_skip "a registration from a callback, after load, is refused"
 	ktap_skip "the same script registers as a plain softirq runtime"
 	ktap_totals
@@ -98,13 +99,15 @@ dmesg_since | grep -qF "percpu netfilter: nf_percpu:$cpu $COUNT" || \
 lunatik stop "$EARLY" > /dev/null 2>&1
 ktap_pass "a packet reaching the shared hook before the runtimes are published is accepted, uncounted"
 
+mark_dmesg
 output=$(lunatik run "$TWICE" softirq percpu 2>&1)
 echo "$output" | grep -q "hook already registered" || fail "the second registration was not refused: $output"
+dmesg_since | grep -qF "$TARGETS" || fail "the hook on a second target was taken for the one already in the set"
 listed=$(lunatik list)
 case "$listed" in
 	*"$TWICE"*) fail "the refused run left the script registered: $listed" ;;
 esac
-ktap_pass "a second registration of the same hook in one runtime is refused"
+ktap_pass "one set holds a hook per target; a second registration of the same one is refused"
 
 mark_dmesg
 run_script "$LATE" softirq percpu

--- a/tests/runtime/percpu_netfilter_twice.lua
+++ b/tests/runtime/percpu_netfilter_twice.lua
@@ -7,6 +7,8 @@
 local netfilter = require("netfilter")
 local nf        = require("linux.nf")
 
+local MARK <const> = 209
+
 local function accept(skb)
 	return nf.action.ACCEPT
 end
@@ -18,6 +20,18 @@ local hook = {
 	priority = nf.ip.pri.FILTER,
 }
 
+local marked = {
+	hook     = accept,
+	pf       = nf.proto.INET,
+	hooknum  = nf.inet.LOCAL_IN,
+	priority = nf.ip.pri.FILTER,
+	mark     = MARK,
+}
+
 netfilter.register(hook)
-netfilter.register(hook)
+netfilter.register(marked) -- a second hook in the same set, this one told apart by its mark
+
+print("percpu netfilter twice: two targets armed")
+
+netfilter.register(marked)
 


### PR DESCRIPTION
The percpu netfilter suite's "twice" case registered one hook twice, so the predicate that tells two targets apart was only ever asked about a hook the set had already seen, and the percpu data never held a list of more than one to tear down.

The case now arms a second hook differing by its mark before repeating one. Setting the second hook's mark to the first's makes it fail, which is what says it discriminates.
