### PR TITLE
probe: drop the handle wrapper, refcount the registration instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ usage: lunatik [load|unload|reload|status|test|list] [run|spawn|stop <script>] [
 * `status`: show which Lunatik kernel modules are currently loaded
 * `test [suite]`: run installed test suites (see [Testing](#testing))
 * `list`: show which runtime environments are currently running
-* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime per CPU id, dispatched to the runtime of the CPU the callback runs on. The script runs once per runtime and can read its id with `lunatik.cpu()`; the runtimes share a netfilter hook, and constructors whose registration is global fail at load in a percpu runtime
+* `run [softirq|hardirq]`: create a new runtime environment to run the script `/lib/modules/lua/<script>.lua`; pass `softirq` for hooks that fire in softirq context (netfilter, XDP), or `hardirq` for hooks that fire in hardirq context (kprobes); optionally pass `percpu` to create one runtime per CPU id, dispatched to the runtime of the CPU the callback runs on. The script runs once per runtime and can read its id with `lunatik.cpu()`; the runtimes share a netfilter hook and a kprobe, and constructors whose registration is global fail at load in a percpu runtime
 * `spawn`: create a new runtime environment and spawn a thread to run the script `/lib/modules/lua/<script>.lua`
 * `stop`: stop the runtime environment created to run the script `<script>`
 * `default`: start a _REPL (Read–Eval–Print Loop)_

--- a/doc/capi.md
+++ b/doc/capi.md
@@ -217,6 +217,18 @@ afterwards. Returns `NULL` on a plain runtime, which has no runtimes to share wi
 `lunatik_getpercpu(L)` tells the two apart, returning the `percpu` object owning the runtime `L`,
 or `NULL`.
 
+### LUNATIK\_PERCPUDATA
+```C
+#define LUNATIK_PERCPUDATA(prefix, cname, T, free)
+```
+Defines `static const lunatik_class_t prefix_class`, named `cname`, for the data a `percpu` object
+holds for the registrations its runtimes share, as [`lunatik_percpudata`](#lunatik_percpudata)
+creates it: a private that is a `struct hlist_head` of `T` entries linked through their
+`struct hlist_node node`, whose `release`, `prefix_release`, unlinks every entry and passes it to
+`free`. For example,
+`LUNATIK_PERCPUDATA(luaprobe_kprobes, "probe.kprobes", luaprobe_kprobe_t, luaprobe_free)`
+defines `luaprobe_kprobes_class`.
+
 ---
 
 ## Object Lifecycle

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -10,17 +10,23 @@
 
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include <linux/kprobes.h>
+#include <linux/list.h>
 #include <linux/string.h>
 
 #include <lunatik.h>
+
+typedef struct luaprobe_kprobe_s {
+	struct hlist_node node;
+	struct kprobe kp;
+	lunatik_object_t *runtime;
+} luaprobe_kprobe_t;
 
 /***
 * Represents a registered kprobe.
 * @type probe
 */
 typedef struct luaprobe_s {
-	struct kprobe kp;
-	lunatik_object_t *runtime;
+	luaprobe_kprobe_t *kprobe;	/* NULL when the percpu object owns the kprobe */
 } luaprobe_t;
 
 static void (*luaprobe_showregs)(struct pt_regs *);
@@ -35,12 +41,12 @@ static int luaprobe_dump(lua_State *L)
 	return 0;
 }
 
-static int luaprobe_handler(lua_State *L, luaprobe_t *probe, const char *handler, struct pt_regs *regs)
+static int luaprobe_handler(lua_State *L, luaprobe_kprobe_t *kprobe, const char *handler, struct pt_regs *regs)
 {
-	struct kprobe *kp = &probe->kp;
+	struct kprobe *kp = &kprobe->kp;
 	const char *symbol = kp->symbol_name;
 
-	if (lunatik_getregistry(L, probe) != LUA_TTABLE) {
+	if (lunatik_getregistry(L, kprobe) != LUA_TTABLE) {
 		pr_err_ratelimited("couldn't find probe table\n");
 		goto out;
 	}
@@ -68,27 +74,27 @@ out:
 
 static int __kprobes luaprobe_pre_handler(struct kprobe *kp, struct pt_regs *regs)
 {
-	luaprobe_t *probe = container_of(kp, luaprobe_t, kp);
+	luaprobe_kprobe_t *kprobe = container_of(kp, luaprobe_kprobe_t, kp);
 	int ret;
 
-	lunatik_run(probe->runtime, luaprobe_handler, ret, probe, "pre", regs);
+	lunatik_run(kprobe->runtime, luaprobe_handler, ret, kprobe, "pre", regs);
 	(void)ret;
 	return 0;
 }
 
 static void __kprobes luaprobe_post_handler(struct kprobe *kp, struct pt_regs *regs, unsigned long flags)
 {
-	luaprobe_t *probe = container_of(kp, luaprobe_t, kp);
+	luaprobe_kprobe_t *kprobe = container_of(kp, luaprobe_kprobe_t, kp);
 	int ret;
 
 	/* flags always seems to be zero; see: https://docs.kernel.org/trace/kprobes.html#api-reference */
-	lunatik_run(probe->runtime, luaprobe_handler, ret, probe, "post", regs);
+	lunatik_run(kprobe->runtime, luaprobe_handler, ret, kprobe, "post", regs);
 	(void)ret;
 }
 
-static void luaprobe_delete(luaprobe_t *probe)
+static void luaprobe_delete(luaprobe_kprobe_t *kprobe)
 {
-	struct kprobe *kp = &probe->kp;
+	struct kprobe *kp = &kprobe->kp;
 	const char *symbol_name = kp->symbol_name;
 
 	if (kp->pre_handler != NULL) {
@@ -104,28 +110,90 @@ static void luaprobe_delete(luaprobe_t *probe)
 	}
 }
 
+static bool luaprobe_match(const struct kprobe *kp, const struct kprobe *spec)
+{
+	if (spec->symbol_name == NULL)
+		return kp->addr == spec->addr;
+	return kp->symbol_name != NULL && strcmp(kp->symbol_name, spec->symbol_name) == 0;
+}
+
+static luaprobe_kprobe_t *luaprobe_find(struct hlist_head *kprobes, const luaprobe_kprobe_t *spec)
+{
+	luaprobe_kprobe_t *kprobe;
+
+	hlist_for_each_entry(kprobe, kprobes, node) {
+		if (luaprobe_match(&kprobe->kp, &spec->kp))
+			return kprobe;
+	}
+	return NULL;
+}
+
+static luaprobe_kprobe_t *luaprobe_register(lua_State *L, lunatik_object_t *runtime, const luaprobe_kprobe_t *spec)
+{
+	luaprobe_kprobe_t *kprobe = lunatik_checkalloc(L, sizeof(luaprobe_kprobe_t));
+	struct kprobe *kp = &kprobe->kp;
+	int ret;
+
+	*kprobe = *spec;
+	kprobe->runtime = runtime;
+
+	if (kp->symbol_name != NULL) {
+		kp->symbol_name = kstrdup(kp->symbol_name, lunatik_gfp(runtime));
+		if (kp->symbol_name == NULL) {
+			lunatik_free(kprobe);
+			lunatik_enomem(L);
+		}
+	}
+
+	if ((ret = register_kprobe(kp)) != 0) {
+		kfree(kp->symbol_name);
+		lunatik_free(kprobe);
+		luaL_error(L, "failed to register probe (%d)", ret);
+	}
+	return kprobe;
+}
+
+static void luaprobe_free(luaprobe_kprobe_t *kprobe)
+{
+	luaprobe_delete(kprobe);
+	lunatik_free(kprobe);
+}
+
+LUNATIK_PERCPUDATA(luaprobe_kprobes, "probe.kprobes", luaprobe_kprobe_t, luaprobe_free);
+
 static void luaprobe_release(void *private)
 {
 	luaprobe_t *probe = (luaprobe_t *)private;
-	luaprobe_delete(probe);
-	if (probe->runtime)
-		lunatik_putobject(probe->runtime);
+	luaprobe_kprobe_t *kprobe = probe->kprobe;
+
+	if (kprobe != NULL) {
+		lunatik_object_t *runtime = kprobe->runtime;
+
+		luaprobe_free(kprobe); /* unregister before the put: the callback reads kprobe->runtime */
+		lunatik_putobject(runtime);
+	}
 }
+
+static const lunatik_class_t luaprobe_class;
+
+#define LUAPROBE_ERR_SHARED	"the percpu object owns this probe"
 
 /***
 * Unregisters and stops the probe.
 * @function stop
+* @raise if the percpu object owns this probe
 */
-static const lunatik_class_t luaprobe_class;
-
 static int luaprobe_stop(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luaprobe_class);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
+	luaprobe_kprobe_t *kprobe = probe->kprobe;
 
-	luaprobe_delete(probe);
+	luaL_argcheck(L, kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
+	luaprobe_delete(kprobe);
+	lunatik_unregister(L, kprobe);
 
-	if (lunatik_toruntime(L) == probe->runtime)
+	if (lunatik_toruntime(L) == kprobe->runtime)
 		lunatik_unregisterobject(L, object);
 	return 0;
 }
@@ -134,14 +202,16 @@ static int luaprobe_stop(lua_State *L)
 * Enables or disables the probe.
 * @function enable
 * @tparam boolean flag true to enable, false to disable
-* @raise if the probe has been stopped
+* @raise if the probe has been stopped, or if the percpu object owns this probe
 */
 static int luaprobe_enable(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luaprobe_class);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
-	struct kprobe *kp = &probe->kp;
 	bool enable = lua_toboolean(L, 2);
+
+	luaL_argcheck(L, probe->kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
+	struct kprobe *kp = &probe->kprobe->kp;
 
 	if (kp->pre_handler == NULL)
 		return luaL_argerror(L, 1, LUNATIK_ERR_NULLPTR);
@@ -158,12 +228,16 @@ static int luaprobe_new(lua_State *L);
 
 /***
 * Creates and registers a new kprobe.
+* In a percpu script the runtimes share one kprobe per symbol or address: the first
+* registration installs it, the others attach their handlers, and a call reaches the
+* runtime of the CPU it ran on.
 * @function new
 * @tparam string|lightuserdata symbol kernel symbol name or address
 * @tparam table handlers table with optional `pre` and `post` callback functions;
 *   each receives the symbol (string or lightuserdata) and a `dump` closure
 * @treturn probe
-* @raise if registration fails, or if called from a percpu runtime
+* @raise if registration fails; in a percpu script, if this runtime already probed the same
+*   symbol or address, or if called after module load
 */
 static const luaL_Reg luaprobe_lib[] = {
 	{"new", luaprobe_new},
@@ -186,41 +260,54 @@ static const lunatik_class_t luaprobe_class = {
 	.opt = LUNATIK_OPT_HARDIRQ | LUNATIK_OPT_SINGLE,
 };
 
+static void luaprobe_checkspec(lua_State *L, int ix, luaprobe_kprobe_t *spec)
+{
+	if (lua_islightuserdata(L, ix))
+		spec->kp.addr = lua_touserdata(L, ix);
+	else
+		spec->kp.symbol_name = luaL_checkstring(L, ix); /* anchored at ix until luaprobe_register copies it */
+}
+
+static luaprobe_kprobe_t *luaprobe_share(lua_State *L, lunatik_object_t *percpu, const luaprobe_kprobe_t *spec)
+{
+	struct hlist_head *kprobes = lunatik_percpudata(L, &luaprobe_kprobes_class, sizeof(struct hlist_head))->private;
+	luaprobe_kprobe_t *kprobe = luaprobe_find(kprobes, spec);
+
+	if (kprobe == NULL) {
+		kprobe = luaprobe_register(L, percpu, spec);
+		hlist_add_head(&kprobe->node, kprobes);
+	}
+	else if (lunatik_getregistry(L, kprobe) != LUA_TNIL)
+		luaL_error(L, "probe already registered");
+	else
+		lua_pop(L, 1);
+	return kprobe;
+}
+
+static luaprobe_kprobe_t *luaprobe_own(lua_State *L, luaprobe_t *probe, lunatik_object_t *runtime,
+	const luaprobe_kprobe_t *spec)
+{
+	probe->kprobe = luaprobe_register(L, runtime, spec);
+	lunatik_getobject(runtime); /* a percpu object is held by its data; a plain runtime is held here */
+	return probe->kprobe;
+}
+
 static int luaprobe_new(lua_State *L)
 {
-	lunatik_checkpercpu(L);
+	luaprobe_kprobe_t spec = {.kp = {.pre_handler = luaprobe_pre_handler, .post_handler = luaprobe_post_handler}};
+	luaprobe_checkspec(L, 1, &spec);
+	luaL_checktype(L, 2, LUA_TTABLE); /* handlers */
+	lunatik_object_t *runtime = lunatik_checkruntime(L, LUNATIK_OPT_HARDIRQ);
+	lunatik_object_t *percpu = lunatik_getpercpu(L);
+
 	lunatik_object_t *object = lunatik_newobject(L, &luaprobe_class, sizeof(luaprobe_t), LUNATIK_OPT_NONE);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
-	struct kprobe *kp = &probe->kp;
-	int ret;
 
-	probe->runtime = lunatik_checkruntime(L, LUNATIK_OPT_HARDIRQ);
-	lunatik_getobject(probe->runtime);
+	luaprobe_kprobe_t *kprobe = percpu != NULL ? luaprobe_share(L, percpu, &spec) :
+		luaprobe_own(L, probe, runtime, &spec);
 
-	if (lua_islightuserdata(L, 1))
-		kp->addr = lua_touserdata(L, 1);
-	else {
-		size_t symbol_len;
-		const char *symbol_name = luaL_checklstring(L, 1, &symbol_len);
-
-		if ((kp->symbol_name = kstrndup(symbol_name, symbol_len, lunatik_gfp(probe->runtime))) == NULL)
-			lunatik_enomem(L);
-	}
-
-	luaL_checktype(L, 2, LUA_TTABLE); /* handlers */
-
-	kp->pre_handler = luaprobe_pre_handler;
-	kp->post_handler = luaprobe_post_handler;
-
-	/* must precede register_kprobe: kprobe may fire immediately */
 	lunatik_registerobject(L, 2, object);
-
-	if ((ret = register_kprobe(kp)) != 0) {
-		kp->pre_handler = NULL; /* shouldn't unregister on release() */
-		lunatik_unregisterobject(L, object);
-		luaL_error(L, "failed to register probe (%d)", ret);
-	}
-
+	lunatik_register(L, 2, kprobe); /* the handler finds this runtime's handlers by the kprobe they share */
 	return 1; /* object */
 }
 

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -138,7 +138,7 @@ static luaprobe_kprobe_t *luaprobe_register(lua_State *L, lunatik_object_t *runt
 	kprobe->runtime = runtime;
 
 	if (kp->symbol_name != NULL) {
-		kp->symbol_name = kstrdup(kp->symbol_name, lunatik_gfp(runtime));
+		kp->symbol_name = kstrdup(kp->symbol_name, lunatik_gfp(lunatik_toruntime(L)));
 		if (kp->symbol_name == NULL) {
 			lunatik_free(kprobe);
 			lunatik_enomem(L);

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -191,10 +191,11 @@ static int luaprobe_stop(lua_State *L)
 
 	luaL_argcheck(L, kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
 	luaprobe_delete(kprobe);
-	lunatik_unregister(L, kprobe);
 
-	if (lunatik_toruntime(L) == kprobe->runtime)
+	if (lunatik_toruntime(L) == kprobe->runtime) {
+		lunatik_unregister(L, kprobe);
 		lunatik_unregisterobject(L, object);
+	}
 	return 0;
 }
 

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -212,10 +212,11 @@ static int luaprobe_enable(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luaprobe_class);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
+	luaprobe_kprobe_t *kprobe = probe->kprobe;
 	bool enable = lua_toboolean(L, 2);
 
-	luaL_argcheck(L, probe->kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
-	struct kprobe *kp = &probe->kprobe->kp;
+	luaL_argcheck(L, kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
+	struct kprobe *kp = &kprobe->kp;
 
 	if (kp->pre_handler == NULL)
 		return luaL_argerror(L, 1, LUNATIK_ERR_NULLPTR);

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -17,6 +17,7 @@
 
 typedef struct luaprobe_kprobe_s {
 	struct hlist_node node;
+	struct kref kref;	/* the set holds one, and every handle registered on it holds another */
 	struct kprobe kp;
 	kprobe_opcode_t *addr;	/* the address asked for, NULL for a symbol: register_kprobe resolves kp.addr */
 	lunatik_object_t *runtime;
@@ -26,9 +27,6 @@ typedef struct luaprobe_kprobe_s {
 * Represents a registered kprobe.
 * @type probe
 */
-typedef struct luaprobe_s {
-	luaprobe_kprobe_t *kprobe;	/* NULL when the percpu object owns the kprobe */
-} luaprobe_t;
 
 static void (*luaprobe_showregs)(struct pt_regs *);
 
@@ -139,6 +137,7 @@ static luaprobe_kprobe_t *luaprobe_register(lua_State *L, lunatik_object_t *runt
 
 	*kprobe = *spec;
 	kprobe->runtime = runtime;
+	kref_init(&kprobe->kref);
 
 	if (kp->symbol_name != NULL) {
 		kp->symbol_name = kstrdup(kp->symbol_name, lunatik_gfp(lunatik_toruntime(L)));
@@ -156,25 +155,35 @@ static luaprobe_kprobe_t *luaprobe_register(lua_State *L, lunatik_object_t *runt
 	return kprobe;
 }
 
-static void luaprobe_free(luaprobe_kprobe_t *kprobe)
+static void luaprobe_free(struct kref *kref)
 {
+	luaprobe_kprobe_t *kprobe = container_of(kref, luaprobe_kprobe_t, kref);
+
 	luaprobe_delete(kprobe);
 	lunatik_free(kprobe);
 }
 
-LUNATIK_PERCPUDATA(luaprobe_kprobes, "probe.kprobes", luaprobe_kprobe_t, luaprobe_free);
+#define luaprobe_put(kprobe)	kref_put(&(kprobe)->kref, luaprobe_free)
+
+#define luaprobe_isshared(kprobe)	lunatik_ispercpu((kprobe)->runtime->opt)
+
+static void luaprobe_disarm(luaprobe_kprobe_t *kprobe)
+{
+	luaprobe_delete(kprobe); /* the set unregisters before its runtimes close, however many handles remain */
+	luaprobe_put(kprobe);
+}
+
+LUNATIK_PERCPUDATA(luaprobe_kprobes, "probe.kprobes", luaprobe_kprobe_t, luaprobe_disarm);
 
 static void luaprobe_release(void *private)
 {
-	luaprobe_t *probe = (luaprobe_t *)private;
-	luaprobe_kprobe_t *kprobe = probe->kprobe;
+	luaprobe_kprobe_t *kprobe = (luaprobe_kprobe_t *)private;
+	lunatik_object_t *runtime = kprobe->runtime;
+	bool owned = !luaprobe_isshared(kprobe); /* the data holds a shared kprobe's object until stop closes both */
 
-	if (kprobe != NULL) {
-		lunatik_object_t *runtime = kprobe->runtime;
-
-		luaprobe_free(kprobe); /* unregister before the put: the callback reads kprobe->runtime */
+	luaprobe_put(kprobe); /* read before the put, which may free the kprobe */
+	if (owned)
 		lunatik_putobject(runtime);
-	}
 }
 
 static const lunatik_class_t luaprobe_class;
@@ -189,16 +198,14 @@ static const lunatik_class_t luaprobe_class;
 static int luaprobe_stop(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luaprobe_class);
-	luaprobe_t *probe = (luaprobe_t *)object->private;
-	luaprobe_kprobe_t *kprobe = probe->kprobe;
+	luaprobe_kprobe_t *kprobe = (luaprobe_kprobe_t *)object->private;
 
-	luaL_argcheck(L, kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
+	lunatik_argchecknull(L, kprobe, 1);
+	luaL_argcheck(L, !luaprobe_isshared(kprobe), 1, LUAPROBE_ERR_SHARED);
 	luaprobe_delete(kprobe);
 
-	if (lunatik_toruntime(L) == kprobe->runtime) {
-		lunatik_unregister(L, kprobe);
+	if (lunatik_toruntime(L) == kprobe->runtime)
 		lunatik_unregisterobject(L, object);
-	}
 	return 0;
 }
 
@@ -211,11 +218,11 @@ static int luaprobe_stop(lua_State *L)
 static int luaprobe_enable(lua_State *L)
 {
 	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luaprobe_class);
-	luaprobe_t *probe = (luaprobe_t *)object->private;
-	luaprobe_kprobe_t *kprobe = probe->kprobe;
+	luaprobe_kprobe_t *kprobe = (luaprobe_kprobe_t *)object->private;
 	bool enable = lua_toboolean(L, 2);
 
-	luaL_argcheck(L, kprobe != NULL, 1, LUAPROBE_ERR_SHARED);
+	lunatik_argchecknull(L, kprobe, 1);
+	luaL_argcheck(L, !luaprobe_isshared(kprobe), 1, LUAPROBE_ERR_SHARED);
 	struct kprobe *kp = &kprobe->kp;
 
 	if (kp->pre_handler == NULL)
@@ -262,7 +269,7 @@ static const lunatik_class_t luaprobe_class = {
 	.methods = luaprobe_mt,
 	.release = luaprobe_release,
 	.opener = luaopen_probe,
-	.opt = LUNATIK_OPT_HARDIRQ | LUNATIK_OPT_SINGLE,
+	.opt = LUNATIK_OPT_HARDIRQ | LUNATIK_OPT_SINGLE | LUNATIK_OPT_EXTERNAL,
 };
 
 static void luaprobe_checkspec(lua_State *L, int ix, luaprobe_kprobe_t *spec)
@@ -286,15 +293,17 @@ static luaprobe_kprobe_t *luaprobe_share(lua_State *L, lunatik_object_t *percpu,
 		luaL_error(L, "probe already registered");
 	else
 		lua_pop(L, 1);
+
+	kref_get(&kprobe->kref); /* the set holds the first reference; this handle holds its own */
 	return kprobe;
 }
 
-static luaprobe_kprobe_t *luaprobe_own(lua_State *L, luaprobe_t *probe, lunatik_object_t *runtime,
-	const luaprobe_kprobe_t *spec)
+static luaprobe_kprobe_t *luaprobe_own(lua_State *L, lunatik_object_t *runtime, const luaprobe_kprobe_t *spec)
 {
-	probe->kprobe = luaprobe_register(L, runtime, spec);
+	luaprobe_kprobe_t *kprobe = luaprobe_register(L, runtime, spec);
+
 	lunatik_getobject(runtime); /* a percpu object is held by its data; a plain runtime is held here */
-	return probe->kprobe;
+	return kprobe;
 }
 
 static int luaprobe_new(lua_State *L)
@@ -305,14 +314,12 @@ static int luaprobe_new(lua_State *L)
 	lunatik_object_t *runtime = lunatik_checkruntime(L, LUNATIK_OPT_HARDIRQ);
 	lunatik_object_t *percpu = lunatik_getpercpu(L);
 
-	lunatik_object_t *object = lunatik_newobject(L, &luaprobe_class, sizeof(luaprobe_t), LUNATIK_OPT_NONE);
-	luaprobe_t *probe = (luaprobe_t *)object->private;
+	lunatik_object_t *object = lunatik_newobject(L, &luaprobe_class, 0, LUNATIK_OPT_NONE);
 
-	luaprobe_kprobe_t *kprobe = percpu != NULL ? luaprobe_share(L, percpu, &spec) :
-		luaprobe_own(L, probe, runtime, &spec);
+	object->private = percpu != NULL ? luaprobe_share(L, percpu, &spec) : luaprobe_own(L, runtime, &spec);
 
+	/* the private is the kprobe, so this files the handlers under the key the handler looks them up by */
 	lunatik_registerobject(L, 2, object);
-	lunatik_register(L, 2, kprobe); /* the handler finds this runtime's handlers by the kprobe they share */
 	return 1; /* object */
 }
 

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -18,6 +18,7 @@
 typedef struct luaprobe_kprobe_s {
 	struct hlist_node node;
 	struct kprobe kp;
+	kprobe_opcode_t *addr;	/* the address asked for, NULL for a symbol: register_kprobe resolves kp.addr */
 	lunatik_object_t *runtime;
 } luaprobe_kprobe_t;
 
@@ -110,11 +111,13 @@ static void luaprobe_delete(luaprobe_kprobe_t *kprobe)
 	}
 }
 
-static bool luaprobe_match(const struct kprobe *kp, const struct kprobe *spec)
+static bool luaprobe_match(const luaprobe_kprobe_t *kprobe, const luaprobe_kprobe_t *spec)
 {
-	if (spec->symbol_name == NULL)
-		return kp->addr == spec->addr;
-	return kp->symbol_name != NULL && strcmp(kp->symbol_name, spec->symbol_name) == 0;
+	const char *symbol = kprobe->kp.symbol_name;
+
+	if (spec->kp.symbol_name == NULL)
+		return kprobe->addr == spec->addr;
+	return symbol != NULL && strcmp(symbol, spec->kp.symbol_name) == 0;
 }
 
 static luaprobe_kprobe_t *luaprobe_find(struct hlist_head *kprobes, const luaprobe_kprobe_t *spec)
@@ -122,7 +125,7 @@ static luaprobe_kprobe_t *luaprobe_find(struct hlist_head *kprobes, const luapro
 	luaprobe_kprobe_t *kprobe;
 
 	hlist_for_each_entry(kprobe, kprobes, node) {
-		if (luaprobe_match(&kprobe->kp, &spec->kp))
+		if (luaprobe_match(kprobe, spec))
 			return kprobe;
 	}
 	return NULL;
@@ -264,7 +267,7 @@ static const lunatik_class_t luaprobe_class = {
 static void luaprobe_checkspec(lua_State *L, int ix, luaprobe_kprobe_t *spec)
 {
 	if (lua_islightuserdata(L, ix))
-		spec->kp.addr = lua_touserdata(L, ix);
+		spec->addr = spec->kp.addr = lua_touserdata(L, ix);
 	else
 		spec->kp.symbol_name = luaL_checkstring(L, ix); /* anchored at ix until luaprobe_register copies it */
 }

--- a/lib/lunatik/runner.lua
+++ b/lib/lunatik/runner.lua
@@ -49,8 +49,8 @@ end
 -- @tparam[opt] string context Execution context: `"process"` (default) or `"softirq"` (for netfilter/XDP hooks).
 -- @tparam[opt] boolean ispercpu create one runtime per CPU id, dispatched by the CPU a
 --   callback fires on; the script runs once per runtime and can read its id with
---   `lunatik.cpu()`. The runtimes share a netfilter hook; constructors whose
---   registration is global refuse to run in a percpu runtime.
+--   `lunatik.cpu()`. The runtimes share a netfilter hook and a kprobe; constructors
+--   whose registration is global refuse to run in a percpu runtime.
 -- @treturn table created Lunatik runtime object, or the percpu object when `ispercpu` is set.
 -- @raise error if the script is already running.
 function runner.run(script, context, ispercpu)

--- a/lunatik_percpu.h
+++ b/lunatik_percpu.h
@@ -6,6 +6,7 @@
 #ifndef lunatik_percpu_h
 #define lunatik_percpu_h
 
+#include <linux/list.h>
 #include <linux/percpu.h>
 #include <linux/preempt.h>
 
@@ -50,6 +51,22 @@ extern const lunatik_class_t lunatik_percpu_class;
 
 int lunatik_percpu(lua_State *L);
 lunatik_object_t *lunatik_percpudata(lua_State *L, const lunatik_class_t *class, size_t size);
+
+#define LUNATIK_PERCPUDATA(prefix, cname, T, free)					\
+static void prefix##_release(void *private)					\
+{										\
+	T *entry;								\
+	struct hlist_node *next;						\
+										\
+	hlist_for_each_entry_safe(entry, next, (struct hlist_head *)private, node) {	\
+		hlist_del(&entry->node);					\
+		free(entry);							\
+	}									\
+}										\
+static const lunatik_class_t prefix##_class = {					\
+	.name = cname,								\
+	.release = prefix##_release,						\
+}
 
 #define LUNATIK_ERR_PERCPU	"not allowed in a percpu runtime"
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -219,14 +219,15 @@ higher-level `netlink.*` modules built on top of it.
   the `personality` syscall, which nothing else on an idle host calls: a
   pinned `setarch` is handled exactly once, by the runtime of the CPU it
   ran on, and no runtime is reached through a kprobe it did not register;
-  a call pinned to the CPU whose runtime is published last is dropped while
-  the runtimes are still being created, and counted once they are up;
-  one set holds a kprobe per target, and a second probe on the same symbol in
-  one runtime is refused; `stop` and `enable` are refused in a percpu runtime,
-  where the object owns the kprobe; the same script probes as a plain hardirq
-  runtime; and a plain runtime stops its own probe, twice with no effect, is
-  refused an `enable` afterwards, and refuses a probe on a symbol the kernel
-  does not have.
+  the set arms that one kprobe however many runtimes it has, and unregisters
+  it when it stops; a call pinned to the CPU whose runtime is published last
+  is dropped while the runtimes are still being created, and counted once they
+  are up; one set holds a kprobe per target, and a second probe on the same
+  symbol in one runtime is refused; `stop` and `enable` are refused in a percpu
+  runtime, where the object owns the kprobe; the same script probes as a plain
+  hardirq runtime; and a plain runtime stops its own probe, twice with no
+  effect, is refused an `enable` afterwards, and refuses a probe on a symbol
+  the kernel does not have.
 
 ### rcu
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -215,6 +215,19 @@ higher-level `netlink.*` modules built on top of it.
   one load generator per CPU; `lunatik stop` must complete within 5s
   with no kernel errors under concurrent handler firings.
 
+- **percpu_probe**: the runtimes of a percpu script share one kprobe on
+  the `personality` syscall, which nothing else on an idle host calls: a
+  pinned `setarch` is handled exactly once, by the runtime of the CPU it
+  ran on, and no runtime is reached through a kprobe it did not register;
+  a call pinned to the CPU whose runtime is published last is dropped while
+  the runtimes are still being created, and counted once they are up;
+  one set holds a kprobe per target, and a second probe on the same symbol in
+  one runtime is refused; `stop` and `enable` are refused in a percpu runtime,
+  where the object owns the kprobe; the same script probes as a plain hardirq
+  runtime; and a plain runtime stops its own probe, twice with no effect, is
+  refused an `enable` afterwards, and refuses a probe on a symbol the kernel
+  does not have.
+
 ### rcu
 
 - **map_values**: `rcu.map()` iterates booleans, integers, userdata,

--- a/tests/README.md
+++ b/tests/README.md
@@ -224,10 +224,10 @@ higher-level `netlink.*` modules built on top of it.
   is dropped while the runtimes are still being created, and counted once they
   are up; one set holds a kprobe per target, and a second probe on the same
   symbol in one runtime is refused; `stop` and `enable` are refused in a percpu
-  runtime, where the object owns the kprobe; the same script probes as a plain
-  hardirq runtime; and a plain runtime stops its own probe, twice with no
-  effect, is refused an `enable` afterwards, and refuses a probe on a symbol
-  the kernel does not have.
+  runtime, where the object owns the kprobe; a probe from a handler, after the
+  script loaded, is refused; the same script probes as a plain hardirq runtime;
+  and a plain runtime stops its own probe, twice with no effect, is refused an
+  `enable` afterwards, and refuses a probe on a symbol the kernel does not have.
 
 ### rcu
 

--- a/tests/probe/percpu_probe.lua
+++ b/tests/probe/percpu_probe.lua
@@ -1,0 +1,24 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test (see percpu_probe.sh).
+
+local lunatik = require("lunatik")
+local probe   = require("probe")
+local systab  = require("syscall.table")
+
+local LIMIT <const> = 16
+
+local cpu = lunatik.cpu() or "plain"
+local hits = 0
+
+local function count()
+	hits = hits + 1
+	if hits <= LIMIT then
+		print("percpu probe: cpu " .. tostring(cpu))
+	end
+end
+
+probe.new(systab["personality"], {pre = count})
+

--- a/tests/probe/percpu_probe.sh
+++ b/tests/probe/percpu_probe.sh
@@ -7,14 +7,15 @@
 # kprobe on the personality syscall, so a pinned setarch, which calls it once,
 # is handled exactly once and by the runtime of the CPU it ran on, which for a
 # kprobe is where the syscall executed, with no runtime reached through a kprobe
-# it did not register; a call reaching the shared kprobe while the runtimes are
-# still being created, pinned to the CPU whose runtime is published last, is
-# dropped, and the same call is counted once they are up; one set holds a kprobe
-# per target, and a second probe on the same symbol in one runtime is refused;
-# stop and enable are refused in a percpu runtime, where the object owns the
-# kprobe; the same script probes as a plain hardirq runtime; and a plain runtime
-# stops its own probe, twice with no effect, is refused an enable afterwards, and
-# refuses a probe on a symbol the kernel does not have.
+# it did not register; the set arms that one kprobe however many runtimes it
+# has, and unregisters it when it stops; a call reaching the shared kprobe while
+# the runtimes are still being created, pinned to the CPU whose runtime is
+# published last, is dropped, and the same call is counted once they are up; one
+# set holds a kprobe per target, and a second probe on the same symbol in one
+# runtime is refused; stop and enable are refused in a percpu runtime, where the
+# object owns the kprobe; the same script probes as a plain hardirq runtime; and
+# a plain runtime stops its own probe, twice with no effect, is refused an enable
+# afterwards, and refuses a probe on a symbol the kernel does not have.
 #
 # Usage: sudo bash tests/probe/percpu_probe.sh
 
@@ -25,6 +26,7 @@ PLAIN="tests/probe/percpu_probe_plain"
 EARLY="tests/probe/percpu_probe_early"
 ARMED="percpu probe early: armed"
 TARGETS="percpu probe twice: two targets armed"
+KPROBES="/sys/kernel/debug/kprobes/list"
 COUNT=3
 TRIES=100
 
@@ -37,6 +39,12 @@ cleanup()
 	lunatik stop "$STOP" > /dev/null 2>&1
 	lunatik stop "$PLAIN" > /dev/null 2>&1
 	lunatik stop "$EARLY" > /dev/null 2>&1
+}
+
+# how many kprobes the kernel holds; nothing where debugfs does not say
+kprobes()
+{
+	[ -r "$KPROBES" ] && grep -c "" "$KPROBES"
 }
 
 trigger()
@@ -78,15 +86,22 @@ command -v taskset > /dev/null 2>&1 && command -v setarch > /dev/null 2>&1 || {
 cpu=$(sed 's/.*[-,]//' /sys/devices/system/cpu/online)
 
 mark_dmesg
+idle=$(kprobes)
 run_script "$SCRIPT" hardirq percpu
+armed=$(kprobes)
 trigger "$cpu"
 check_dmesg || { ktap_totals; exit 1; }
 dmesg_since | grep -qF "couldn't find probe table" && fail "a kprobe fired on a runtime that did not register it"
 hits=$(dmesg_since | grep -c "percpu probe: cpu $cpu$")
 others=$(dmesg_since | grep -o "percpu probe: cpu [0-9]*" | grep -vc "cpu $cpu$")
 lunatik stop "$SCRIPT" > /dev/null 2>&1
+stopped=$(kprobes)
 [ "$hits" = "$COUNT" ] || fail "the runtime of CPU $cpu counted $hits of $COUNT"
 [ "$others" = "0" ] || fail "$others hits landed on another runtime: $(dmesg_since | grep -o 'percpu probe: cpu [0-9]*' | sort -u | tr '\n' ' ')"
+if [ -n "$armed" ]; then
+	[ "$armed" = "$((idle + 1))" ] || fail "the runtimes armed $((armed - idle)) kprobes on one target"
+	[ "$stopped" = "$idle" ] || fail "stopping the set left $((stopped - idle)) kprobes armed"
+fi
 ktap_pass "the runtimes share one kprobe: each call is handled once, by the runtime of the CPU it ran on"
 
 mark_dmesg

--- a/tests/probe/percpu_probe.sh
+++ b/tests/probe/percpu_probe.sh
@@ -13,9 +13,11 @@
 # published last, is dropped, and the same call is counted once they are up; one
 # set holds a kprobe per target, and a second probe on the same symbol in one
 # runtime is refused; stop and enable are refused in a percpu runtime, where the
-# object owns the kprobe; the same script probes as a plain hardirq runtime; and
-# a plain runtime stops its own probe, twice with no effect, is refused an enable
-# afterwards, and refuses a probe on a symbol the kernel does not have.
+# object owns the kprobe; a probe from a handler, after the script loaded, is
+# refused before it could sleep in hardirq; the same script probes as a plain
+# hardirq runtime; and a plain runtime stops its own probe, twice with no effect,
+# is refused an enable afterwards, and refuses a probe on a symbol the kernel
+# does not have.
 #
 # Usage: sudo bash tests/probe/percpu_probe.sh
 
@@ -24,6 +26,7 @@ TWICE="tests/probe/percpu_probe_twice"
 STOP="tests/probe/percpu_probe_stop"
 PLAIN="tests/probe/percpu_probe_plain"
 EARLY="tests/probe/percpu_probe_early"
+LATE="tests/probe/percpu_probe_late"
 ARMED="percpu probe early: armed"
 TARGETS="percpu probe twice: two targets armed"
 KPROBES="/sys/kernel/debug/kprobes/list"
@@ -39,6 +42,7 @@ cleanup()
 	lunatik stop "$STOP" > /dev/null 2>&1
 	lunatik stop "$PLAIN" > /dev/null 2>&1
 	lunatik stop "$EARLY" > /dev/null 2>&1
+	lunatik stop "$LATE" > /dev/null 2>&1
 }
 
 # how many kprobes the kernel holds; nothing where debugfs does not say
@@ -69,7 +73,7 @@ trap cleanup EXIT
 cleanup
 
 ktap_header
-ktap_plan 6
+ktap_plan 7
 
 command -v taskset > /dev/null 2>&1 && command -v setarch > /dev/null 2>&1 || {
 	echo "# SKIP: taskset or setarch not available"
@@ -77,6 +81,7 @@ command -v taskset > /dev/null 2>&1 && command -v setarch > /dev/null 2>&1 || {
 	ktap_skip "a call reaching the shared kprobe before the runtimes are published is dropped"
 	ktap_skip "one set holds a kprobe per target; a second probe on the same symbol is refused"
 	ktap_skip "stop and enable are refused in a percpu runtime"
+	ktap_skip "a probe from a handler, after load, is refused"
 	ktap_skip "the same script probes as a plain hardirq runtime"
 	ktap_skip "a plain runtime stops its probe once, refuses enable afterwards and refuses an unknown symbol"
 	ktap_totals
@@ -134,6 +139,16 @@ run_script "$STOP" hardirq percpu
 check_dmesg || { ktap_totals; exit 1; }
 lunatik stop "$STOP" > /dev/null 2>&1
 ktap_pass "stop and enable are refused in a percpu runtime"
+
+mark_dmesg
+run_script "$LATE" hardirq percpu
+trigger "$cpu"
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$LATE" > /dev/null 2>&1
+dmesg_since | grep -qF "percpu probe late: " || fail "the handler did not run"
+dmesg_since | grep -q "percpu probe late: not allowed after module load" || \
+	fail "the late probe was not refused: $(dmesg_since | grep 'percpu probe late')"
+ktap_pass "a probe from a handler, after load, is refused"
 
 mark_dmesg
 run_script "$SCRIPT" hardirq

--- a/tests/probe/percpu_probe.sh
+++ b/tests/probe/percpu_probe.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Regression test for a kprobe in a percpu script: the runtimes share one
+# kprobe on the personality syscall, so a pinned setarch, which calls it once,
+# is handled exactly once and by the runtime of the CPU it ran on, which for a
+# kprobe is where the syscall executed, with no runtime reached through a kprobe
+# it did not register; a call reaching the shared kprobe while the runtimes are
+# still being created, pinned to the CPU whose runtime is published last, is
+# dropped, and the same call is counted once they are up; one set holds a kprobe
+# per target, and a second probe on the same symbol in one runtime is refused;
+# stop and enable are refused in a percpu runtime, where the object owns the
+# kprobe; the same script probes as a plain hardirq runtime; and a plain runtime
+# stops its own probe, twice with no effect, is refused an enable afterwards, and
+# refuses a probe on a symbol the kernel does not have.
+#
+# Usage: sudo bash tests/probe/percpu_probe.sh
+
+SCRIPT="tests/probe/percpu_probe"
+TWICE="tests/probe/percpu_probe_twice"
+STOP="tests/probe/percpu_probe_stop"
+PLAIN="tests/probe/percpu_probe_plain"
+EARLY="tests/probe/percpu_probe_early"
+ARMED="percpu probe early: armed"
+TARGETS="percpu probe twice: two targets armed"
+COUNT=3
+TRIES=100
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup()
+{
+	lunatik stop "$SCRIPT" > /dev/null 2>&1
+	lunatik stop "$TWICE" > /dev/null 2>&1
+	lunatik stop "$STOP" > /dev/null 2>&1
+	lunatik stop "$PLAIN" > /dev/null 2>&1
+	lunatik stop "$EARLY" > /dev/null 2>&1
+}
+
+trigger()
+{
+	local cpu="$1" i
+	for ((i = 0; i < COUNT; i++)); do
+		taskset -c "$cpu" setarch "$(uname -m)" -R true > /dev/null 2>&1
+	done
+}
+
+trigger_when_armed()
+{
+	local try
+	for ((try = 0; try < TRIES; try++)); do
+		dmesg_since | grep -qF "$ARMED" && break
+		sleep 0.02
+	done
+	trigger "$1"
+}
+
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 6
+
+command -v taskset > /dev/null 2>&1 && command -v setarch > /dev/null 2>&1 || {
+	echo "# SKIP: taskset or setarch not available"
+	ktap_skip "the runtimes share one kprobe: each call is handled once, by the runtime of the CPU it ran on"
+	ktap_skip "a call reaching the shared kprobe before the runtimes are published is dropped"
+	ktap_skip "one set holds a kprobe per target; a second probe on the same symbol is refused"
+	ktap_skip "stop and enable are refused in a percpu runtime"
+	ktap_skip "the same script probes as a plain hardirq runtime"
+	ktap_skip "a plain runtime stops its probe once, refuses enable afterwards and refuses an unknown symbol"
+	ktap_totals
+	exit 0
+}
+
+cpu=$(sed 's/.*[-,]//' /sys/devices/system/cpu/online)
+
+mark_dmesg
+run_script "$SCRIPT" hardirq percpu
+trigger "$cpu"
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -qF "couldn't find probe table" && fail "a kprobe fired on a runtime that did not register it"
+hits=$(dmesg_since | grep -c "percpu probe: cpu $cpu$")
+others=$(dmesg_since | grep -o "percpu probe: cpu [0-9]*" | grep -vc "cpu $cpu$")
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+[ "$hits" = "$COUNT" ] || fail "the runtime of CPU $cpu counted $hits of $COUNT"
+[ "$others" = "0" ] || fail "$others hits landed on another runtime: $(dmesg_since | grep -o 'percpu probe: cpu [0-9]*' | sort -u | tr '\n' ' ')"
+ktap_pass "the runtimes share one kprobe: each call is handled once, by the runtime of the CPU it ran on"
+
+mark_dmesg
+trigger_when_armed "$cpu" &
+early=$!
+run_script "$EARLY" hardirq percpu
+wait $early
+check_dmesg || { ktap_totals; exit 1; }
+dmesg_since | grep -qF "couldn't find probe table" && fail "a kprobe fired for a runtime that did not register it"
+early_hits=$(dmesg_since | grep -c "percpu probe early: cpu")
+trigger "$cpu"
+late_hits=$(dmesg_since | grep -c "percpu probe early: cpu $cpu\$")
+lunatik stop "$EARLY" > /dev/null 2>&1
+[ "$early_hits" = "0" ] || fail "$early_hits calls were handled before the runtimes were published"
+[ "$late_hits" = "$COUNT" ] || fail "the same trigger counted $late_hits of $COUNT once the runtimes were published"
+ktap_pass "a call reaching the shared kprobe before the runtimes are published is dropped"
+
+mark_dmesg
+output=$(lunatik run "$TWICE" hardirq percpu 2>&1)
+echo "$output" | grep -q "probe already registered" || fail "the second registration was not refused: $output"
+dmesg_since | grep -qF "$TARGETS" || fail "the probe on a second target was taken for the one already in the set"
+listed=$(lunatik list)
+case "$listed" in
+	*"$TWICE"*) fail "the refused run left the script registered: $listed" ;;
+esac
+ktap_pass "one set holds a kprobe per target; a second probe on the same symbol is refused"
+
+mark_dmesg
+run_script "$STOP" hardirq percpu
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$STOP" > /dev/null 2>&1
+ktap_pass "stop and enable are refused in a percpu runtime"
+
+mark_dmesg
+run_script "$SCRIPT" hardirq
+trigger "$cpu"
+check_dmesg || { ktap_totals; exit 1; }
+plain=$(dmesg_since | grep -c "percpu probe: cpu plain$")
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+[ "$plain" = "$COUNT" ] || fail "the plain runtime counted $plain of $COUNT"
+ktap_pass "the same script probes as a plain hardirq runtime"
+
+mark_dmesg
+run_script "$PLAIN" hardirq
+check_dmesg || { ktap_totals; exit 1; }
+lunatik stop "$PLAIN" > /dev/null 2>&1
+ktap_pass "a plain runtime stops its probe once, refuses enable afterwards and refuses an unknown symbol"
+
+ktap_totals
+

--- a/tests/probe/percpu_probe_early.lua
+++ b/tests/probe/percpu_probe_early.lua
@@ -1,0 +1,24 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test, a call during creation (see percpu_probe.sh).
+
+local lunatik = require("lunatik")
+local probe   = require("probe")
+local systab  = require("syscall.table")
+
+local SPIN <const> = 100000000
+
+local cpu = lunatik.cpu()
+
+local function count()
+	print("percpu probe early: cpu " .. tostring(cpu))
+end
+
+probe.new(systab["personality"], {pre = count})
+
+print("percpu probe early: armed")
+
+for _ = 1, SPIN do end -- widen the gap between arming the kprobe and publishing this runtime
+

--- a/tests/probe/percpu_probe_late.lua
+++ b/tests/probe/percpu_probe_late.lua
@@ -1,0 +1,24 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test, a probe after load (see percpu_probe.sh).
+
+local probe  = require("probe")
+local systab = require("syscall.table")
+
+local reported = false
+
+local function nop() end
+
+local function probe_late()
+	if reported then
+		return
+	end
+	reported = true
+	local ok, err = pcall(probe.new, systab["personality"], {pre = nop})
+	print("percpu probe late: " .. (ok and "registered" or err:gsub("^.-:%d+: ", "")))
+end
+
+probe.new(systab["personality"], {pre = probe_late})
+

--- a/tests/probe/percpu_probe_plain.lua
+++ b/tests/probe/percpu_probe_plain.lua
@@ -1,0 +1,31 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test, the plain runtime methods (see percpu_probe.sh).
+
+local probe  = require("probe")
+local systab = require("syscall.table")
+local test   = require("util").test
+
+local UNKNOWN <const> = "lunatik_no_such_symbol"
+
+local function nop() end
+
+test("a plain runtime stops its probe once and enables it while it lives", function()
+	local p = probe.new(systab["personality"], {pre = nop})
+	p:enable(false)
+	p:enable(true)
+	p:stop()
+	p:stop() -- stopping again is a no-op
+	local ok, err = pcall(p.enable, p, true)
+	assert(not ok, "enable was accepted after stop")
+	assert(err:match("null pointer"), "enable raised something else: " .. tostring(err))
+end)
+
+test("a probe on a symbol the kernel does not have is refused", function()
+	local ok, err = pcall(probe.new, UNKNOWN, {pre = nop})
+	assert(not ok, "a probe on an unknown symbol was accepted")
+	assert(err:match("failed to register probe"), "probe.new raised something else: " .. tostring(err))
+end)
+

--- a/tests/probe/percpu_probe_stop.lua
+++ b/tests/probe/percpu_probe_stop.lua
@@ -1,0 +1,22 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test, stop in a percpu runtime (see percpu_probe.sh).
+
+local probe  = require("probe")
+local systab = require("syscall.table")
+local test   = require("util").test
+
+local function nop() end
+
+test("stop and enable are refused in a percpu runtime", function()
+	local p = probe.new(systab["personality"], {pre = nop})
+	local ok, err = pcall(p.stop, p)
+	assert(not ok, "stop was accepted")
+	assert(err:match("percpu object owns this probe"), "stop raised something else: " .. tostring(err))
+	local okenable, errenable = pcall(p.enable, p, false)
+	assert(not okenable, "enable was accepted")
+	assert(errenable:match("percpu object owns this probe"), "enable raised something else: " .. tostring(errenable))
+end)
+

--- a/tests/probe/percpu_probe_twice.lua
+++ b/tests/probe/percpu_probe_twice.lua
@@ -1,0 +1,20 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the percpu probe test, duplicate registration (see percpu_probe.sh).
+
+local probe  = require("probe")
+local systab = require("syscall.table")
+
+local SYMBOL <const> = "sys_ni_syscall"
+
+local function nop() end
+
+probe.new(systab["personality"], {pre = nop})
+probe.new(SYMBOL, {pre = nop}) -- a second kprobe in the same set, this one found by name
+
+print("percpu probe twice: two targets armed")
+
+probe.new(SYMBOL, {pre = nop})
+

--- a/tests/probe/run.sh
+++ b/tests/probe/run.sh
@@ -11,7 +11,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
 SEP=$'\n'
-for t in "$DIR"/kprobe_concurrent.sh; do
+for t in "$DIR"/kprobe_concurrent.sh "$DIR"/percpu_probe.sh; do
 	echo "${SEP}# --- $(basename "$t") ---"
 	bash "$t" || FAILED=$((FAILED+1))
 done


### PR DESCRIPTION
Folded into #795 as its probe commit; closed as superseded.

Proposed against #795 rather than after it: the one commit here is a `fixup!` of "probe: share one kprobe among the runtimes of a percpu script", so if it is taken it folds into that commit instead of landing as a correction to it.

`luaprobe_t` was not a handle type, it was compensation for the registration having no lifetime of its own. The set frees a shared kprobe at stop and the handles are released after, so the handle could not point at the kprobe; it pointed at a framework-owned block whose one field carried two jobs at once, what the handle points at and who owns it. A `struct kref` on the registration retires both. The handle points at the kprobe directly, through `LUNATIK_OPT_EXTERNAL`, which is what the framework already calls a private it does not own; ownership becomes a property of the registration, read from the runtime it names, instead of a sentinel to keep in sync. Two things then fall out on their own: the handlers table was being filed under two keys, the wrapper's address and the kprobe the handler looks it up by, and now there is one; and `luaprobe_stop` returns to the shape it has on master, the extra unregister having existed only to reach past the wrapper.

It does not reach `luanetfilter`, whose handle carries the runtime and the skb besides the hook, so the two bindings stop being symmetric until something like #840 puts the discipline in the core. The module gains 400 bytes of text on aarch64, which is what `refcount_dec_and_test` costs at two put sites and not a shape that can be traded away: `noinline` on the release makes it larger. Suite 153/0/0, and the percpu probe suite run three times over leaves no kprobe armed and no kernel complaint, on a kernel with neither KMEMLEAK nor KASAN to see a refcount defect.
