### PR TITLE
lib: stop unregisters without asking whose runtime it is

### DIFF
--- a/lib/luadevice.c
+++ b/lib/luadevice.c
@@ -267,8 +267,7 @@ static int luadevice_stop(lua_State *L)
 	luadevice_delete(luadev);
 	lunatik_unlock(object);
 
-	if (lunatik_toruntime(L) == luadev->runtime)
-		lunatik_unregisterobject(L, object);
+	lunatik_unregisterobject(L, object);
 	return 0;
 }
 

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -124,9 +124,7 @@ static int luaprobe_stop(lua_State *L)
 	luaprobe_t *probe = (luaprobe_t *)object->private;
 
 	luaprobe_delete(probe);
-
-	if (lunatik_toruntime(L) == probe->runtime)
-		lunatik_unregisterobject(L, object);
+	lunatik_unregisterobject(L, object);
 	return 0;
 }
 


### PR DESCRIPTION
Closes #857. `luaprobe_stop` and `luadevice_stop` unregistered the object only when `lunatik_toruntime(L)` matched the runtime the private names, and that comparison cannot be false.

Both classes carry `LUNATIK_OPT_SINGLE`, so every route an object takes between states goes through `lunatik_cloneobject`, which raises for such an object, or through `lunatik_checkshareable`, which gates a value on the same property. The handle is only ever held by the runtime that created it. It dates to a draft where `luaprobe_class` had no `SINGLE`.

`luaprobe_stop` is touched by #795, so whichever lands second rebases over two lines.
