### PR TITLE
probe: refuse new, stop and enable from a handler

### DIFF
--- a/doc/capi.md
+++ b/doc/capi.md
@@ -201,6 +201,17 @@ Returns the runtime associated with `L` and raises a Lua error if its context do
 process runtime. Typically called from `lunatik_new*` functions to enforce that a class is
 only instantiated in a compatible runtime.
 
+### lunatik\_checkarmed
+```C
+void lunatik_checkarmed(lua_State *L);
+```
+Raises a Lua error, `"not allowed after module load"`, when `L` belongs to an interrupt-context
+runtime that has finished loading. An IRQ runtime is process context only while its script body
+runs, so a call that may sleep is allowed there and must be refused afterwards, when the runtime
+lock is a spinlock: from a hook or a handler, and from the `resume` of such a runtime. Use it in
+an entry point that reaches a sleeping kernel call, where `lunatik_checkruntime` answers the
+different question of whether the class matches the runtime at all.
+
 ### lunatik\_percpudata
 ```C
 lunatik_object_t *lunatik_percpudata(lua_State *L, const lunatik_class_t *class, size_t size);

--- a/lib/luabpf.c
+++ b/lib/luabpf.c
@@ -390,8 +390,7 @@ static const lunatik_class_t luabpf_queue_class = {
 static int luabpf_open(lua_State *L, const lunatik_class_t *class, enum bpf_map_type type,
 	const char *expected)
 {
-	if (unlikely(lunatik_cannotsleep(L, lunatik_isready(lunatik_toruntime(L)))))
-		luaL_argerror(L, 1, "not allowed after module load");
+	lunatik_checkarmed(L);
 
 	const char *pathname = luaL_checkstring(L, 1);
 	lunatik_object_t *object = lunatik_newobject(L, class, 0, LUNATIK_OPT_NONE);
@@ -413,10 +412,10 @@ static int luabpf_##name##_open(lua_State *L)						\
 * @function hash
 * @tparam string path Path to a pinned eBPF hash map.
 * @treturn bpf_hash Opened map handle.
-* @raise Error if the path does not resolve to a pinned eBPF hash map.
-* Path lookup may sleep, so on interrupt-context runtimes (softirq/hardirq)
-* the constructors are only allowed during script load; the returned handle
-* can then be used from handlers.
+* @raise Error if the path does not resolve to a pinned eBPF hash map, or if called
+* after module load: the path lookup sleeps, so on an interrupt-context runtime
+* (softirq/hardirq) the constructors are only allowed while the script body runs;
+* the returned handle can then be used from handlers.
 * @usage
 *   local bpf = require("bpf")
 *   local counter = bpf.hash("/sys/fs/bpf/counters")

--- a/lib/luaprobe.c
+++ b/lib/luaprobe.c
@@ -115,11 +115,14 @@ static void luaprobe_release(void *private)
 /***
 * Unregisters and stops the probe.
 * @function stop
+* @raise if called after module load: unregister_kprobe sleeps, and the runtime is
+*   in hardirq by then
 */
 static const lunatik_class_t luaprobe_class;
 
 static int luaprobe_stop(lua_State *L)
 {
+	lunatik_checkarmed(L);
 	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luaprobe_class);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
 
@@ -134,10 +137,12 @@ static int luaprobe_stop(lua_State *L)
 * Enables or disables the probe.
 * @function enable
 * @tparam boolean flag true to enable, false to disable
-* @raise if the probe has been stopped
+* @raise if the probe has been stopped, or if called after module load:
+*   enable_kprobe and disable_kprobe sleep, and the runtime is in hardirq by then
 */
 static int luaprobe_enable(lua_State *L)
 {
+	lunatik_checkarmed(L);
 	lunatik_object_t *object = lunatik_checkobjectclass(L, 1, &luaprobe_class);
 	luaprobe_t *probe = (luaprobe_t *)object->private;
 	struct kprobe *kp = &probe->kp;
@@ -163,7 +168,8 @@ static int luaprobe_new(lua_State *L);
 * @tparam table handlers table with optional `pre` and `post` callback functions;
 *   each receives the symbol (string or lightuserdata) and a `dump` closure
 * @treturn probe
-* @raise if registration fails, or if called from a percpu runtime
+* @raise if registration fails, if called from a percpu runtime, or if called after
+*   module load: register_kprobe sleeps, and the runtime is in hardirq by then
 */
 static const luaL_Reg luaprobe_lib[] = {
 	{"new", luaprobe_new},
@@ -188,6 +194,7 @@ static const lunatik_class_t luaprobe_class = {
 
 static int luaprobe_new(lua_State *L)
 {
+	lunatik_checkarmed(L);
 	lunatik_checkpercpu(L);
 	lunatik_object_t *object = lunatik_newobject(L, &luaprobe_class, sizeof(luaprobe_t), LUNATIK_OPT_NONE);
 	luaprobe_t *probe = (luaprobe_t *)object->private;

--- a/lunatik.h
+++ b/lunatik.h
@@ -196,6 +196,7 @@ static inline void lunatik_checkfield(lua_State *L, int idx, const char *field, 
 #define LUNATIK_ERR_METATABLE	"metatable not found"
 #define LUNATIK_ERR_CONTEXT	"process-context class in interrupt-context runtime"
 #define LUNATIK_ERR_RUNTIME	"runtime context mismatch"
+#define LUNATIK_ERR_ARMED	"not allowed after module load"
 
 #define lunatik_context(opt)	((opt) & (LUNATIK_OPT_SOFTIRQ | LUNATIK_OPT_HARDIRQ))
 
@@ -222,6 +223,12 @@ static inline void lunatik_checkclass(lua_State *L, const lunatik_class_t *class
 {
 	if (lunatik_cannotsleep(L, !lunatik_isirq(class->opt)))
 		luaL_error(L, "'%s': %s", class->name, LUNATIK_ERR_CONTEXT);
+}
+
+static inline void lunatik_checkarmed(lua_State *L)
+{
+	if (unlikely(lunatik_cannotsleep(L, lunatik_isready(lunatik_toruntime(L)))))
+		luaL_error(L, LUNATIK_ERR_ARMED);
 }
 
 static inline void lunatik_setclass(lua_State *L, const lunatik_class_t *class, bool monitor)

--- a/lunatik_percpu.c
+++ b/lunatik_percpu.c
@@ -52,7 +52,7 @@ lunatik_object_t *lunatik_percpudata(lua_State *L, const lunatik_class_t *class,
 		return NULL;
 
 	if (lunatik_isready(lunatik_toruntime(L)))
-		luaL_error(L, "not allowed after module load");
+		luaL_error(L, LUNATIK_ERR_ARMED);
 
 	lunatik_object_t *data = lunatik_finddata(lunatik_topercpu(object), class);
 	return data != NULL ? data : lunatik_newdata(L, object, class, size);

--- a/tests/README.md
+++ b/tests/README.md
@@ -211,6 +211,13 @@ higher-level `netlink.*` modules built on top of it.
 
 ### probe
 
+- **armed**: `probe.new`, `stop` and `enable` all reach a kprobe call that
+  sleeps, so each is allowed while the script loads, in process context, and
+  refused from a handler, where the runtime is in hardirq: the script registers,
+  toggles and stops a probe on the way in, then probes `vfs_read` and calls all
+  three from its own handler. Do not run it against a build without the guard,
+  which would reach `synchronize_rcu` with interrupts off.
+
 - **kprobe_concurrent**: registers kprobes on every syscall and runs
   one load generator per CPU; `lunatik stop` must complete within 5s
   with no kernel errors under concurrent handler firings.

--- a/tests/probe/armed.lua
+++ b/tests/probe/armed.lua
@@ -1,0 +1,40 @@
+--
+-- SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+-- SPDX-License-Identifier: MIT OR GPL-2.0-only
+--
+-- Kernel-side script for the armed-runtime test (see armed.sh).
+
+local probe = require("probe")
+
+local SYMBOL <const> = "vfs_read"
+local ARMED <const> = "not allowed after module load"
+
+local handle
+local done = false
+
+local function refused(what, method, ...)
+	local ok, err = pcall(method, ...)
+	if not ok and type(err) == "string" and err:find(ARMED, 1, true) then
+		print("probe armed: " .. what)
+	end
+end
+
+local function pre()
+	if done then
+		return
+	end
+	done = true
+
+	refused("new", probe.new, SYMBOL, {})
+	refused("stop", handle.stop, handle)
+	refused("enable", handle.enable, handle, false)
+end
+
+local spare = probe.new(SYMBOL, {})
+spare:enable(false)
+spare:enable(true)
+spare:stop()
+print("probe loading: new, enable and stop")
+
+handle = probe.new(SYMBOL, {pre = pre})
+

--- a/tests/probe/armed.sh
+++ b/tests/probe/armed.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: (c) 2026 Ring Zero Desenvolvimento de Software LTDA
+# SPDX-License-Identifier: MIT OR GPL-2.0-only
+#
+# Covers the refusal a probe handler gets from the three entry points that sleep.
+# register_kprobe takes kprobe_mutex, cpus_read_lock and text_mutex;
+# unregister_kprobe takes kprobe_mutex and waits on synchronize_rcu; enable_kprobe
+# and disable_kprobe take kprobe_mutex. A probe script runs in a hardirq runtime,
+# which is process context only while its body loads, so from a handler all three
+# must be refused.
+#
+# The script exercises the other half first: while it loads, in process context,
+# it registers a probe, disables and re-enables it and stops it. Then it probes
+# vfs_read and, on its first hit, calls probe.new, stop and enable from the
+# handler, reporting each one the runtime refuses.
+#
+# Do not run this against a build without lunatik_checkarmed: unregister_kprobe
+# would reach synchronize_rcu with interrupts off and hang the machine. That is
+# also why the guard itself is not proven by removing it; what is proven below is
+# that the assertions read what they claim.
+#
+# Usage: sudo bash tests/probe/armed.sh
+
+SCRIPT="tests/probe/armed"
+
+source "$(dirname "$(readlink -f "$0")")/../lib.sh"
+
+cleanup() { lunatik stop "$SCRIPT" > /dev/null 2>&1; }
+trap cleanup EXIT
+cleanup
+
+ktap_header
+ktap_plan 4
+
+mark_dmesg
+run_script "$SCRIPT" hardirq
+dd if=/dev/zero of=/dev/null bs=512 count=1 > /dev/null 2>&1
+sleep 1
+lunatik stop "$SCRIPT" > /dev/null 2>&1
+check_dmesg || { ktap_totals; exit 1; }
+
+reported() { dmesg_since | grep -qF "probe $1"; }
+
+reported "loading: new, enable and stop" || fail "an entry point was refused while the script loaded"
+ktap_pass "new, enable and stop are allowed while the script loads, in process context"
+
+reported "armed: new" || fail "probe.new from a handler was not refused"
+ktap_pass "probe.new is refused from a handler, where register_kprobe would sleep"
+
+reported "armed: stop" || fail "stop from a handler was not refused"
+ktap_pass "stop is refused from a handler, where unregister_kprobe would sleep"
+
+reported "armed: enable" || fail "enable from a handler was not refused"
+ktap_pass "enable is refused from a handler, where enable_kprobe would sleep"
+
+ktap_totals
+

--- a/tests/probe/run.sh
+++ b/tests/probe/run.sh
@@ -11,7 +11,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 FAILED=0
 
 SEP=$'\n'
-for t in "$DIR"/kprobe_concurrent.sh; do
+for t in "$DIR"/kprobe_concurrent.sh "$DIR"/armed.sh; do
 	echo "${SEP}# --- $(basename "$t") ---"
 	bash "$t" || FAILED=$((FAILED+1))
 done


### PR DESCRIPTION
Closes #858. `probe.new`, `stop` and `enable` all reach a kprobe call that sleeps, and a handler could call all three: `register_kprobe` takes `kprobe_mutex`, `cpus_read_lock` and `text_mutex`; `unregister_kprobe` takes `kprobe_mutex` and waits on `synchronize_rcu`; `enable_kprobe` and `disable_kprobe` take `kprobe_mutex`. A probe script runs in a hardirq runtime, which is process context only while its body loads.

The check was already written out in `luabpf` and its message in `lunatik_percpudata`, so the first commit gives both a name in `lunatik.h`, documented in `doc/capi.md`, and the second adopts it in the three probe entry points. `luabpf` raised with `luaL_argerror`, blaming argument #1 for a context no argument could have fixed; the named check raises with `luaL_error`, as the other context checks do. The test covers both halves, the calls allowed while the body loads and refused from a handler; it is not proven by removing the guard, since with it gone `unregister_kprobe` reaches `synchronize_rcu` with interrupts off, and the header says so. The survey the check prompted found the same gap in `netfilter`, `hid` and `netlink.channel`, filed as #863, #864 and #865; and refusing `stop` from a handler leaves a probe with no way to disarm itself, which `luanotifier` answers differently, filed as #869.

`lib/luaprobe.c` is rewritten by #795: rebasing costs four hunks there and one in `tests/probe/run.sh`, in either order, so this and #859 are better landed first, with #795 carrying the check into its rewritten `luaprobe_new`.
