### PR TITLE
checks: a core change says so in its subject

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,4 +25,9 @@ jobs:
           out=$(bash "tools/checks/$check.sh" $files 2>&1) || true
           test -n "$out" && echo "::warning title=$check::$(printf '%s' "$out" | sed ':a;N;$!ba;s/\n/%0A/g')"
         done
+        # core-subject reads one commit: the staged diff above is the whole pull request
+        for commit in $(git rev-list "origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }}"); do
+          out=$(git show -s --format=%s "$commit" | bash tools/checks/core-subject.sh $(git show --name-only --format= "$commit") 2>&1) || true
+          test -n "$out" && echo "::warning title=core-subject::$(printf '%s' "$out" | sed ':a;N;$!ba;s/\n/%0A/g')"
+        done
         true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,10 +130,12 @@ the last one.
 
 `tools/checks/` holds the mechanical checks: comment and LDoc style on framework files
 (`module-conventions.sh`), test scripts that cannot detect a failed load (`test-harness.sh`),
-cppcheck on userspace test C (`cppcheck-tests.sh`), and the trailing blank line rule and the refusal
-of a staged conflict marker (`pre-commit`). Each takes file paths and skips what does not apply, so any
-editor, assistant, or CI can run them. The `Checks` workflow runs them over a pull request's diff:
-`pre-commit` fails the run, the heuristic checks annotate it. Install the commit gate with:
+cppcheck on userspace test C (`cppcheck-tests.sh`), a core change riding inside a binding's commit
+(`core-subject.sh`, which reads that commit's subject on stdin), and the trailing blank line rule and
+the refusal of a staged conflict marker (`pre-commit`). Each takes file paths and skips what does not
+apply, so any editor, assistant, or CI can run them. The `Checks` workflow runs them over a pull
+request's diff, and `core-subject.sh` over each commit of it: `pre-commit` fails the run, the
+heuristic checks annotate it. Install the commit gate with:
 
     ln -s ../../tools/checks/pre-commit .git/hooks/pre-commit
 

--- a/tools/checks/core-subject.sh
+++ b/tools/checks/core-subject.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Checks that a commit touching the core says so in its subject: a core change
+# every binding's runtime path goes through, riding inside a binding's commit,
+# is invisible to whoever reads the history by subject. Heuristic: it nudges a
+# review, it does not rewrite.
+# Usage: core-subject.sh <file>...   with the commit subject on stdin
+# Prints the finding; exits 1 when there is one. A file list carrying no core
+# file, or carrying nothing else, is skipped silently, so callers can pass any
+# commit's files.
+
+iscore() {
+	case "${1##*/}" in
+		lunatik.h|lunatik_core.c|lunatik_obj.c|lunatik_val.c|lunatik_val.h|lunatik_aux.c|lunatik_run.c|lunatik_percpu.c|lunatik_percpu.h)
+			return 0 ;;
+	esac
+	case "$1" in
+		doc/capi.md|*/doc/capi.md) return 0 ;;
+	esac
+	return 1
+}
+
+core="" other=""
+for f in "$@"; do
+	if iscore "$f"; then core="$core  $f
+"; else other="$f"; fi
+done
+[ -n "$core" ] && [ -n "$other" ] || exit 0
+
+read -r subject
+case "$subject" in
+	lunatik*:*|core:*|capi:*|api:*) exit 0 ;;
+esac
+printf '%s\n' "$subject" | grep -qE 'lunatik[_.][A-Za-z_]|LUNATIK_[A-Z]|capi\.md|[Cc] API' && exit 0
+
+printf '"%s" changes the core without saying so:\n%sA core change is its own commit, or its subject names the core it changes.\n' \
+	"$subject" "$core"
+exit 1
+


### PR DESCRIPTION
A core change that rides inside a binding's commit, under a subject naming only the binding, is what a review of #848 found: the lock-owner scheme in lunatik.h and doc/capi.md shipped as part of "fsnotify: watch filesystem events from Lua". The rule is not that core and binding never mix; AGENTS.md sanctions a core check adopted by four bindings as one commit. The rule is that the subject says so.

core-subject.sh takes a commit's file list as arguments and its subject on stdin, and fails when the list carries a core file and a file outside the core while the subject names neither. The Checks workflow runs it per commit over the pull request's range, since the squashed diff it already stages cannot see commit boundaries. Over the last 400 commits of master it fires on 9, 4 of them the shape it is for; the noise is docs sweeps and autogen migrations whose only core file is doc/capi.md, kept in because dropping it blinds the check to a new C API entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)